### PR TITLE
Refactor/objective constraints

### DIFF
--- a/bofire/domain/features.py
+++ b/bofire/domain/features.py
@@ -840,7 +840,7 @@ class ContinuousOutput(OutputFeature):
         self,
         lower: float,
         upper: float,
-        df_data: Optional[pd.DataFrame] = None,
+        experiments: Optional[pd.DataFrame] = None,
         plot_details: bool = True,
         line_options: Optional[Dict] = None,
         scatter_options: Optional[Dict] = None,
@@ -852,7 +852,7 @@ class ContinuousOutput(OutputFeature):
         Args:
             lower (float): lower bound for the plot
             upper (float): upper bound for the plot
-            df_data (Optional[pd.DataFrame], optional): If provided, scatter also the historical data in the plot. Defaults to None.
+            experiments (Optional[pd.DataFrame], optional): If provided, scatter also the historical data in the plot. Defaults to None.
         """
         if self.objective is None:
             raise ValueError(
@@ -867,13 +867,13 @@ class ContinuousOutput(OutputFeature):
         line_options["color"] = line_options.get("color", "black")
         scatter_options["color"] = scatter_options.get("color", "red")
 
-        x = pd.DataFrame(np.linspace(lower, upper, 5000))
+        x = pd.Series(np.linspace(lower, upper, 5000))
         reward = self.objective.__call__(x)
         fig, ax = plt.subplots()
         ax.plot(x, reward, **line_options)
         # TODO: validate dataframe
-        if df_data is not None:
-            x_data = df_data.loc[df_data[self.key].notna(), self.key].values
+        if experiments is not None:
+            x_data = experiments.loc[experiments[self.key].notna(), self.key].values
             ax.scatter(
                 x_data,  # type: ignore
                 self.objective.__call__(x_data),  # type: ignore

--- a/bofire/domain/objectives.py
+++ b/bofire/domain/objectives.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from abc import abstractmethod
-from typing import Dict
+from typing import Dict, Union
 
 import numpy as np
 import pandas as pd
@@ -22,7 +22,7 @@ class Objective(BaseModel):
     """The base class for all objectives"""
 
     @abstractmethod
-    def __call__(self, x: pd.DataFrame) -> pd.DataFrame:
+    def __call__(self, x: Union[pd.Series, np.ndarray]) -> Union[pd.Series, np.ndarray]:
         """Abstract method to define the call function for the class Objective
 
         Args:
@@ -110,7 +110,7 @@ class IdentityObjective(Objective):
             )
         return values
 
-    def __call__(self, x: np.ndarray) -> np.ndarray:
+    def __call__(self, x: Union[pd.Series, np.ndarray]) -> Union[pd.Series, np.ndarray]:
         """The call function returning a reward for passed x values
 
         Args:
@@ -143,7 +143,7 @@ class MinimizeObjective(IdentityObjective):
         upper_bound (float, optional): Upper bound for normalizing the objective between zero and one. Defaults to one.
     """
 
-    def __call__(self, x: np.ndarray) -> np.ndarray:
+    def __call__(self, x: Union[pd.Series, np.ndarray]) -> Union[pd.Series, np.ndarray]:
         """The call function returning a reward for passed x values
 
         Args:
@@ -167,7 +167,7 @@ class DeltaObjective(IdentityObjective):
     ref_point: float
     scale: float = 1
 
-    def __call__(self, x: np.ndarray) -> np.ndarray:
+    def __call__(self, x: Union[pd.Series, np.ndarray]) -> Union[pd.Series, np.ndarray]:
         """The call function returning a reward for passed x values
 
         Args:
@@ -203,7 +203,7 @@ class MaximizeSigmoidObjective(SigmoidObjective):
 
     """
 
-    def __call__(self, x: np.ndarray) -> np.ndarray:
+    def __call__(self, x: Union[pd.Series, np.ndarray]) -> Union[pd.Series, np.ndarray]:
         """The call function returning a sigmoid shaped reward for passed x values.
 
         Args:
@@ -224,7 +224,7 @@ class MinimizeSigmoidObjective(SigmoidObjective):
         tp (float): Turning point of the sigmoid function.
     """
 
-    def __call__(self, x: np.ndarray) -> np.ndarray:
+    def __call__(self, x: Union[pd.Series, np.ndarray]) -> Union[pd.Series, np.ndarray]:
         """The call function returning a sigmoid shaped reward for passed x values.
 
         Args:
@@ -245,7 +245,7 @@ class ConstantObjective(Objective):
 
     w: float
 
