### PR TITLE
Feature/sampling

### DIFF
--- a/bofire/domain/domain.py
+++ b/bofire/domain/domain.py
@@ -705,10 +705,7 @@ class Domain(BaseModel):
             pd.DataFrame: dataframe with suggested experiments (candidates)
         """
         # check that each input feature has a col and is valid in itself
-        for feat in self.get_features(InputFeature):
-            if feat.key not in candidates:
-                raise ValueError(f"no col for input feature `{feat.key}`")
-            feat.validate_candidental(candidates[feat.key])
+        self.input_features.validate_inputs(candidates)
         # check if all constraints are fulfilled
         if not self.constraints.is_fulfilled(candidates).all():
             raise ValueError("Constraints not fulfilled.")

--- a/bofire/domain/features.py
+++ b/bofire/domain/features.py
@@ -1001,7 +1001,9 @@ class InputFeatures(Features):
         Returns:
             pd.DataFrame: Dataframe containing the samples.
         """
-        return pd.concat([feat.sample(n) for feat in self.get(InputFeature)], axis=1)
+        return self.validate_inputs(
+            pd.concat([feat.sample(n) for feat in self.get(InputFeature)], axis=1)
+        )
 
     def sample_sobol(self, n: int) -> pd.DataFrame:
         """Draw uniformly random samples
@@ -1013,6 +1015,24 @@ class InputFeatures(Features):
             pd.DataFrame: Dataframe containing the samples.
         """
         pass
+
+    def validate_inputs(self, inputs: pd.DataFrame) -> pd.DataFrame:
+        """Validate a pandas dataframe with input feature values.
+
+        Args:
+            inputs (pd.Dataframe): Inputs to validate.
+
+        Raises:
+            ValueError: Raises a Valueerror if a feature based validation raises an exception.
+
+        Returns:
+            pd.Dataframe: Validated dataframe
+        """
+        for feature in self:
+            if feature.key not in inputs:
+                raise ValueError(f"no col for input feature `{feature.key}`")
+            feature.validate_candidental(inputs[feature.key])
+        return inputs
 
     def add(self, feature: InputFeature):
         """Add a input feature to the container.

--- a/bofire/domain/features.py
+++ b/bofire/domain/features.py
@@ -146,6 +146,44 @@ class InputFeature(Feature):
 class NumericalInputFeature(InputFeature):
     """Abstracht base class for all numerical (ordinal) input features."""
 
+    def to_unit_range(
+        self, values: pd.Series, use_real_bounds: bool = False
+    ) -> pd.Series:
+        """_summary_
+
+        Args:
+            values (pd.Series): _description_
+            use_real_bounds (bool, optional): _description_. Defaults to False.
+
+        Returns:
+            pd.Series: _description_
+        """
+        if use_real_bounds:
+            lower, upper = self.get_real_feature_bounds(values)
+        else:
+            lower, upper = self.lower_bound, self.upper_bound
+        valrange = upper - lower
+        return values - lower / valrange
+
+    def from_unit_range(
+        self, values: pd.Series, use_real_bounds: bool = False
+    ) -> pd.Series:
+        """_summary_
+
+        Args:
+            values (pd.Series): _description_
+            use_real_bounds (bool, optional): _description_. Defaults to False.
+
+        Returns:
+            pd.Series: _description_
+        """
+        if use_real_bounds:
+            lower, upper = self.get_real_feature_bounds(values)
+        else:
+            lower, upper = self.lower_bound, self.upper_bound
+        valrange = upper - lower
+        return (values * valrange) + lower
+
     def is_fixed(self):
         """Method to check if the feature is fixed
 
@@ -954,7 +992,7 @@ class InputFeatures(Features):
 
     features: Optional[List[InputFeature]] = Field(default_factory=lambda: [])
 
-    def sample(self, n: int = 1) -> pd.DataFrame:
+    def sample_uniform(self, n: int = 1) -> pd.DataFrame:
         """Draw uniformly random samples
 
         Args:
@@ -964,6 +1002,17 @@ class InputFeatures(Features):
             pd.DataFrame: Dataframe containing the samples.
         """
         return pd.concat([feat.sample(n) for feat in self.get(InputFeature)], axis=1)
