### PR TITLE
Refactor/no desirability

### DIFF
--- a/bofire/domain/desirability_functions.py
+++ b/bofire/domain/desirability_functions.py
@@ -61,7 +61,6 @@ class DesirabilityFunction(BaseModel):
             DesirabilityFunction: Instaniated desirability function of the type specified in the `config`.
         """
         mapper = {
-            "NoDesirabilityFunction": NoDesirabilityFunction,
             "MaxIdentityDesirabilityFunction": MaxIdentityDesirabilityFunction,
             "MinIdentityDesirabilityFunction": MinIdentityDesirabilityFunction,
             "DeltaIdentityDesirabilityFunction": DeltaIdentityDesirabilityFunction,
@@ -72,25 +71,6 @@ class DesirabilityFunction(BaseModel):
             "CloseToTargetDesirabilityFunction": CloseToTargetDesirabilityFunction,
         }
         return mapper[config["type"]](**config)
-
-
-class NoDesirabilityFunction(DesirabilityFunction):
-    """Dummy desirability function to allow output features which should not be optimized
-
-    Args:
-        DesirabilityFunction (DesirabilityFunction): The base class for all desirability functions
-    """
-
-    def __call__(self, x: np.ndarray) -> None:
-        """Dummy call function returning None
-
-        Args:
-            x (np.ndarray): An array of x values
-
-        Returns:
-            None: No reward is returned
-        """
-        return None
 
 
 class IdentityDesirabilityFunction(DesirabilityFunction):

--- a/bofire/domain/util.py
+++ b/bofire/domain/util.py
@@ -45,7 +45,7 @@ def is_categorical(s: pd.Series, categories: List[str]):
 def filter_by_attribute(
     data: List,
     attribute_getter: Callable[[Type], Any],
-    includes: Union[Type, List[Type]],
+    includes: Union[Type, List[Type]] = None,
     excludes: Union[Type, List[Type]] = None,
     exact: bool = False,
 ):
@@ -56,6 +56,9 @@ def filter_by_attribute(
             data_with_attr.append(d)
         except AttributeError:
             pass
+
+    print("includes", includes)
+    print("excludes", excludes)
 
     filtered = filter_by_class(
         [(i, attribute_getter(d)) for i, d in enumerate(data_with_attr)],
@@ -73,11 +76,13 @@ def filter_by_attribute(
 
 def filter_by_class(
     data: List,
-    includes: Union[Type, List[Type]],
+    includes: Union[Type, List[Type]] = None,
     excludes: Union[Type, List[Type]] = None,
     exact: bool = False,
     key: Callable[[Type], Any] = lambda x: x,
 ) -> List:
+    if includes is None:
+        includes = []
     if not isinstance(includes, list):
         includes = [includes]
     if excludes is None:
@@ -85,8 +90,12 @@ def filter_by_class(
     if not isinstance(excludes, list):
         excludes = [excludes]
 
-    if len(includes) == 0:
+    if len(includes) == len(excludes) == 0:
         raise ValueError("no filter provided")
+
+    if len(includes) == 0:
+        includes = [object]
+
     if len([x for x in includes if x in excludes]) > 0:
         raise ValueError("includes and excludes overlap")
 

--- a/tests/bofire/domain/test_features.py
+++ b/tests/bofire/domain/test_features.py
@@ -208,6 +208,10 @@ FEATURE_SPECS = {
                 **VALID_CONTINUOUS_OUTPUT_FEATURE_SPEC,
                 "desirability_function": desirability_function,
             },
+            {
+                **VALID_CONTINUOUS_OUTPUT_FEATURE_SPEC,
+                "desirability_function": None,
+            },
         ],
         "invalids": [*get_invalids(VALID_CONTINUOUS_OUTPUT_FEATURE_SPEC)],
     },

--- a/tests/bofire/domain/test_util.py
+++ b/tests/bofire/domain/test_util.py
@@ -155,6 +155,36 @@ def test_filter_by_attribute(data, includes, expected):
 
 
 @pytest.mark.parametrize(
+    "data,excludes,expected",
+    [
+        (data, [A], []),
+        (data, [A2], [a, a1, a11, a12]),
+    ],
+)
+def test_filter_by_class_only_exclude(data, excludes, expected):
+    res = filter_by_class(data, excludes=excludes)
+    print("got:", [type(x).__name__ for x in res])
+    print("expected:", [type(x).__name__ for x in expected])
+    assert set(res) == set(expected)
+
+
+@pytest.mark.parametrize(
+    "data,excludes,expected",
+    [
+        (data2, [B2], [c, c1, c11, c12, c3]),
+        (data2, [B], [c3]),
+    ],
+)
+def test_filter_by_attribute_only_exclude(data, excludes, expected):
+    res = filter_by_attribute(
+        data, attribute_getter=lambda of: of.attribute, excludes=excludes
+    )
+    print("got:", [type(x.attribute).__name__ for x in res])
+    print("expected:", [type(x.attribute).__name__ for x in expected])
+    assert set(res) == set(expected)
+
+
+@pytest.mark.parametrize(
     "data,includes,expected",
     [
         (data, [A], [a]),
@@ -268,14 +298,17 @@ def test_filter_by_attribute_exclude_exact(data, includes, exclude, expected):
 
 
 @pytest.mark.parametrize(
-    "includes",
+    "includes, excludes",
     [
-        ([]),
+        ([], []),
+        ([], None),
+        (None, None),
+        (None, []),
     ],
 )
-def test_filter_by_class_no_cls(includes):
+def test_filter_by_class_no_cls(includes, excludes):
     with pytest.raises(ValueError):
-        filter_by_class(data, includes)
+        filter_by_class(data, includes=includes, excludes=excludes)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
This PR implements the discussed changes regarding the `ContinuousOutputFeatureWoDesirabilityFunction`. It is removed and the functionality is now supported by the normal `ContinuousOutputFeature` with `desirability_function = None`

In addition I changed the `filter_by_class` and `filter_by_attribute` methods to also have the possibility to just exclude in the filter process. With this one can say:

`self.filter_outputs_by_desirability(exclude=DesirabilityFunction)` and one gets only those Output features which do not have a desirability function attached.