-    def __call__(self, x: np.ndarray) -> np.ndarray:
+    def __call__(self, x: Union[pd.Series, np.ndarray]) -> Union[pd.Series, np.ndarray]:
         """The call function returning the fixed value as reward
 
         Args:
@@ -284,7 +284,7 @@ class AbstractTargetObjective(Objective):
 class CloseToTargetObjective(AbstractTargetObjective):
     exponent: float
 
-    def __call__(self, x: np.ndarray) -> np.ndarray:
+    def __call__(self, x: Union[pd.Series, np.ndarray]) -> Union[pd.Series, np.ndarray]:
         return (
             np.abs(x - self.target_value) ** self.exponent
             - self.tolerance**self.exponent
@@ -304,7 +304,7 @@ class TargetObjective(AbstractTargetObjective):
 
     steepness: TGt0
 
-    def __call__(self, x: np.ndarray) -> np.ndarray:
+    def __call__(self, x: Union[pd.Series, np.ndarray]) -> Union[pd.Series, np.ndarray]:
         """The call function returning a reward for passed x values.
 
         Args:

--- a/bofire/domain/objectives.py
+++ b/bofire/domain/objectives.py
@@ -1,12 +1,13 @@
 from __future__ import annotations
 
 from abc import abstractmethod
-from typing import Dict, Union
+from typing import Callable, Dict, List, Union
 
 import numpy as np
 import pandas as pd
 from pydantic.class_validators import root_validator
 from pydantic.types import confloat
+from torch import Tensor
 
 from bofire.domain.util import BaseModel
 
@@ -16,6 +17,22 @@ from bofire.domain.util import BaseModel
 TGt0 = confloat(gt=0)
 TGe0 = confloat(ge=0)
 TWeight = confloat(gt=0, le=1)
+
+
+class BotorchConstrainedObjective:
+    """This abstract class offers a convenience routine for transforming sigmoid based objectives to botorch output constraints."""
+
+    @abstractmethod
+    def get_callables(self, idx: int) -> List[Callable[[Tensor], Tensor]]:
+        """Create a callable that can be used by `botorch.utils.objective.apply_constraints` to setup ouput constrained optimizations.
+
+        Args:
+            idx (int): Index of the constraint objective in the list of outputs.
+
+        Returns:
+            List[Callable[[Tensor], Tensor]]: List of callables that can be used by botorch for setting up the constrained objective.
+        """
+        pass
 
 
 class Objective(BaseModel):
@@ -179,7 +196,7 @@ class DeltaObjective(IdentityObjective):
         return (self.ref_point - x) * self.scale
 
 
-class SigmoidObjective(Objective):
+class SigmoidObjective(Objective, BotorchConstrainedObjective):
     """Base class for all sigmoid shaped objectives
 
     Attributes:
@@ -214,6 +231,17 @@ class MaximizeSigmoidObjective(SigmoidObjective):
         """
         return 1 / (1 + np.exp(-1 * self.steepness * (x - self.tp)))
 
+    def get_callables(self, idx: int):
+        """Create a callable that can be used by `botorch.utils.objective.apply_constraints` to setup ouput constrained optimizations.
+
+        Args:
+            idx (int): Index of the constraint objective in the list of outputs.
+
+        Returns:
+            List[Callable[[Tensor], Tensor]]: List of callables that can be used by botorch for setting up the constrained objective.
+        """
+        return [lambda Z: (Z[..., idx] - self.tp) * -1.0]
+
 
 class MinimizeSigmoidObjective(SigmoidObjective):
     """Class for a minimizing a sigmoid objective
@@ -234,6 +262,17 @@ class MinimizeSigmoidObjective(SigmoidObjective):
             np.ndarray: A reward calculated with a sigmoid function. The stepness and the tipping point can be modified via passed arguments.
         """
         return 1 - 1 / (1 + np.exp(-1 * self.steepness * (x - self.tp)))
+
+    def get_callables(self, idx: int):
+        """Create a callable that can be used by `botorch.utils.objective.apply_constraints` to setup ouput constrained optimizations.
+
+        Args:
+            idx (int): Index of the constraint objective in the list of outputs.
+
+        Returns:
+            List[Callable[[Tensor], Tensor]]: List of callables that can be used by botorch for setting up the constrained objective.
+        """
+        return [lambda Z: (Z[..., idx] - self.tp)]
 
 
 class ConstantObjective(Objective):
@@ -291,7 +330,7 @@ class CloseToTargetObjective(AbstractTargetObjective):
         )
 
 
-class TargetObjective(AbstractTargetObjective):
+class TargetObjective(AbstractTargetObjective, BotorchConstrainedObjective):
     """Class for objectives for optimizing towards a target value
 
     Attributes:
@@ -332,3 +371,19 @@ class TargetObjective(AbstractTargetObjective):
                 )
             )
         )
+
+    def get_callables(self, idx: int):
+        """Create a callable that can be used by `botorch.utils.objective.apply_constraints` to setup ouput constrained optimizations.
+
+        Here two callables are returned as the constraint is a product of the `MaximizeSigmoidObjective` and `MinimizeSigmoidObjective`.
+
+        Args:
+            idx (int): Index of the constraint objective in the list of outputs.
+
+        Returns:
+            List[Callable[[Tensor], Tensor]]: List of callables that can be used by botorch for setting up the constrained objective.
+        """
+        return [
+            lambda Z: (Z[..., idx] - (self.target_value - self.tolerance)) * -1.0,
+            lambda Z: (Z[..., idx] - (self.target_value + self.tolerance)),
+        ]

--- a/bofire/domain/objectives.py
+++ b/bofire/domain/objectives.py
@@ -23,7 +23,7 @@ class BotorchConstrainedObjective:
     """This abstract class offers a convenience routine for transforming sigmoid based objectives to botorch output constraints."""
 
     @abstractmethod
-    def get_callables(self, idx: int) -> List[Callable[[Tensor], Tensor]]:
+    def to_constraints(self, idx: int) -> List[Callable[[Tensor], Tensor]]:
         """Create a callable that can be used by `botorch.utils.objective.apply_constraints` to setup ouput constrained optimizations.
 
         Args:
