### PR TITLE
Feature/sampling2

### DIFF
--- a/bofire/domain/domain.py
+++ b/bofire/domain/domain.py
@@ -117,6 +117,39 @@ class Domain(BaseModel):
         return v
 
     @validator("constraints", always=True)
+    def validate_linear_constraints(cls, v, values):
+        """Validate if all features included in linear constraints are continuous ones.
+
+        Args:
+            v (List[Constraint]): List of constraints or empty if no constraints are defined
+            values (List[InputFeature]): List of input features of the domain
+
+        Raises:
+            ValueError: _description_
+
+
+        Returns:
+           List[Constraint]: List of constraints defined for the domain
+        """
+        if "input_features" not in values:
+            return v
+
+        # gather continuous input_features in dictionary
+        continuous_input_features_dict = {}
+        for f in values["input_features"]:
+            if type(f) is ContinuousInput:
+                continuous_input_features_dict[f.key] = f
+
+        # check if non continuous input features appear in linear constraints
+        for c in v:
+            if isinstance(c, LinearConstraint):
+                for f in c.features:
+                    assert (
+                        f in continuous_input_features_dict
+                    ), f"{f} must be continuous."
+        return v
+
+    @validator("constraints", always=True)
     def validate_lower_bounds_in_nchoosek_constraints(cls, v, values):
         """Validate the lower bound as well if the chosen number of allowed features is continuous.
 

--- a/bofire/samplers.py
+++ b/bofire/samplers.py
@@ -12,11 +12,15 @@ from bofire.domain.constraints import (
     Constraint,
     LinearEqualityConstraint,
     LinearInequalityConstraint,
+    NChooseKConstraint,
+    NonlinearInqualityConstraint,
 )
 from bofire.domain.features import (
+    CategoricalDescriptorInput,
     CategoricalInput,
     ContinuousInput,
     ContinuousOutput,
+    DiscreteInput,
     Feature,
     SamplingMethodEnum,
     Tnum_samples,
@@ -30,7 +34,25 @@ from bofire.strategies.strategy import (
 from bofire.utils.torch_tools import get_linear_constraints, tkwargs
 
 
+def apply_nchoosek(samples: pd.DataFrame, constraint: NChooseKConstraint):
+    """Apply an NChooseK constraint in place.
+
+    Args:
+        samples (pd.DataFrame): Dataframe with samples
+        constraint (NChooseKConstraint): NChooseK constraint which should be applied.
+    """
+    n_zeros = len(constraint.features) - constraint.max_count
+    for i in samples.index:
+        s = np.random.choice(constraint.features, size=n_zeros, replace=False)
+        samples.loc[i, s] = 0
+
+
 class Sampler(BaseModel):
+    """Base class for sampling methods in BoFire for sampling from constrained input spaces.
+
+    Attributes
+        domain (Domain): Domain defining the constrained input space
+    """
 
     domain: Domain
 
@@ -42,6 +64,14 @@ class Sampler(BaseModel):
 
     @validate_arguments
     def __call__(self, n: Tnum_samples) -> pd.DataFrame:
+        """Generates the samples.
+
+        Args:
+            n (Tnum_samples): number of samples to generate
+
+        Returns:
+            pd.DataFrame: Dataframe with samples.
+        """
         samples = self._sample(n)
         if len(samples) != n:
             raise ValueError(f"expected {n} samples, got {len(samples)}.")
@@ -49,12 +79,20 @@ class Sampler(BaseModel):
 
     @abstractmethod
     def _sample(self, n: Tnum_samples) -> pd.DataFrame:
+        """Abstract method that has to be overwritten in the actual sampler to generate the samples
+
+        Args:
+            n (Tnum_samples): number of samples to generate
+
+        Returns:
+            pd.DataFrame: Dataframe with samples.
+        """
         pass
 
     @classmethod
     @abstractmethod
     def is_constraint_implemented(cls, my_type: Type[Constraint]) -> bool:
-        """Abstract method to check if a specific constraint type is implemented for the strategy
+        """Abstract method to check if a specific constraint type is implemented for the sampler
 
         Args:
             my_type (Type[Constraint]): Constraint class
@@ -67,7 +105,7 @@ class Sampler(BaseModel):
     @classmethod
     @abstractmethod
     def is_feature_implemented(cls, my_type: Type[Feature]) -> bool:
-        """Abstract method to check if a specific feature type is implemented for the strategy
+        """Abstract method to check if a specific feature type is implemented for the sampler
 
         Args:
             my_type (Type[Feature]): Feature class
@@ -79,18 +117,26 @@ class Sampler(BaseModel):
 
 
 class PolytopeSampler(Sampler):
+    """Sampler that generates samples from a Polytope defined by linear equality and ineqality constraints.
+
+    Attributes:
+        domain (Domain): Domain defining the constrained input space
+    """
+
     def _sample(self, n: Tnum_samples) -> pd.DataFrame:
+        if len(self.domain.constraints) == 0:
+            return self.domain.input_features.sample(n, SamplingMethodEnum.UNIFORM)
 
         # get the bounds
         lower = [
-            feat.lower_bound
+            feat.lower_bound  # type: ignore
             for feat in self.domain.get_features(ContinuousInput)
-            if not feat.is_fixed()
+            if not feat.is_fixed()  # type: ignore
         ]
         upper = [
-            feat.upper_bound
+            feat.upper_bound  # type: ignore
             for feat in self.domain.get_features(ContinuousInput)
-            if not feat.is_fixed()
+            if not feat.is_fixed()  # type: ignore
         ]
         bounds = torch.tensor([lower, upper]).to(**tkwargs)
 
@@ -100,12 +146,12 @@ class PolytopeSampler(Sampler):
             bounds=bounds.to(**tkwargs),
             inequality_constraints=get_linear_constraints(
                 domain=self.domain,
-                constraint=LinearInequalityConstraint,
+                constraint=LinearInequalityConstraint,  # type: ignore
                 unit_scaled=False,
             ),
             equality_constraints=get_linear_constraints(
                 domain=self.domain,
-                constraint=LinearEqualityConstraint,
+                constraint=LinearEqualityConstraint,  # type: ignore
                 unit_scaled=False,
             ),
             n_burnin=1000,
@@ -119,7 +165,7 @@ class PolytopeSampler(Sampler):
         free_continuals = [
             feat.key
             for feat in self.domain.get_features(ContinuousInput)
-            if not feat.is_fixed()
+            if not feat.is_fixed()  # type: ignore
         ]
 
         # setup the output
@@ -129,22 +175,44 @@ class PolytopeSampler(Sampler):
             columns=free_continuals,
         )
 
-        # setup the categoricals as uniform sampled vals
-        for feat in self.domain.get_features(CategoricalInput):
-            samples[feat.key] = feat.sample(n)
+        # setup the categoricals and discrete ones as uniform sampled vals
+        for feat in self.domain.get_features([CategoricalInput, DiscreteInput]):
+            samples[feat.key] = feat.sample(n)  # type: ignore
 
         # setup the fixed continuous ones
         for feat in self.domain.input_features.get_fixed():
-            samples[feat.key] = feat.fixed_value()
+            samples[feat.key] = feat.fixed_value()  # type: ignore
 
         return samples
 
+    @classmethod
+    def is_constraint_implemented(cls, my_type: Type[Feature]) -> bool:
+        return my_type in [LinearInequalityConstraint, LinearEqualityConstraint]
+
+    @classmethod
+    def is_feature_implemented(cls, my_type: Type[Feature]) -> bool:
+        return my_type in [
+            ContinuousInput,
+            ContinuousOutput,
+            CategoricalInput,
+            DiscreteInput,
+            CategoricalDescriptorInput,
+        ]
+
 
 class RejectionSampler(Sampler):
+    """Sampler that generates samples via rejection sampling.
+
+    Attributes:
+        domain (Domain): Domain defining the constrained input space
+        sampling_method (SamplingMethodEnum, optional): Method to generate the base samples. Defaults to UNIFORM.
+        num_base_samples (int, optional): Number of base samples to sample in each iteration. Defaults to 1000.
+        max_iters (int, optinal): Number of iterations. Defaults to 1000.
+    """
 
     sampling_method: SamplingMethodEnum = SamplingMethodEnum.UNIFORM
-    num_base_samples: int = 1000
-    max_iters: int = 1000
+    num_base_samples: Tnum_samples = 1000
+    max_iters: Tnum_samples = 1000
 
     def _sample(self, n: Tnum_samples) -> pd.DataFrame:
         if len(self.domain.constraints) == 0:
@@ -166,8 +234,18 @@ class RejectionSampler(Sampler):
 
     @classmethod
     def is_constraint_implemented(cls, my_type: Type[Feature]) -> bool:
-        return my_type in [LinearInequalityConstraint]
+        return my_type in [
+            LinearInequalityConstraint,
+            NonlinearInqualityConstraint,
+            NChooseKConstraint,
+        ]
 
     @classmethod
     def is_feature_implemented(cls, my_type: Type[Feature]) -> bool:
-        return my_type in [ContinuousInput, ContinuousOutput]
+        return my_type in [
+            ContinuousInput,
+            ContinuousOutput,
+            DiscreteInput,
+            CategoricalInput,
+            CategoricalDescriptorInput,
+        ]

--- a/bofire/samplers.py
+++ b/bofire/samplers.py
@@ -222,7 +222,7 @@ class RejectionSampler(Sampler):
         valid_samples = []
         while n_found < n:
             if n_iters > self.max_iters:
-                raise Exception("Maximum iterations exceeded in rejection sampling.")
+                raise ValueError("Maximum iterations exceeded in rejection sampling.")
             samples = self.domain.input_features.sample(
                 self.num_base_samples, method=self.sampling_method
             )

--- a/bofire/samplers.py
+++ b/bofire/samplers.py
@@ -1,0 +1,108 @@
+from abc import abstractmethod
+from typing import Type
+
+import numpy as np
+import pandas as pd
+from pydantic import validate_arguments, validator
+
+from bofire.domain import Domain
+from bofire.domain.constraints import Constraint, LinearInequalityConstraint
+from bofire.domain.features import (
+    ContinuousInput,
+    ContinuousOutput,
+    Feature,
+    SamplingMethodEnum,
+    Tnum_samples,
+)
+from bofire.domain.util import BaseModel
+from bofire.strategies.strategy import (
+    validate_constraints,
+    validate_features,
+    validate_input_feature_count,
+)
+
+
+class Sampler(BaseModel):
+
+    domain: Domain
+
+    _validate_constraints = validator("domain", allow_reuse=True)(validate_constraints)
+    _validate_features = validator("domain", allow_reuse=True)(validate_features)
+    _validate_input_feature_count = validator("domain", allow_reuse=True)(
+        validate_input_feature_count
+    )
+
+    @validate_arguments
+    def __call__(self, n: Tnum_samples) -> pd.DataFrame:
+        samples = self._sample(n)
+        if len(samples) != n:
+            raise ValueError(f"expected {n} samples, got {len(samples)}.")
+        return self.domain.validate_candidates(samples, only_inputs=True)
+
+    @abstractmethod
+    def _sample(self, n: Tnum_samples) -> pd.DataFrame:
+        pass
+
+    @classmethod
+    @abstractmethod
+    def is_constraint_implemented(cls, my_type: Type[Constraint]) -> bool:
+        """Abstract method to check if a specific constraint type is implemented for the strategy
+
+        Args:
+            my_type (Type[Constraint]): Constraint class
+
+        Returns:
+            bool: True if the constraint type is valid for the strategy chosen, False otherwise
+        """
+        pass
+
+    @classmethod
+    @abstractmethod
+    def is_feature_implemented(cls, my_type: Type[Feature]) -> bool:
+        """Abstract method to check if a specific feature type is implemented for the strategy
+
+        Args:
+            my_type (Type[Feature]): Feature class
+
+        Returns:
+            bool: True if the feature type is valid for the strategy chosen, False otherwise
+        """
+        pass
+
+
+class ConstrainedSampler(Sampler):
+    def _sample(self, n: Tnum_samples) -> pd.DataFrame:
+        return super()._sample(n)
+
+
+class RejectionSampler(Sampler):
+
+    sampling_method: SamplingMethodEnum = SamplingMethodEnum.UNIFORM
+    num_base_samples: int = 1000
+    max_iters: int = 1000
+
+    def _sample(self, n: Tnum_samples) -> pd.DataFrame:
+        if len(self.domain.constraints) == 0:
+            return self.domain.input_features.sample(n, self.sampling_method)
+        n_iters = 0
+        n_found = 0
+        valid_samples = []
+        while n_found < n:
+            if n_iters > self.max_iters:
+                raise Exception("Maximum iterations exceeded in rejection sampling.")
+            samples = self.domain.input_features.sample(
+                self.num_base_samples, method=self.sampling_method
+            )
+            valid = self.domain.constraints.is_fulfilled(samples)
+            n_found += np.sum(valid)
+            valid_samples.append(samples[valid])
+            n_iters += 1
+        return pd.concat(valid_samples, ignore_index=True).iloc[:n]
+
+    @classmethod
+    def is_constraint_implemented(cls, my_type: Type[Feature]) -> bool:
+        return my_type in [LinearInequalityConstraint]
+
+    @classmethod
+    def is_feature_implemented(cls, my_type: Type[Feature]) -> bool:
+        return my_type in [ContinuousInput, ContinuousOutput]

--- a/bofire/samplers.py
+++ b/bofire/samplers.py
@@ -63,7 +63,7 @@ class Sampler(BaseModel):
     )
 
     @validate_arguments
-    def __call__(self, n: Tnum_samples) -> pd.DataFrame:
+    def ask(self, n: Tnum_samples) -> pd.DataFrame:
         """Generates the samples.
 
         Args:

--- a/bofire/strategies/strategy.py
+++ b/bofire/strategies/strategy.py
@@ -13,6 +13,83 @@ from bofire.domain.objectives import Objective
 from bofire.utils.transformer import Transformer
 
 
+def validate_constraints(cls, domain: Domain):
+    """Validator to ensure that all constraints defined in the domain are valid for the chosen strategy
+
+    Args:
+        domain (Domain): The domain to be used in the strategy
+
+    Raises:
+        ValueError: if a constraint is defined in the domain but is invalid for the strategy chosen
+
+    Returns:
+        Domain: the domain
+    """
+    for constraint in domain.constraints:
+        if not cls.is_constraint_implemented(type(constraint)):
+            raise ValueError(
+                f"constraint `{type(constraint)}` is not implemented for strategy `{cls.__name__}`"  # type: ignore
+            )
+    return domain
+
+
+def validate_features(cls, domain: Domain):
+    """Validator to ensure that all features defined in the domain are valid for the chosen strategy
+
+    Args:
+        domain (Domain): The domain to be used in the strategy
+
+    Raises:
+        ValueError: if a feature type is defined in the domain but is invalid for the strategy chosen
+
+    Returns:
+        Domain: the domain
+    """
+    for feature in domain.input_features + domain.output_features:
+        if not cls.is_feature_implemented(type(feature)):
+            raise ValueError(
+                f"feature `{type(feature)}` is not implemented for strategy `{cls.__name__}`"  # type: ignore
+            )
+    return domain
+
+
+def validate_input_feature_count(cls, domain: Domain):
+    """Validator to ensure that at least one input is defined.
+
+    Args:
+        domain (Domain): The domain to be used in the strategy
+
+    Raises:
+        ValueError: if no input feature is specified
+
+    Returns:
+        Domain: the domain
+    """
+    if len(domain.input_features) == 0:
+        raise ValueError("no input feature specified")
+    return domain
+
+
+def validate_output_feature_count(cls, domain: Domain):
+    """Validator to ensure that at least one output feature with attached objective is defined.
+
+    Args:
+        domain (Domain): The domain to be used in the strategy
+
+    Raises:
+        ValueError: if no output feature is specified
+        ValueError: if not output feauture with an attached objective is specified
+
+    Returns:
+        Domain: the domain
+    """
+    if len(domain.output_features) == 0:
+        raise ValueError("no output feature specified")
+    if len(domain.output_features.get_by_objective(Objective)) == 0:
+        raise ValueError("no output feature with objective specified")
+    return domain
+
+
 class Strategy(BaseModel):
     """Base class for all strategies
 
@@ -28,6 +105,15 @@ class Strategy(BaseModel):
     seed: Optional[NonNegativeInt]
     rng: Optional[np.random.Generator]
 
+    _validate_constraints = validator("domain", allow_reuse=True)(validate_constraints)
+    _validate_features = validator("domain", allow_reuse=True)(validate_features)
+    _validate_input_feature_count = validator("domain", allow_reuse=True)(
+        validate_input_feature_count
+    )
+    _validate_output_feature_count = validator("domain", allow_reuse=True)(
+        validate_output_feature_count
+    )
+
     def __init__(self, **data: Any):
         super().__init__(**data)
         # we setup a random seed here
@@ -36,69 +122,6 @@ class Strategy(BaseModel):
         self.rng = np.random.default_rng(self.seed)
 
         self._init_domain()
-
-    @validator("domain")
-    def validate_feature_count(cls, domain: Domain):
-        """Validator to ensure that at least one input and output feature with objective are defined
-
-        Args:
-            domain (Domain): The domain to be used in the strategy
-
-        Raises:
-            ValueError: if no input feature is specified
-            ValueError: if no output feature is specified
-            ValueError: if not output feauture with an attached objective is specified
-
-        Returns:
-            Domain: the domain
-        """
-        if len(domain.input_features) == 0:
-            raise ValueError("no input feature specified")
-        if len(domain.output_features) == 0:
-            raise ValueError("no output feature specified")
-        if len(domain.output_features.get_by_objective(Objective)) == 0:
-            raise ValueError("no output feature with objective specified")
-        return domain
-
-    @validator("domain")
-    def validate_constraints(cls, domain: Domain):
-        """Validator to ensure that all constraints defined in the domain are valid for the chosen strategy
-
-        Args:
-            domain (Domain): The domain to be used in the strategy
-
-        Raises:
-            ValueError: if a constraint is defined in the domain but is invalid for the strategy chosen
-
-        Returns:
-            Domain: the domain
-        """
-        for constraint in domain.constraints:
-            if not cls.is_constraint_implemented(type(constraint)):
-                raise ValueError(
-                    f"constraint `{type(constraint)}` is not implemented for strategy `{cls.__name__}`"  # type: ignore
-                )
-        return domain
-
-    @validator("domain")
-    def validate_features(cls, domain: Domain):
-        """Validator to ensure that all features defined in the domain are valid for the chosen strategy
-
-        Args:
-            domain (Domain): The domain to be used in the strategy
-
-        Raises:
-            ValueError: if a feature type is defined in the domain but is invalid for the strategy chosen
-
-        Returns:
-            Domain: the domain
-        """
-        for feature in domain.input_features + domain.output_features:
-            if not cls.is_feature_implemented(type(feature)):
-                raise ValueError(
-                    f"feature `{type(feature)}` is not implemented for strategy `{cls.__name__}`"  # type: ignore
-                )
-        return domain
 
     @validator("domain")
     def validate_objectives(cls, domain: Domain):

--- a/bofire/utils/torch_tools.py
+++ b/bofire/utils/torch_tools.py
@@ -1,8 +1,14 @@
+from typing import List, Tuple, Union
+
 import numpy as np
 import torch
+from torch import Tensor
 
 from bofire.domain import Domain
-from bofire.domain.constraints import LinearConstraint
+from bofire.domain.constraints import (
+    LinearEqualityConstraint,
+    LinearInequalityConstraint,
+)
 from bofire.domain.features import InputFeature
 
 tkwargs = {
@@ -12,8 +18,20 @@ tkwargs = {
 
 
 def get_linear_constraints(
-    domain: Domain, constraint: LinearConstraint, unit_scaled: bool = False
-):
+    domain: Domain,
+    constraint: Union[LinearEqualityConstraint, LinearInequalityConstraint],
+    unit_scaled: bool = False,
+) -> List[Tuple[Tensor, Tensor, float]]:
+    """Converts linear constraints to the form required by BoTorch.
+
+    Args:
+        domain (Domain): Optimization problem definition.
+        constraint (Union[LinearEqualityConstraint, LinearInequalityConstraint]): Type of constraint that should be converted.
+        unit_scaled (bool, optional): If True, transforms constraints by assuming that the bound for the continuous features are [0,1]. Defaults to False.
+
+    Returns:
+        List[Tuple[Tensor, Tensor, float]]: List of tuples, each tuple consists of a tensor with the feature indices, coefficients and a float for the rhs.
+    """
     constraints = []
     for c in domain.constraints.get(constraint):
         indices = []

--- a/bofire/utils/torch_tools.py
+++ b/bofire/utils/torch_tools.py
@@ -21,17 +21,17 @@ def get_linear_constraints(
         lower = []
         upper = []
         rhs = 0.0
-        for i, featkey in enumerate(c.features):
+        for i, featkey in enumerate(c.features):  # type: ignore
             idx = domain.get_feature_keys(InputFeature).index(featkey)
             feat = domain.get_feature(featkey)
-            if feat.is_fixed():
-                rhs -= feat.fixed_value() * c.coefficients[i]
+            if feat.is_fixed():  # type: ignore
+                rhs -= feat.fixed_value() * c.coefficients[i]  # type: ignore
             else:
-                lower.append(feat.lower_bound)
-                upper.append(feat.upper_bound)
+                lower.append(feat.lower_bound)  # type: ignore
+                upper.append(feat.upper_bound)  # type: ignore
                 indices.append(idx)
                 coefficients.append(
-                    c.coefficients[i]
+                    c.coefficients[i]  # type: ignore
                 )  # if unit_scaled == False else c_scaled.coefficients[i])
         if unit_scaled:
             lower = np.array(lower)
@@ -42,7 +42,7 @@ def get_linear_constraints(
                 (
                     torch.tensor(indices),
                     -torch.tensor(scaled_coefficients).to(**tkwargs),
-                    -(rhs + c.rhs - np.sum(np.array(coefficients) * lower)),
+                    -(rhs + c.rhs - np.sum(np.array(coefficients) * lower)),  # type: ignore
                 )
             )
         else:
@@ -50,7 +50,7 @@ def get_linear_constraints(
                 (
                     torch.tensor(indices),
                     -torch.tensor(coefficients).to(**tkwargs),
-                    -(rhs + c.rhs),
+                    -(rhs + c.rhs),  # type: ignore
                 )
             )
     return constraints

--- a/bofire/utils/torch_tools.py
+++ b/bofire/utils/torch_tools.py
@@ -1,0 +1,56 @@
+import numpy as np
+import torch
+
+from bofire.domain import Domain
+from bofire.domain.constraints import LinearConstraint
+from bofire.domain.features import InputFeature
+
+tkwargs = {
+    "dtype": torch.double,
+    "device": "cpu",
+}
+
+
+def get_linear_constraints(
+    domain: Domain, constraint: LinearConstraint, unit_scaled: bool = False
+):
+    constraints = []
+    for c in domain.constraints.get(constraint):
+        indices = []
+        coefficients = []
+        lower = []
+        upper = []
+        rhs = 0.0
+        for i, featkey in enumerate(c.features):
+            idx = domain.get_feature_keys(InputFeature).index(featkey)
+            feat = domain.get_feature(featkey)
+            if feat.is_fixed():
+                rhs -= feat.fixed_value() * c.coefficients[i]
+            else:
+                lower.append(feat.lower_bound)
+                upper.append(feat.upper_bound)
+                indices.append(idx)
+                coefficients.append(
+                    c.coefficients[i]
+                )  # if unit_scaled == False else c_scaled.coefficients[i])
+        if unit_scaled:
+            lower = np.array(lower)
+            upper = np.array(upper)
+            s = upper - lower
+            scaled_coefficients = s * np.array(coefficients)
+            constraints.append(
+                (
+                    torch.tensor(indices),
+                    -torch.tensor(scaled_coefficients).to(**tkwargs),
+                    -(rhs + c.rhs - np.sum(np.array(coefficients) * lower)),
+                )
+            )
+        else:
+            constraints.append(
+                (
+                    torch.tensor(indices),
+                    torch.tensor(coefficients).to(**tkwargs),
+                    -(rhs + c.rhs),
+                )
+            )
+    return constraints

--- a/bofire/utils/torch_tools.py
+++ b/bofire/utils/torch_tools.py
@@ -49,7 +49,7 @@ def get_linear_constraints(
             constraints.append(
                 (
                     torch.tensor(indices),
-                    torch.tensor(coefficients).to(**tkwargs),
+                    -torch.tensor(coefficients).to(**tkwargs),
                     -(rhs + c.rhs),
                 )
             )

--- a/tests/bofire/domain/test_constraints.py
+++ b/tests/bofire/domain/test_constraints.py
@@ -226,7 +226,7 @@ def test_constraints_plus():
     ],
 )
 def test_constraints_call(constraints, num_candidates):
-    candidates = input_features.sample_uniform(num_candidates)
+    candidates = input_features.sample(num_candidates, "UNIFORM")
     returned = constraints(candidates)
     assert returned.shape == (num_candidates, len(constraints))
 
@@ -239,7 +239,7 @@ def test_constraints_call(constraints, num_candidates):
     ],
 )
 def test_constraints_is_fulfilled(constraints, num_candidates, fulfilled):
-    candidates = input_features.sample_uniform(num_candidates)
+    candidates = input_features.sample(num_candidates, "UNIFORM")
     returned = constraints.is_fulfilled(candidates)
     assert returned.shape == (num_candidates,)
     assert returned.dtype == bool

--- a/tests/bofire/domain/test_domain.py
+++ b/tests/bofire/domain/test_domain.py
@@ -14,6 +14,7 @@ from bofire.domain.features import (
     CategoricalInput,
     ContinuousInput,
     ContinuousOutput,
+    DiscreteInput,
     Feature,
     InputFeature,
     OutputFeature,
@@ -84,6 +85,27 @@ def test_invalid_domain_arg_types(input_features, output_features, constraints):
             output_features=output_features,
             constraints=constraints,
         )
+
+
+@pytest.mark.parametrize(
+    "input_features, constraints",
+    [
+        (
+            [
+                ContinuousInput(key="if1", lower_bound=0, upper_bound=1),
+                DiscreteInput(key="if2", values=[0.2, 0.7, 1.0]),
+            ],
+            [
+                LinearEqualityConstraint(
+                    features=["if1", "if2"], coefficients=[1.0, 1.0], rhs=11
+                )
+            ],
+        )
+    ],
+)
+def test_invalid_type_in_linear_constraints(input_features, constraints):
+    with pytest.raises(ValidationError):
+        Domain(input_features=input_features, constraints=constraints)
 
 
 @pytest.mark.parametrize(

--- a/tests/bofire/domain/test_features.py
+++ b/tests/bofire/domain/test_features.py
@@ -1236,31 +1236,19 @@ def test_input_features_get_free(features, expected):
 
 
 @pytest.mark.parametrize(
-    "features, num_samples",
+    "features, num_samples, method",
     [
-        (input_features, 1),
-        (input_features, 2),
-        (InputFeatures(features=[if1, if2, if3, if4, if5, if6, if7]), 1),
-        (InputFeatures(features=[if1, if2, if3, if4, if5, if6, if7]), 1024),
+        (features, num_samples, method)
+        for features in [
+            input_features,
+            InputFeatures(features=[if1, if2, if3, if4, if5, if6, if7]),
+        ]
+        for num_samples in [1, 2, 1024]
+        for method in ["UNIFORM", "SOBOL", "LHS"]
     ],
 )
-def test_input_features_sample_uniform(features, num_samples):
-    samples = features.sample_uniform(num_samples)
-    assert samples.shape == (num_samples, len(features))
-    assert list(samples.columns) == features.get_keys()
-
-
-@pytest.mark.parametrize(
-    "features, num_samples",
-    [
-        (input_features, 1),
-        (input_features, 2),
-        (InputFeatures(features=[if1, if2, if3, if4, if5, if6, if7]), 1),
-        (InputFeatures(features=[if1, if2, if3, if4, if5, if6, if7]), 1024),
-    ],
-)
-def test_input_features_sample_sobol(features, num_samples):
-    samples = features.sample_sobol(num_samples)
+def test_input_features_sample(features, num_samples, method):
+    samples = features.sample(num_samples, method=method)
     assert samples.shape == (num_samples, len(features))
     assert list(samples.columns) == features.get_keys()
 

--- a/tests/bofire/test_samplers.py
+++ b/tests/bofire/test_samplers.py
@@ -37,7 +37,7 @@ def test_rejection_sampler(features, constraints, sampling_method, num_samples):
         constraints=constraints,
     )
     sampler = RejectionSampler(domain=domain, sampling_method=sampling_method)
-    sampler(num_samples)
+    sampler.ask(num_samples)
 
 
 def test_rejection_sampler_not_converged():
@@ -47,7 +47,7 @@ def test_rejection_sampler_not_converged():
     )
     sampler = RejectionSampler(domain=domain, num_base_samples=16, max_iters=2)
     with pytest.raises(ValueError):
-        sampler(128)
+        sampler.ask(128)
 
 
 if1 = ContinuousInput(
@@ -112,5 +112,5 @@ domains = [
 )
 def test_RandomStrategyConstraints(domain, candidate_count):
     sampler = PolytopeSampler(domain=domain)
-    samples = sampler(candidate_count)
+    samples = sampler.ask(candidate_count)
     assert len(samples) == candidate_count

--- a/tests/bofire/test_samplers.py
+++ b/tests/bofire/test_samplers.py
@@ -1,9 +1,13 @@
 import pytest
 
 from bofire.domain import Domain
-from bofire.domain.constraints import Constraints, LinearInequalityConstraint
-from bofire.domain.features import ContinuousInput, InputFeatures
-from bofire.samplers import RejectionSampler
+from bofire.domain.constraints import (
+    Constraints,
+    LinearEqualityConstraint,
+    LinearInequalityConstraint,
+)
+from bofire.domain.features import CategoricalInput, ContinuousInput, InputFeatures
+from bofire.samplers import PolytopeSampler, RejectionSampler
 
 input_features = InputFeatures(
     features=[
@@ -38,3 +42,69 @@ def test_rejection_sampler(features, constraints, sampling_method, num_samples):
 
 def test_rejection_sampler_not_converged():
     pass
+
+
+if1 = ContinuousInput(
+    lower_bound=0.0,
+    upper_bound=1.0,
+    key="if1",
+)
+if2 = ContinuousInput(
+    lower_bound=0.0,
+    upper_bound=1.0,
+    key="if2",
+)
+if3 = ContinuousInput(
+    lower_bound=0.0,
+    upper_bound=1.0,
+    key="if3",
+)
+if4 = ContinuousInput(
+    lower_bound=0.1,
+    upper_bound=0.1,
+    key="if4",
+)
+if5 = CategoricalInput(
+    categories=["a", "b", "c"],
+    key="if5",
+)
+if6 = CategoricalInput(
+    categories=["a", "b", "c"],
+    allowed=[False, True, False],
+    key="if6",
+)
+c1 = LinearEqualityConstraint(
+    features=["if1", "if2", "if3", "if4"], coefficients=[1.0, 1.0, 1.0, 1.0], rhs=1.0
+)
+c2 = LinearInequalityConstraint.from_greater_equal(
+    features=["if1", "if2"], coefficients=[1.0, 1.0], rhs=0.2
+)
+c3 = LinearInequalityConstraint.from_greater_equal(
+    features=["if1", "if2", "if4"], coefficients=[1.0, 1.0, 0.5], rhs=0.2
+)
+
+domains = [
+    Domain(input_features=[if1, if2, if3], constraints=[c2]),
+    Domain(input_features=[if1, if2, if3, if4], constraints=[c1, c2]),
+    Domain(input_features=[if1, if2, if3, if4], constraints=[c1, c2, c3]),
+    Domain(input_features=[if1, if2, if3, if5], constraints=[c2]),
+    Domain(input_features=[if1, if2, if3, if4, if5], constraints=[c1, c2]),
+    Domain(input_features=[if1, if2, if3, if4, if5], constraints=[c1, c2, c3]),
+    Domain(input_features=[if1, if2, if3, if6], constraints=[c2]),
+    Domain(input_features=[if1, if2, if3, if4, if6], constraints=[c1, c2]),
+    Domain(input_features=[if1, if2, if3, if4, if6], constraints=[c1, c2, c3]),
+]
+
+
+@pytest.mark.parametrize(
+    "domain, candidate_count",
+    [
+        (domain, candidate_count)
+        for domain in domains
+        for candidate_count in range(1, 5)
+    ],
+)
+def test_RandomStrategyConstraints(domain, candidate_count):
+    sampler = PolytopeSampler(domain=domain)
+    samples = sampler(candidate_count)
+    assert len(samples) == candidate_count

--- a/tests/bofire/test_samplers.py
+++ b/tests/bofire/test_samplers.py
@@ -1,0 +1,40 @@
+import pytest
+
+from bofire.domain import Domain
+from bofire.domain.constraints import Constraints, LinearInequalityConstraint
+from bofire.domain.features import ContinuousInput, InputFeatures
+from bofire.samplers import RejectionSampler
+
+input_features = InputFeatures(
+    features=[
+        ContinuousInput(key=f"if{i}", lower_bound=0, upper_bound=1) for i in range(1, 4)
+    ]
+)
+constraints = Constraints(
+    constraints=[
+        LinearInequalityConstraint(
+            features=["if1", "if2", "if3"], coefficients=[1, 1, 1], rhs=1
+        )
+    ]
+)
+
+
+@pytest.mark.parametrize(
+    "features, constraints, sampling_method, num_samples",
+    [
+        (input_features, constraints, sampling_method, num_samples)
+        for sampling_method in ["SOBOL", "UNIFORM", "LHS"]
+        for num_samples in [1, 2, 64, 128]
+    ],
+)
+def test_rejection_sampler(features, constraints, sampling_method, num_samples):
+    domain = Domain(
+        input_features=features,
+        constraints=constraints,
+    )
+    sampler = RejectionSampler(domain=domain, sampling_method=sampling_method)
+    sampler(num_samples)
+
+
+def test_rejection_sampler_not_converged():
+    pass

--- a/tests/bofire/test_samplers.py
+++ b/tests/bofire/test_samplers.py
@@ -41,7 +41,13 @@ def test_rejection_sampler(features, constraints, sampling_method, num_samples):
 
 
 def test_rejection_sampler_not_converged():
-    pass
+    domain = Domain(
+        input_features=input_features,
+        constraints=constraints,
+    )
+    sampler = RejectionSampler(domain=domain, num_base_samples=16, max_iters=2)
+    with pytest.raises(ValueError):
+        sampler(128)
 
 
 if1 = ContinuousInput(

--- a/tests/bofire/utils/test_torch_tools.py
+++ b/tests/bofire/utils/test_torch_tools.py
@@ -62,7 +62,7 @@ def test_get_linear_constraints():
     assert len(constraints) == 1
     assert constraints[0][2] == c2.rhs * -1
     assert torch.allclose(constraints[0][0], torch.tensor([0, 1]))
-    # assert torch.allclose(constraints[0][1]) ==
+    assert torch.allclose(constraints[0][1], torch.tensor([-1.0, -1.0]).to(**tkwargs))
 
     domain = Domain(
         input_features=[if1, if2, if3, if4],
@@ -72,12 +72,16 @@ def test_get_linear_constraints():
     assert len(constraints) == 1
     assert constraints[0][2] == -1 * (c1.rhs - 0.1)
     assert len(constraints[0][0]) == len(c1.features) - 1
+    assert torch.allclose(constraints[0][0], torch.tensor([0, 1, 2]))
+    assert torch.allclose(constraints[0][1], torch.tensor([-1, -1, -1]).to(**tkwargs))
     assert len(constraints[0][1]) == len(c1.coefficients) - 1
     constraints = get_linear_constraints(domain, LinearInequalityConstraint)
     assert len(constraints) == 1
     assert constraints[0][2] == c2.rhs * -1
     assert len(constraints[0][0]) == len(c2.features)
     assert len(constraints[0][1]) == len(c2.coefficients)
+    assert torch.allclose(constraints[0][0], torch.tensor([0, 1]))
+    assert torch.allclose(constraints[0][1], torch.tensor([-1.0, -1.0]).to(**tkwargs))
 
     domain = Domain(
         input_features=[if1, if2, if3, if4, if5],
@@ -88,14 +92,20 @@ def test_get_linear_constraints():
     assert constraints[0][2] == (c1.rhs - 0.1) * -1
     assert len(constraints[0][0]) == len(c1.features) - 1
     assert len(constraints[0][1]) == len(c1.coefficients) - 1
+    assert torch.allclose(constraints[0][0], torch.tensor([0, 1, 2]))
+    assert torch.allclose(constraints[0][1], torch.tensor([-1, -1, -1]).to(**tkwargs))
     constraints = get_linear_constraints(domain, LinearInequalityConstraint)
     assert len(constraints) == 2
     assert constraints[0][2] == c2.rhs * -1
     assert len(constraints[0][0]) == len(c2.features)
     assert len(constraints[0][1]) == len(c2.coefficients)
+    assert torch.allclose(constraints[0][0], torch.tensor([0, 1]))
+    assert torch.allclose(constraints[0][1], torch.tensor([-1.0, -1.0]).to(**tkwargs))
     assert constraints[1][2] == (c3.rhs - 0.5 * 0.1) * -1
     assert len(constraints[1][0]) == len(c3.features) - 1
     assert len(constraints[1][1]) == len(c3.coefficients) - 1
+    assert torch.allclose(constraints[1][0], torch.tensor([0, 1]))
+    assert torch.allclose(constraints[1][1], torch.tensor([-1.0, -1.0]).to(**tkwargs))
 
 
 def test_get_linear_constraints_unit_scaled():
@@ -130,3 +140,4 @@ def test_get_linear_constraints_unit_scaled():
     assert torch.allclose(
         constraints[0][1], torch.tensor([0.4, 0.6, 0.5]).to(**tkwargs) * -1
     )
+    assert torch.allclose(constraints[0][0], torch.tensor([1, 2, 0]))

--- a/tests/bofire/utils/test_torch_tools.py
+++ b/tests/bofire/utils/test_torch_tools.py
@@ -1,0 +1,132 @@
+import torch
+
+from bofire.domain import Domain
+from bofire.domain.constraints import (
+    LinearEqualityConstraint,
+    LinearInequalityConstraint,
+)
+from bofire.domain.features import CategoricalInput, ContinuousInput
+from bofire.utils.torch_tools import get_linear_constraints, tkwargs
+
+if1 = ContinuousInput(
+    lower_bound=0.0,
+    upper_bound=1.0,
+    key="if1",
+)
+if2 = ContinuousInput(
+    lower_bound=0.0,
+    upper_bound=1.0,
+    key="if2",
+)
+if3 = ContinuousInput(
+    lower_bound=0.0,
+    upper_bound=1.0,
+    key="if3",
+)
+if4 = ContinuousInput(
+    lower_bound=0.1,
+    upper_bound=0.1,
+    key="if4",
+)
+if5 = CategoricalInput(
+    categories=["a", "b", "c"],
+    key="if5",
+)
+if6 = CategoricalInput(
+    categories=["a", "b", "c"],
+    allowed=[False, True, False],
+    key="if6",
+)
+c1 = LinearEqualityConstraint(
+    features=["if1", "if2", "if3", "if4"], coefficients=[1.0, 1.0, 1.0, 1.0], rhs=1.0
+)
+c2 = LinearInequalityConstraint(
+    features=["if1", "if2"], coefficients=[1.0, 1.0], rhs=0.2
+)
+c3 = LinearInequalityConstraint(
+    features=["if1", "if2", "if4"], coefficients=[1.0, 1.0, 0.5], rhs=0.2
+)
+
+
+def test_get_linear_constraints():
+    domain = Domain(input_features=[if1, if2])
+    constraints = get_linear_constraints(domain, LinearEqualityConstraint)
+    assert len(constraints) == 0
+    constraints = get_linear_constraints(domain, LinearInequalityConstraint)
+    assert len(constraints) == 0
+
+    domain = Domain(input_features=[if1, if2, if3], constraints=[c2])
+    constraints = get_linear_constraints(domain, LinearEqualityConstraint)
+    assert len(constraints) == 0
+    constraints = get_linear_constraints(domain, LinearInequalityConstraint)
+    assert len(constraints) == 1
+    assert constraints[0][2] == c2.rhs * -1
+    assert torch.allclose(constraints[0][0], torch.tensor([0, 1]))
+    # assert torch.allclose(constraints[0][1]) ==
+
+    domain = Domain(
+        input_features=[if1, if2, if3, if4],
+        constraints=[c1, c2],
+    )
+    constraints = get_linear_constraints(domain, LinearEqualityConstraint)
+    assert len(constraints) == 1
+    assert constraints[0][2] == -1 * (c1.rhs - 0.1)
+    assert len(constraints[0][0]) == len(c1.features) - 1
+    assert len(constraints[0][1]) == len(c1.coefficients) - 1
+    constraints = get_linear_constraints(domain, LinearInequalityConstraint)
+    assert len(constraints) == 1
+    assert constraints[0][2] == c2.rhs * -1
+    assert len(constraints[0][0]) == len(c2.features)
+    assert len(constraints[0][1]) == len(c2.coefficients)
+
+    domain = Domain(
+        input_features=[if1, if2, if3, if4, if5],
+        constraints=[c1, c2, c3],
+    )
+    constraints = get_linear_constraints(domain, LinearEqualityConstraint)
+    assert len(constraints) == 1
+    assert constraints[0][2] == (c1.rhs - 0.1) * -1
+    assert len(constraints[0][0]) == len(c1.features) - 1
+    assert len(constraints[0][1]) == len(c1.coefficients) - 1
+    constraints = get_linear_constraints(domain, LinearInequalityConstraint)
+    assert len(constraints) == 2
+    assert constraints[0][2] == c2.rhs * -1
+    assert len(constraints[0][0]) == len(c2.features)
+    assert len(constraints[0][1]) == len(c2.coefficients)
+    assert constraints[1][2] == (c3.rhs - 0.5 * 0.1) * -1
+    assert len(constraints[1][0]) == len(c3.features) - 1
+    assert len(constraints[1][1]) == len(c3.coefficients) - 1
+
+
+def test_get_linear_constraints_unit_scaled():
+    domain = Domain()
+    domain.add_feature(
+        ContinuousInput(key="base_polymer", lower_bound=0.3, upper_bound=0.7)
+    )
+    domain.add_feature(
+        ContinuousInput(key="glas_fibre", lower_bound=0.1, upper_bound=0.7)
+    )
+    domain.add_feature(
+        ContinuousInput(key="additive", lower_bound=0.1, upper_bound=0.6)
+    )
+    domain.add_feature(
+        ContinuousInput(key="temperature", lower_bound=30.0, upper_bound=700.0)
+    )
+    domain.add_constraint(
+        LinearEqualityConstraint(
+            coefficients=[1.0, 1.0, 1.0],
+            features=["base_polymer", "glas_fibre", "additive"],
+            rhs=1.0,
+        )
+    )
+
+    constraints = get_linear_constraints(
+        domain, LinearEqualityConstraint, unit_scaled=True
+    )
+    assert len(constraints) == 1
+    assert len(constraints[0][0]) == 3
+    assert len(constraints[0][1]) == 3
+    assert constraints[0][2] == 0.5 * -1
+    assert torch.allclose(
+        constraints[0][1], torch.tensor([0.4, 0.6, 0.5]).to(**tkwargs) * -1
+    )


### PR DESCRIPTION
This PR implements the features:
- refactoring of sampling methods in InputFeatures --> one method that can be called with an EnumArgument to choose the actual sampling method.
- In addition to UNIFORM and SOBOL, also LHS (latin hypercube sampling) is now supported.
- For constrained sampling a new base class, called `Sampler` is implemented. we can discuss if this is necesseray or if we implement it just as a Strategy. Difference is that samplers do not take care for past experiments and not at all for output features. But we can discuss this.
- I implemented then the `RejectionSampler` and the `PolytopeSampler`. So far NChooseK is not yet supported as the definition of NChooseK is wider in bofire than in opti. But we can for the start easily adopt the strategy for dealing with them as in opti. This can crash if you have on a feature bot a linear constraint and an nchoosek constraint.
- In addtion a module torch_tools.py is introduced. There I implemented a method to create torch linear (in)equality constraints out of our constraint definitions. This method was also available in mbo, but I ported the one from everest as this is also able to remove fixed features from linear constraints. Unit scaling is also supported.
- `PolytopeSampler` is implemented by using fatures from botorch. For this reason, botorch is now a new dependency.

Any comments @DavidWalz @jkleinekorte @R-M-Lee @bertiqwerty ?