+
+    def sample_sobol(self, n: int) -> pd.DataFrame:
+        """Draw uniformly random samples
+
+        Args:
+            n (int, optional): Number of samples. Defaults to 1.
+
+        Returns:
+            pd.DataFrame: Dataframe containing the samples.
+        """
+        pass
 
     def add(self, feature: InputFeature):
         """Add a input feature to the container.

--- a/bofire/domain/features.py
+++ b/bofire/domain/features.py
@@ -1,4 +1,5 @@
 import itertools
+import warnings
 from abc import abstractmethod
 from typing import Dict, List, Optional, Type, Union
 
@@ -8,6 +9,7 @@ import pandas as pd
 from pydantic import Field, validator
 from pydantic.class_validators import root_validator
 from pydantic.types import conlist
+from scipy.stats.qmc import Sobol
 
 from bofire.domain.objectives import MaximizeObjective, Objective
 from bofire.domain.util import (
@@ -149,40 +151,44 @@ class NumericalInputFeature(InputFeature):
     def to_unit_range(
         self, values: pd.Series, use_real_bounds: bool = False
     ) -> pd.Series:
-        """_summary_
+        """Convert to the unit range between 0 and 1.
 
         Args:
-            values (pd.Series): _description_
-            use_real_bounds (bool, optional): _description_. Defaults to False.
+            values (pd.Series): values to be transformed
+            use_real_bounds (bool, optional): if True, use the bounds from the actual values else the bounds from the feature.
+                Defaults to False.
+
+        Raises:
+            ValueError: If lower_bound == upper bound an error is raised
 
         Returns:
-            pd.Series: _description_
+            pd.Series: transformed values.
         """
         if use_real_bounds:
             lower, upper = self.get_real_feature_bounds(values)
         else:
             lower, upper = self.lower_bound, self.upper_bound
+        if lower == upper:
+            raise ValueError("Fixed feature cannot be transformed to unit range.")
         valrange = upper - lower
-        return values - lower / valrange
+        return (values - lower) / valrange
 
-    def from_unit_range(
-        self, values: pd.Series, use_real_bounds: bool = False
-    ) -> pd.Series:
-        """_summary_
+    def from_unit_range(self, values: pd.Series) -> pd.Series:
+        """Convert from unit range.
 
         Args:
-            values (pd.Series): _description_
-            use_real_bounds (bool, optional): _description_. Defaults to False.
+            values (pd.Series): values to transform from.
+
+        Raises:
+            ValueError: if the feature is fixed raise a value error.
 
         Returns:
             pd.Series: _description_
         """
-        if use_real_bounds:
-            lower, upper = self.get_real_feature_bounds(values)
-        else:
-            lower, upper = self.lower_bound, self.upper_bound
-        valrange = upper - lower
-        return (values * valrange) + lower
+        if self.is_fixed():
+            raise ValueError("Fixed feature cannot be transformed from unit range.")
+        valrange = self.upper_bound - self.lower_bound
+        return (values * valrange) + self.lower_bound
 
     def is_fixed(self):
         """Method to check if the feature is fixed
@@ -208,7 +214,8 @@ class NumericalInputFeature(InputFeature):
 
         Args:
             values (pd.Series): A dataFrame with experiments
-            strict (bool, optional): Boolean to distinguish if the occurence of fixed features in the dataset should be considered or not. Defaults to False.
+            strict (bool, optional): Boolean to distinguish if the occurence of fixed features in the dataset should be considered or not.
+                Defaults to False.
 
         Raises:
             ValueError: when a value is not numerical
@@ -992,6 +999,22 @@ class InputFeatures(Features):
 
     features: Optional[List[InputFeature]] = Field(default_factory=lambda: [])
 
+    def get_fixed(self) -> "InputFeatures":
+        """Gets all features in `self` that are fixed and returns them as new `InputFeatures` object.
+
+        Returns:
+            InputFeatures: Input features object containing only fixed features.
+        """
+        return InputFeatures(features=[feat for feat in self if feat.is_fixed()])
+
+    def get_free(self) -> "InputFeatures":
+        """Gets all features in `self` that are not fixed and returns them as new `InputFeatures` object.
+
+        Returns:
+            InputFeatures: Input features object containing only non-fixed features.
+        """
+        return InputFeatures(features=[feat for feat in self if not feat.is_fixed()])
+
     def sample_uniform(self, n: int = 1) -> pd.DataFrame:
         """Draw uniformly random samples
 
@@ -1014,7 +1037,29 @@ class InputFeatures(Features):
         Returns:
             pd.DataFrame: Dataframe containing the samples.
         """