@@ -231,7 +231,7 @@ class MaximizeSigmoidObjective(SigmoidObjective):
         """
         return 1 / (1 + np.exp(-1 * self.steepness * (x - self.tp)))
 
-    def get_callables(self, idx: int):
+    def to_constraints(self, idx: int):
         """Create a callable that can be used by `botorch.utils.objective.apply_constraints` to setup ouput constrained optimizations.
 
         Args:
@@ -263,7 +263,7 @@ class MinimizeSigmoidObjective(SigmoidObjective):
         """
         return 1 - 1 / (1 + np.exp(-1 * self.steepness * (x - self.tp)))
 
-    def get_callables(self, idx: int):
+    def to_constraints(self, idx: int):
         """Create a callable that can be used by `botorch.utils.objective.apply_constraints` to setup ouput constrained optimizations.
 
         Args:
@@ -372,7 +372,7 @@ class TargetObjective(AbstractTargetObjective, BotorchConstrainedObjective):
             )
         )
 
-    def get_callables(self, idx: int):
+    def to_constraints(self, idx: int):
         """Create a callable that can be used by `botorch.utils.objective.apply_constraints` to setup ouput constrained optimizations.
 
         Here two callables are returned as the constraint is a product of the `MaximizeSigmoidObjective` and `MinimizeSigmoidObjective`.

--- a/tests/bofire/domain/test_features.py
+++ b/tests/bofire/domain/test_features.py
@@ -21,7 +21,11 @@ from bofire.domain.features import (
     OutputFeature,
     OutputFeatures,
 )
-from bofire.domain.objectives import MinimizeObjective, Objective
+from bofire.domain.objectives import (
+    MaximizeSigmoidObjective,
+    MinimizeObjective,
+    Objective,
+)
 from tests.bofire.domain.utils import get_invalids
 
 objective = MinimizeObjective(w=1)
@@ -1297,3 +1301,28 @@ def test_output_features_call(features, samples):
     o = features(samples)
     assert o.shape == (len(samples), len(features.get_keys_by_objective(Objective)))
     assert list(o.columns) == features.get_keys_by_objective(Objective)
+
+
+@pytest.mark.parametrize(
+    "feature, data",
+    [
+        (
+            ContinuousOutput(
+                key="of1", objective=MaximizeSigmoidObjective(w=1, tp=15, steepness=0.5)
+            ),
+            None,
+        ),
+        (
+            ContinuousOutput(
+                key="of1", objective=MaximizeSigmoidObjective(w=1, tp=15, steepness=0.5)
+            ),
+            pd.DataFrame(
+                columns=["of1", "of2", "of3"],
+                index=range(5),
+                data=np.random.uniform(size=(5, 3)),
+            ),
+        ),
+    ],
+)
+def test_output_feature_plot(feature, data):
+    feature.plot(lower=0, upper=30, experiments=data)

--- a/tests/bofire/domain/test_objectives.py
+++ b/tests/bofire/domain/test_objectives.py
@@ -212,8 +212,8 @@ def test_invalid_desirability_function_specs(cls, spec):
         (TargetObjective(w=1, target_value=15, steepness=2, tolerance=5)),
     ],
 )
-def test_maximize_sigmoid_objective_get_callables(objective):
-    cs = objective.get_callables(idx=0)
+def test_maximize_sigmoid_objective_to_constraints(objective):
+    cs = objective.to_constraints(idx=0)
 
     x = torch.from_numpy(np.linspace(0, 30, 500)).unsqueeze(-1)
     y = torch.ones([500])


### PR DESCRIPTION
This PR resolves the issue regarding output constraint objectives discussed in https://github.com/experimental-design/bofire/issues/19 by introducing a new class called `BotorchOutputObjective`. This class also implements a `get_callables` method to use the objectives directly in constrained ooptimizations in botorch for example with `qNoisyExpectedHypervolumeImprovement` as shown here qNoisyExpectedHypervolumeImprovement. So far these constraints are not supported in everest/bofire for qehvi and qnehvi and parego.

The only thing what botorch is currently not supporting is a different `steepness` or `eta` in their nomenclature for having several constraints with different steepness values. I have PR up in botorch to solve this: https://github.com/pytorch/botorch/pull/1526

 