### PR TITLE
Refactor/containers

### DIFF
--- a/bofire/domain/constraints.py
+++ b/bofire/domain/constraints.py
@@ -353,8 +353,12 @@ class Constraints(BaseModel):
     def __getitem__(self, i):
         return self.constraints[i]
 
-    def evaluate_constraints(self, experiments: pd.DataFrame) -> pd.DataFrame:
+    def __call__(self, experiments: pd.DataFrame) -> pd.DataFrame:
         return pd.concat([c(experiments) for c in self.constraints], axis=1)
+
+    def add(self, constraint: Constraint):
+        assert isinstance(constraint, Constraint)
+        self.constraints.append(constraint)
 
     def is_fulfilled(self, experiments: pd.DataFrame) -> pd.Series:
         """Method to check if all constraints are fulfilled on all rows of the provided dataframe
@@ -387,9 +391,11 @@ class Constraints(BaseModel):
         Returns:
             List[Constraint]: List of constraints in the domain fitting to the passed requirements.
         """
-        return filter_by_class(
-            self.constraints,
-            includes=includes,
-            excludes=excludes,
-            exact=exact,
+        return Constraints(
+            constraints=filter_by_class(
+                self.constraints,
+                includes=includes,
+                excludes=excludes,
+                exact=exact,
+            )
         )

--- a/bofire/domain/domain.py
+++ b/bofire/domain/domain.py
@@ -18,24 +18,23 @@ from bofire.domain.features import (
     ContinuousOutput,
     Feature,
     InputFeature,
+    InputFeatures,
     OutputFeature,
+    OutputFeatures,
 )
 from bofire.domain.objectives import Objective
-from bofire.domain.util import (
-    BaseModel,
-    filter_by_attribute,
-    filter_by_class,
-    is_numeric,
-)
+from bofire.domain.util import BaseModel, is_numeric
 
 
 class Domain(BaseModel):
 
-    input_features: Optional[List[InputFeature]] = Field(default_factory=lambda: [])
-    output_features: Optional[List[OutputFeature]] = Field(default_factory=lambda: [])
-    constraints: Optional[Constraints] = Field(
-        default_factory=lambda: Constraints(constraints=[])
+    input_features: Optional[InputFeatures] = Field(
+        default_factory=lambda: InputFeatures()
     )
+    output_features: Optional[OutputFeatures] = Field(
+        default_factory=lambda: OutputFeatures()
+    )
+    constraints: Optional[Constraints] = Field(default_factory=lambda: Constraints())
     experiments: Optional[pd.DataFrame]
     candidates: Optional[pd.DataFrame]
     """Representation of the optimization problem/domain
@@ -45,6 +44,33 @@ class Domain(BaseModel):
         output_features (List[OutputFeature], optional): List of output features. Defaults to [].
         constraints (List[Constraint], optional): List of constraints. Defaults to [].
     """
+
+    @validator("input_features", always=True, pre=True)
+    def validate_input_features_list(cls, v, values):
+        if isinstance(v, list):
+            return InputFeatures(features=v)
+        if isinstance(v, Constraint):
+            return InputFeatures(features=[v])
+        else:
+            return v
+
+    @validator("output_features", always=True, pre=True)
+    def validate_output_features_list(cls, v, values):
+        if isinstance(v, list):
+            return OutputFeatures(features=v)
+        if isinstance(v, Constraint):
+            return OutputFeatures(features=[v])
+        else:
+            return v
+
+    @validator("constraints", always=True, pre=True)
+    def validate_constraints_list(cls, v, values):
+        if isinstance(v, list):
+            return Constraints(constraints=v)
+        if isinstance(v, Constraint):
+            return Constraints(constraints=[v])
+        else:
+            return v
 
     @validator("output_features", always=True)
     def validate_unique_output_feature_keys(cls, v, values):
@@ -67,13 +93,6 @@ class Domain(BaseModel):
         if len(set(keys)) != len(keys):
             raise ValueError("feature keys are not unique")
         return v
-
-    @validator("constraints", always=True, pre=True)
-    def validate_constraints_list(cls, v, values):
-        if isinstance(v, list):
-            return Constraints(constraints=v)
-        else:
-            return v
 
     @validator("constraints", always=True)
     def validate_constraints(cls, v, values):
@@ -219,15 +238,8 @@ class Domain(BaseModel):
         Returns:
             List[Feature]: List of features in the domain fitting to the passed requirements.
         """
-        return list(
-            sorted(
-                filter_by_class(
-                    self.input_features + self.output_features,
-                    includes=includes,
-                    excludes=excludes,
-                    exact=exact,
-                )
-            )
+        return (self.input_features + self.output_features).get(
+            includes, excludes, exact
         )
 
     def get_feature_keys(
@@ -266,57 +278,6 @@ class Domain(BaseModel):
         """
         return {f.key: f for f in self.input_features + self.output_features}[key]
 
-    TObjective = Type[Objective]
-
-    def get_outputs_by_objective(
-        self,
-        includes: Union[List[TObjective], TObjective] = Objective,
-        excludes: Union[List[TObjective], TObjective, None] = None,
-        exact: bool = False,
-    ) -> List[OutputFeature]:
-        """Get output features filtered by the type of the attached objective.
-
-        Args:
-            includes (Union[List[TObjective], TObjective], optional): Objective class or list of objective classes
-                to be returned. Defaults to Objective.
-            excludes (Union[List[TObjective], TObjective, None], optional): Objective class or list of specific objective classes to be excluded from the return. Defaults to None.
-            exact (bool, optional): Boolean to distinguish if only the exact classes listed in includes and no subclasses inherenting from this class shall be returned. Defaults to False.
-
-        Returns:
-            List[OutputFeature]: List of output features fitting to the passed requirements.
-        """
-        if self.output_features is None:
-            return []
-        else:
-            return sorted(
-                filter_by_attribute(
-                    self.get_features(ContinuousOutput),
-                    lambda of: of.objective,
-                    includes,
-                    excludes,
-                    exact,
-                )
-            )
-
-    def get_output_keys_by_objective(
-        self,
-        includes: Union[List[TObjective], TObjective] = Objective,
-        excludes: Union[List[TObjective], TObjective, None] = None,
-        exact: bool = False,
-    ) -> List[str]:
-        """Get keys of output features filtered by the type of the attached objective.
-
-        Args:
-            includes (Union[List[TObjective], TObjective], optional): Objective class or list of objective classes
-                to be returned. Defaults to Objective.
-            excludes (Union[List[TObjective], TObjective, None], optional): Objective class or list of specific objective classes to be excluded from the return. Defaults to None.
-            exact (bool, optional): Boolean to distinguish if only the exact classes listed in includes and no subclasses inherenting from this class shall be returned. Defaults to False.
-
-        Returns:
-            List[str]: List of output feature keys fitting to the passed requirements.
-        """
-        return [f.key for f in self.get_outputs_by_objective(includes, excludes, exact)]
-
     def add_constraint(self, constraint: Constraint):
         """Add a constraint to the optimzation domain
 
@@ -342,9 +303,9 @@ class Domain(BaseModel):
         if feature.key in self.get_feature_keys():
             raise ValueError(f"Feature with key {feature.key} already in domain.")
         if isinstance(feature, InputFeature):
-            self.input_features.append(feature)
+            self.input_features.add(feature)
         elif isinstance(feature, OutputFeature):
-            self.output_features.append(feature)
+            self.output_features.add(feature)
         else:
             raise TypeError(f"Cannot add feature of type {type(feature)}")
 
@@ -490,16 +451,6 @@ class Domain(BaseModel):
         #         used_features_list_final2.append(used), unused_features_list2.append(unused)
 
         return used_features_list_final, unused_features_list
-
-    # TODO: needs to be tested
-    def evaluate_objectives(self, experiments: pd.DataFrame) -> pd.DataFrame:
-        return pd.concat(
-            [
-                feat.objective(experiments[feat.name])
-                for feat in self.get_features(ContinuousOutput)
-            ],
-            axis=1,
-        )
 
     def preprocess_experiments_one_valid_output(
         self,
@@ -781,7 +732,7 @@ class Domain(BaseModel):
                 raise ValueError(f"no col for input feature `{feat.key}`")
             feat.validate_candidental(candidates[feat.key])
         # for each continuous output feature with an attached objective object
-        for key in self.get_output_keys_by_objective(Objective):
+        for key in self.output_features.get_keys_by_objective(Objective):
             # check that pred, sd, and des cols are specified and numerical
             for col in [f"{key}_pred", f"{key}_sd", f"{key}_des"]:
                 if col not in candidates:
@@ -797,7 +748,7 @@ class Domain(BaseModel):
             raise ValueError("Constraints not fulfilled.")
         # validate no additional cols exist
         if_count = len(self.get_features(InputFeature))
-        of_count = len(self.get_outputs_by_objective(Objective))
+        of_count = len(self.output_features.get_keys_by_objective(Objective))
         # input features, prediction, standard deviation and reward for each output feature, 3 additional usefull infos: reward, aquisition function, strategy
         if len(candidates.columns) != if_count + 3 * of_count:
             raise ValueError("additional columns found")
@@ -826,15 +777,15 @@ class Domain(BaseModel):
             self.get_feature_keys(InputFeature)
             + [
                 f"{output_feature_key}_pred"
-                for output_feature_key in self.get_outputs_by_objective(Objective)
+                for output_feature_key in self.output_features.get_by_key(Objective)
             ]
             + [
                 f"{output_feature_key}_sd"
-                for output_feature_key in self.get_outputs_by_objective(Objective)
+                for output_feature_key in self.output_features.get_by_key(Objective)
             ]
             + [
                 f"{output_feature_key}_des"
-                for output_feature_key in self.get_outputs_by_objective(Objective)
+                for output_feature_key in self.output_features.get_by_key(Objective)
             ]
         )
 

--- a/bofire/domain/domain.py
+++ b/bofire/domain/domain.py
@@ -13,7 +13,6 @@ from bofire.domain.constraints import (
     NChooseKConstraint,
 )
 from bofire.domain.features import (
-    CategoricalInput,
     ContinuousInput,
     ContinuousOutput,
     Feature,
@@ -333,28 +332,6 @@ class Domain(BaseModel):
             self.input_features = [f for f in self.input_features if f.key != key]
         if output_count > 0:
             self.output_features = [f for f in self.output_features if f.key != key]
-
-    def get_categorical_combinations(
-        self, include: Feature = InputFeature, exclude: Feature = None
-    ):
-        """get a list of tuples pairing the feature keys with a list of valid categories
-
-        Args:
-            include (Feature, optional): Features to be included. Defaults to InputFeature.
-            exclude (Feature, optional): Features to be excluded, e.g. subclasses of the included features. Defaults to None.
-
-        Returns:
-            List[(str, List[str])]: Returns a list of tuples pairing the feature keys with a list of valid categories (str)
-        """
-        features = [
-            f
-            for f in self.get_features(includes=include, excludes=exclude)
-            if isinstance(f, CategoricalInput) and not f.is_fixed()
-        ]
-        list_of_lists = [
-            [(f.key, cat) for cat in f.get_allowed_categories()] for f in features
-        ]
-        return list(itertools.product(*list_of_lists))
 
     # getting list of fixed values
     def get_nchoosek_combinations(self):

--- a/bofire/domain/features.py
+++ b/bofire/domain/features.py
@@ -928,6 +928,17 @@ class InputFeatures(Features):
 
     features: Optional[List[InputFeature]] = Field(default_factory=lambda: [])
 
+    def sample(self, n: int = 1) -> pd.DataFrame:
+        """Draw uniformly random samples
+
+        Args:
+            n (int, optional): Number of samples. Defaults to 1.
+
+        Returns:
+            pd.DataFrame: Dataframe containing the samples.
+        """
+        return pd.concat([feat.sample(n) for feat in self.get(InputFeature)])
+
     def get_categorical_combinations(
         self, include: Feature = InputFeature, exclude: Feature = None
     ):

--- a/bofire/domain/features.py
+++ b/bofire/domain/features.py
@@ -1,3 +1,4 @@
+import itertools
 from abc import abstractmethod
 from typing import Dict, List, Optional, Type, Union
 
@@ -926,6 +927,28 @@ class Features(BaseModel):
 class InputFeatures(Features):
 
     features: Optional[List[InputFeature]] = Field(default_factory=lambda: [])
+
+    def get_categorical_combinations(
+        self, include: Feature = InputFeature, exclude: Feature = None
+    ):
+        """get a list of tuples pairing the feature keys with a list of valid categories
+
+        Args:
+            include (Feature, optional): Features to be included. Defaults to InputFeature.
+            exclude (Feature, optional): Features to be excluded, e.g. subclasses of the included features. Defaults to None.
+
+        Returns:
+            List[(str, List[str])]: Returns a list of tuples pairing the feature keys with a list of valid categories (str)
+        """
+        features = [
+            f
+            for f in self.get(includes=include, excludes=exclude)
+            if isinstance(f, CategoricalInput) and not f.is_fixed()
+        ]
+        list_of_lists = [
+            [(f.key, cat) for cat in f.get_allowed_categories()] for f in features
+        ]
+        return list(itertools.product(*list_of_lists))
 
 
 class OutputFeatures(Features):

--- a/bofire/domain/util.py
+++ b/bofire/domain/util.py
@@ -24,6 +24,7 @@ class BaseModel(_BaseModel):
     class Config:
         validate_assignment = True
         arbitrary_types_allowed = True
+        copy_on_model_validation = False
 
 
 class KeyModel(BaseModel):

--- a/bofire/utils/reduce.py
+++ b/bofire/utils/reduce.py
@@ -89,7 +89,7 @@ def reduce_domain(domain: Domain) -> Tuple[Domain, AffineTransform]:
 
     # only consider continuous inputs
     continuous_inputs = domain.get_features(ContinuousInput)
-    other_inputs = domain.get_features(InputFeature, excludes=[ContinuousInput])
+    other_inputs = domain.input_features.get(InputFeature, excludes=[ContinuousInput])
 
     # assemble Matrix A from equality constraints
     N = len(linear_equalities)
@@ -197,7 +197,6 @@ def reduce_domain(domain: Domain) -> Tuple[Domain, AffineTransform]:
         _equalities.append((name_lhs, names_rhs, coeffs))
 
     trafo = AffineTransform(_equalities)
-
     # remove remaining dependencies of eliminated inputs from the problem
     _domain = remove_eliminated_inputs(_domain, trafo)
     return _domain, trafo

--- a/bofire/utils/reduce.py
+++ b/bofire/utils/reduce.py
@@ -82,8 +82,8 @@ def reduce_domain(domain: Domain) -> Tuple[Domain, AffineTransform]:
         return domain, AffineTransform([])
 
     # find linear equality constraints
-    linear_equalities = domain.get_constraints(LinearEqualityConstraint)
-    other_constraints = domain.get_constraints(
+    linear_equalities = domain.constraints.get(LinearEqualityConstraint)
+    other_constraints = domain.constraints.get(
         Constraint, excludes=[LinearEqualityConstraint]
     )
 
@@ -216,12 +216,12 @@ def check_domain_for_reduction(domain: Domain) -> bool:
         return False
 
     # are there any linear equality constraints?
-    linear_equalities = domain.get_constraints(LinearEqualityConstraint)
+    linear_equalities = domain.constraints.get(LinearEqualityConstraint)
     if len(linear_equalities) == 0:
         return False
 
     # are there no NChooseKConstraint constraints?
-    if len(domain.get_constraints([NChooseKConstraint])) > 0:
+    if len(domain.constraints.get([NChooseKConstraint])) > 0:
         return False
 
     # are there continuous inputs
@@ -290,7 +290,7 @@ def remove_eliminated_inputs(domain: Domain, transform: AffineTransform) -> Doma
         coeffs_dict[e[0]] = coeffs
 
     constraints = []
-    for c in domain.get_constraints():
+    for c in domain.constraints.get():
         # Nonlinear constraints not supported
         if not isinstance(c, LinearConstraint):
             raise ValueError(

--- a/tests/bofire/domain/test_domain.py
+++ b/tests/bofire/domain/test_domain.py
@@ -240,7 +240,7 @@ def test_unknown_features_in_domain(output_features, input_features, constraints
 )
 def test_categorical_combinations_of_domain_defaults(domain, data):
     expected = list(itertools.product(*data))
-    assert domain.get_categorical_combinations() == expected
+    assert domain.input_features.get_categorical_combinations() == expected
 
 
 @pytest.mark.parametrize(
@@ -334,7 +334,9 @@ def test_categorical_combinations_of_domain_defaults(domain, data):
 def test_categorical_combinations_of_domain_filtered(domain, data, include, exclude):
     expected = list(itertools.product(*data))
     assert (
-        domain.get_categorical_combinations(include=include, exclude=exclude)
+        domain.input_features.get_categorical_combinations(
+            include=include, exclude=exclude
+        )
         == expected
     )
 

--- a/tests/bofire/domain/test_domain.py
+++ b/tests/bofire/domain/test_domain.py
@@ -596,7 +596,7 @@ domain = Domain(input_features=[if1, if2], output_features=[of1, of2, of1_, of2_
     ],
 )
 def test_get_features(domain, FeatureType, exact, expected):
-    assert domain.get_features(FeatureType, exact=exact) == expected
+    assert domain.get_features(FeatureType, exact=exact).features == expected
 
 
 @pytest.mark.parametrize(
@@ -608,15 +608,13 @@ def test_get_features(domain, FeatureType, exact, expected):
         (domain, [], [Objective], False, [of1_, of2_]),
     ],
 )
-def test_get_outputs_by_desirability(
-    domain: Domain, includes, excludes, exact, expected
-):
+def test_get_outputs_by_objective(domain: Domain, includes, excludes, exact, expected):
     assert (
-        domain.get_outputs_by_objective(
+        domain.output_features.get_by_objective(
             includes=includes,
             excludes=excludes,
             exact=exact,
-        )
+        ).features
         == expected
     )
 
@@ -647,11 +645,11 @@ def test_get_feature_keys(domain, FeatureType, exact, expected):
         (domain, [], [Objective], False, ["out3", "out4"]),
     ],
 )
-def test_get_output_keys_by_desirability(
+def test_get_output_keys_by_objective(
     domain: Domain, includes, excludes, exact, expected
 ):
     assert (
-        domain.get_output_keys_by_objective(
+        domain.output_features.get_keys_by_objective(
             includes=includes,
             excludes=excludes,
             exact=exact,


### PR DESCRIPTION
As already mentioned is some email, I was looking in more detail into opti's parameter and constraints classes and I liked it. So I integrated it also into boFire. 

domain.constraints is now not anymore a list but a `Constraints` object which behaves like a list but implements additional features which are only relevant for constraints. The same for input and output features. All methods which needs access to more than one object stay in the `Domain` class.

@bertiqwerty @DavidWalz @R-M-Lee @jkleinekorte What do you think? Do you like this, or do you want to have it as before? If you like it, I will add more tests to it. 

Looking forward to your feedback!

Best,

Johannes