-        pass
+        free_features = self.get_free()
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            X = Sobol(len(free_features)).random(n)
+        res = []
+        for i, feat in enumerate(free_features):
+            if isinstance(feat, ContinuousInput):
+                x = feat.from_unit_range(X[:, i])
+            elif isinstance(feat, (DiscreteInput, CategoricalInput)):
+                if isinstance(feat, DiscreteInput):
+                    levels = feat.values
+                else:
+                    levels = feat.get_allowed_categories()
+                bins = np.linspace(0, 1, len(levels) + 1)
+                idx = np.digitize(X[:, i], bins) - 1
+                x = np.array(levels)[idx]
+            else:
+                raise (ValueError(f"Unknown input feature with key {feat.key}"))
+            res.append(pd.Series(x, name=feat.key))
+        samples = pd.concat(res, axis=1)
+        for feat in self.get_fixed():
+            samples[feat.key] = feat.fixed_value()
+        return self.validate_inputs(samples)
 
     def validate_inputs(self, inputs: pd.DataFrame) -> pd.DataFrame:
         """Validate a pandas dataframe with input feature values.

--- a/bofire/domain/features.py
+++ b/bofire/domain/features.py
@@ -1059,7 +1059,7 @@ class InputFeatures(Features):
         samples = pd.concat(res, axis=1)
         for feat in self.get_fixed():
             samples[feat.key] = feat.fixed_value()
-        return self.validate_inputs(samples)
+        return self.validate_inputs(samples)[self.get_keys(InputFeature)]
 
     def validate_inputs(self, inputs: pd.DataFrame) -> pd.DataFrame:
         """Validate a pandas dataframe with input feature values.

--- a/tests/bofire/domain/test_constraints.py
+++ b/tests/bofire/domain/test_constraints.py
@@ -210,7 +210,7 @@ def test_constraints_plus():
     ],
 )
 def test_constraints_call(constraints, num_candidates):
-    candidates = input_features.sample(num_candidates)
+    candidates = input_features.sample_uniform(num_candidates)
     returned = constraints(candidates)
     assert returned.shape == (num_candidates, len(constraints))
 
@@ -223,7 +223,7 @@ def test_constraints_call(constraints, num_candidates):
     ],
 )
 def test_constraints_is_fulfilled(constraints, num_candidates, fulfilled):
-    candidates = input_features.sample(num_candidates)
+    candidates = input_features.sample_uniform(num_candidates)
     returned = constraints.is_fulfilled(candidates)
     assert returned.shape == (num_candidates,)
     assert returned.dtype == bool

