### PR TITLE
Refactor/serialize

### DIFF
--- a/bofire/domain/constraints.py
+++ b/bofire/domain/constraints.py
@@ -368,10 +368,23 @@ class Constraints(BaseModel):
     constraints: List[Constraint] = Field(default_factory=lambda: [])
 
     def to_config(self) -> List:
+        """Serializes a `Constraints` object.
+
+        Returns:
+            List: Constraints objects as serialized list.
+        """
         return [constraint.to_config() for constraint in self.constraints]
 
     @classmethod
     def from_config(cls, config: List) -> "Constraints":
+        """Instantiates a `Constraints` object based on the serialized list.
+
+        Args:
+            config (List): Serialized `Constraints` object as list.
+
+        Returns:
+            Constraints: Initialized `Constraints` object.
+        """
         return cls(
             constraints=[Constraint.from_config(constraint) for constraint in config]
         )

--- a/bofire/domain/constraints.py
+++ b/bofire/domain/constraints.py
@@ -367,6 +367,15 @@ class Constraints(BaseModel):
 
     constraints: List[Constraint] = Field(default_factory=lambda: [])
 
+    def to_config(self) -> List:
+        return [constraint.to_config() for constraint in self.constraints]
+
+    @classmethod
+    def from_config(cls, config: List) -> "Constraints":
+        return cls(
+            constraints=[Constraint.from_config(constraint) for constraint in config]
+        )
+
     def __iter__(self):
         return iter(self.constraints)
 

--- a/bofire/domain/domain.py
+++ b/bofire/domain/domain.py
@@ -152,9 +152,9 @@ class Domain(BaseModel):
             Dict: Serialized version of the domain as dictionary.
         """
         config: Dict[str, Any] = {
-            "input_features": [feat.to_config() for feat in self.input_features],
-            "output_features": [feat.to_config() for feat in self.output_features],
-            "constraints": [constraint.to_config() for constraint in self.constraints],
+            "input_features": self.input_features.to_config(),
+            "output_features": self.output_features.to_config(),
+            "constraints": self.constraints.to_config(),
         }
         if self.experiments is not None and self.num_experiments > 0:
             config["experiments"] = self.experiments.to_dict()
@@ -170,24 +170,13 @@ class Domain(BaseModel):
             config (Dict): Serialized version of a domain as dictionary.
         """
         d = cls(
-            input_features=InputFeatures(
-                features=[
-                    typing.cast(InputFeature, Feature.from_config(feat))
-                    for feat in config["input_features"]
-                ]
+            input_features=typing.cast(
+                InputFeatures, InputFeatures.from_config(config["input_features"])
             ),
-            output_features=OutputFeatures(
-                features=[
-                    typing.cast(OutputFeature, Feature.from_config(feat))
-                    for feat in config["output_features"]
-                ]
+            output_features=typing.cast(
+                OutputFeatures, OutputFeatures.from_config(config["output_features"])
             ),
-            constraints=Constraints(
-                constraints=[
-                    Constraint.from_config(constraint)
-                    for constraint in config["constraints"]
-                ]
-            ),
+            constraints=Constraints.from_config(config["constraints"]),
         )
         if "experiments" in config.keys():
             d.set_experiments(experiments=config["experiments"])

--- a/bofire/domain/features.py
+++ b/bofire/domain/features.py
@@ -930,6 +930,13 @@ class Features(BaseModel):
 
     features: List[Feature] = Field(default_factory=lambda: [])
 
+    def to_config(self) -> List:
+        return [feat.to_config() for feat in self.features]
+
+    @classmethod
+    def from_config(cls, config: List) -> Features:
+        return cls(features=[Feature.from_config(feat) for feat in config])
+
     def __iter__(self):
         return iter(self.features)
 

--- a/bofire/domain/features.py
+++ b/bofire/domain/features.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import itertools
 import warnings
 from abc import abstractmethod
-from typing import Any, Dict, List, Optional, Tuple, Type, TypeVar, Union
+from typing import Any, Dict, List, Optional, Tuple, Type, TypeVar, Union, cast
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -953,11 +953,17 @@ class Features(BaseModel):
         """
         if config["type"] == "inputs":
             return InputFeatures(
-                features=[Feature.from_config(feat) for feat in config["features"]]  # type: ignore
+                features=[
+                    cast(InputFeature, Feature.from_config(feat))
+                    for feat in config["features"]
+                ]
             )
         if config["type"] == "outputs":
             return OutputFeatures(
-                features=[Feature.from_config(feat) for feat in config["features"]]  # type: ignore
+                features=[
+                    cast(OutputFeature, Feature.from_config(feat))
+                    for feat in config["features"]
+                ]
             )
         if config["type"] == "general":
             return Features(

--- a/tests/bofire/domain/test_constraints.py
+++ b/tests/bofire/domain/test_constraints.py
@@ -182,6 +182,13 @@ constraints2 = Constraints(constraints=[c4, c5])
 constraints3 = Constraints(constraints=[c6])
 
 
+@pytest.mark.parametrize("constraints", [constraints, constraints2, constraints3])
+def test_constraints_serialize(constraints):
+    config = constraints.to_config()
+    nconstraints = Constraints.from_config(config=config)
+    assert constraints == nconstraints
+
+
 @pytest.mark.parametrize(
     "constraints",
     [

--- a/tests/bofire/domain/test_features.py
+++ b/tests/bofire/domain/test_features.py
@@ -1075,6 +1075,13 @@ output_features = OutputFeatures(features=[of1, of2])
 features = Features(features=[if1, if2, of1, of2])
 
 
+@pytest.mark.parametrize("features", [input_features, output_features, features])
+def test_features_serialie(features):
+    config = features.to_config()
+    nfeatures = Features.from_config(config=config)
+    assert nfeatures == features
+
+
 @pytest.mark.parametrize(
     "FeatureContainer, features",
     [


### PR DESCRIPTION
This PR refactors the domain serializers by introducing serializers  for `Features`, `InputFeatures`, `OutputFeatures` and `Constraints` and using them also in the `Domain`.