--- a/tests/bofire/domain/test_features.py
+++ b/tests/bofire/domain/test_features.py
@@ -16,6 +16,7 @@ from bofire.domain.features import (
     DiscreteInput,
     Feature,
     Features,
+    InputFeature,
     InputFeatures,
     OutputFeature,
     OutputFeatures,
@@ -106,6 +107,7 @@ FEATURE_SPECS = {
     ContinuousInput: {
         "valids": [
             VALID_CONTINUOUS_INPUT_FEATURE_SPEC,
+            VALID_FIXED_CONTINUOUS_INPUT_FEATURE_SPEC,
         ],
         "invalids": [
             *get_invalids(VALID_CONTINUOUS_INPUT_FEATURE_SPEC),
@@ -114,6 +116,7 @@ FEATURE_SPECS = {
     DiscreteInput: {
         "valids": [
             VALID_DISCRETE_INPUT_FEATURE_SPEC,
+            VALID_FIXED_DISCRETE_INPUT_FEATURE_SPEC,
         ],
         "invalids": [
             *get_invalids(VALID_DISCRETE_INPUT_FEATURE_SPEC),
@@ -151,6 +154,7 @@ FEATURE_SPECS = {
                 **VALID_CATEGORICAL_INPUT_FEATURE_SPEC,
                 "allowed": [True, False, True],
             },
+            VALID_FIXED_CATEGORICAL_INPUT_FEATURE_SPEC,
         ],
         "invalids": [
             *get_invalids(VALID_CATEGORICAL_INPUT_FEATURE_SPEC),
@@ -181,6 +185,7 @@ FEATURE_SPECS = {
                 **VALID_CATEGORICAL_DESCRIPTOR_INPUT_FEATURE_SPEC,
                 "allowed": [True, False, True],
             },
+            VALID_FIXED_CATEGORICAL_DESCRIPTOR_INPUT_FEATURE_SPEC,
         ],
         "invalids": [
             *get_invalids(VALID_CATEGORICAL_DESCRIPTOR_INPUT_FEATURE_SPEC),
@@ -221,6 +226,22 @@ FEATURE_SPECS = {
         "invalids": [*get_invalids(VALID_CONTINUOUS_OUTPUT_FEATURE_SPEC)],
     },
 }
+
+
+@pytest.mark.parametrize(
+    "cls, spec, n",
+    [
+        (cls, valid, n)
+        for cls, data in FEATURE_SPECS.items()
+        for valid in data["valids"]
+        for n in [1, 5]
+    ],
+)
+def test_input_feature_sample(cls, spec, n):
+    feature = cls(**spec)
+    if isinstance(feature, InputFeature):
+        samples = feature.sample(n)
+        feature.validate_candidental(samples)
 
 
 @pytest.mark.parametrize(
@@ -1113,7 +1134,7 @@ def test_features_add_invalid(features, feature):
     ],
 )
 def test_input_features_sample(features, num_samples):
-    samples = features.sample(num_samples)
+    samples = features.sample_uniform(num_samples)
     assert samples.shape == (num_samples, len(features))
     assert list(samples.columns) == input_features.get_keys()
 

--- a/tests/bofire/domain/test_features.py
+++ b/tests/bofire/domain/test_features.py
@@ -1057,6 +1057,13 @@ if3 = ContinuousInput(**{**VALID_FIXED_CONTINUOUS_INPUT_FEATURE_SPEC, "key": "if
 if4 = CategoricalInput(**{**VALID_FIXED_CATEGORICAL_INPUT_FEATURE_SPEC, "key": "if4"})
 if5 = DiscreteInput(**{**VALID_DISCRETE_INPUT_FEATURE_SPEC, "key": "if5"})
 if6 = DiscreteInput(**{**VALID_FIXED_DISCRETE_INPUT_FEATURE_SPEC, "key": "if6"})
+if7 = CategoricalInput(
+    **{
+        **VALID_CATEGORICAL_INPUT_FEATURE_SPEC,
+        "key": "if7",
+        "allowed": [True, False, True],
+    }
+)
 
 
 of1 = ContinuousOutput(**{**VALID_CONTINUOUS_OUTPUT_FEATURE_SPEC, "key": "of1"})
@@ -1233,12 +1240,14 @@ def test_input_features_get_free(features, expected):
     [
         (input_features, 1),
         (input_features, 2),
+        (InputFeatures(features=[if1, if2, if3, if4, if5, if6, if7]), 1),
+        (InputFeatures(features=[if1, if2, if3, if4, if5, if6, if7]), 1024),
     ],
 )
 def test_input_features_sample_uniform(features, num_samples):
     samples = features.sample_uniform(num_samples)
     assert samples.shape == (num_samples, len(features))
-    assert list(samples.columns) == input_features.get_keys()
+    assert list(samples.columns) == features.get_keys()
 
 
 @pytest.mark.parametrize(
@@ -1246,12 +1255,14 @@ def test_input_features_sample_uniform(features, num_samples):
     [
         (input_features, 1),
         (input_features, 2),
+        (InputFeatures(features=[if1, if2, if3, if4, if5, if6, if7]), 1),
+        (InputFeatures(features=[if1, if2, if3, if4, if5, if6, if7]), 1024),
     ],
 )
 def test_input_features_sample_sobol(features, num_samples):
     samples = features.sample_sobol(num_samples)
     assert samples.shape == (num_samples, len(features))
-    assert list(samples.columns) == input_features.get_keys()
+    assert list(samples.columns) == features.get_keys()
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
This PR brings (back) the following features:
- `to_unit_range` and `from_unit_range` as methods of the `NumericalInputFeature`.
- `get_fixed` and `get_free` as methods of `InputFeatures` to filter quickly over fixed/non-fixed features
- uniform sampling as a method of `InputFeatures`, I really like how you did it in opti 
- sobol sampling also as method of `InputFeatures`. In opti you had it as part of the sampling module, in everest we had it as part of the `RandomStrategy`. But I think it makes most sense to have it as a method of `InputFeatures` as uniform sampling as it only affects the input features. 