### PR TITLE
Remove add features

### DIFF
--- a/bofire/benchmarks/benchmark.py
+++ b/bofire/benchmarks/benchmark.py
@@ -16,7 +16,7 @@ from bofire.strategies.strategy import Strategy
 # TODO: remove reduction parameter as soon as additive/multiplicative is part of Domain
 def best(domain: Domain, reduction: Callable[[pd.DataFrame], pd.Series]):
     assert domain.experiments is not None
-    outputs_with_objectives = domain.output_features.get_by_objective(Objective)
+    outputs_with_objectives = domain.outputs().get_by_objective(Objective)
     output_values = domain.experiments[outputs_with_objectives.get_keys()]
     objective_values = list()
     for output, col_name in zip(outputs_with_objectives, output_values):
@@ -75,7 +75,7 @@ def _single_run(
     pbar = tqdm(range(n_iterations), position=run_idx)
     for i in pbar:
         X = strategy.ask(candidate_count=n_candidates_per_proposals)
-        X = X[benchmark.domain.input_features.get_keys()]
+        X = X[benchmark.domain.inputs().get_keys()]
         Y = benchmark.f(X)
         XY = pd.concat([X, Y], axis=1)
         strategy.tell(XY)

--- a/bofire/benchmarks/benchmark.py
+++ b/bofire/benchmarks/benchmark.py
@@ -1,0 +1,109 @@
+from abc import ABCMeta, abstractmethod
+from typing import Callable, List, Optional, Protocol, Tuple
+
+import numpy as np
+import pandas as pd
+from tqdm import tqdm
+
+from bofire.domain.domain import Domain
+from bofire.domain.features import OutputFeature
+from bofire.domain.objectives import Objective
+from bofire.strategies.strategy import Strategy
+
+
+# TODO: remove reduction parameter as soon as additive/multiplicative is part of Domain
+def best(domain: Domain, reduction: Callable[[pd.DataFrame], pd.Series]):
+    assert domain.experiments is not None
+    outputs_with_objectives = domain.output_features.get_by_objective(Objective)
+    output_values = domain.experiments[outputs_with_objectives.get_keys()]
+    objective_values = list()
+    for output, col_name in zip(outputs_with_objectives, output_values):
+        assert isinstance(output, OutputFeature)
+        assert output.objective is not None
+        objective_values.append(output.objective(output_values[col_name]))
+    objective_values = reduction(pd.concat([ov.to_frame() for ov in objective_values]))
+    return objective_values.max()
+
+
+# TODO: remove as soon as additive/multiplicative is part of Domain
+def best_additive(domain: Domain):
+    return best(domain, lambda df: df.sum(axis=1))
+
+
+# TODO: remove as soon as additive/multiplicative is part of Domain
+def best_multiplicative(domain: Domain):
+    return best(domain, lambda df: df.prod(axis=1))
+
+
+class Benchmark:
+    @property
+    @abstractmethod
+    def domain(self) -> Domain:
+        pass
+
+    @abstractmethod
+    def f(self, candidates: pd.DataFrame) -> pd.DataFrame:
+        pass
+
+    def get_optima(self) -> pd.DataFrame:
+        raise NotImplementedError()
+
+
+class StrategyFactory(Protocol):
+    def __call__(self, domain: Domain) -> Strategy:
+        ...
+
+
+def _single_run(
+    run_idx: int,
+    benchmark: Benchmark,
+    strategy_factory: StrategyFactory,
+    n_iterations: int,
+    metric: Callable[[Domain], float],
+    initial_sampler: Optional[Callable[[Domain], pd.DataFrame]],
+    n_candidates: int = 1,
+) -> Tuple[Benchmark, pd.Series]:
+
+    if initial_sampler is not None:
+        X = initial_sampler(benchmark.domain)
+        Y = benchmark.f(X)
+        XY = pd.concat([X, Y], axis=1)
+        benchmark.domain.experiments = XY
+    strategy = strategy_factory(domain=benchmark.domain)
+    metric_values = np.zeros(n_iterations)
+    pbar = tqdm(range(n_iterations), position=run_idx)
+    for i in pbar:
+        X = strategy.ask(candidate_count=n_candidates)
+        X = X[benchmark.domain.input_features.get_keys()]
+        Y = benchmark.f(X)
+        XY = pd.concat([X, Y], axis=1)
+        strategy.tell(XY)
+        metric_values[i] = metric(strategy.domain)
+        pbar.set_description(f"{metric_values[i]:0.3f}")
+    return benchmark, pd.Series(metric_values)
+
+
+def run(
+    benchmark: Benchmark,
+    strategy_factory: StrategyFactory,
+    n_iterations: int,
+    metric: Callable[[Domain], float],
+    initial_sampler: Optional[Callable[[Domain], pd.DataFrame]] = None,
+    n_candidates: int = 1,
+    n_runs: int = 1,
+) -> List[Tuple[Benchmark, pd.DataFrame]]:
+
+    results = list()
+    for run_idx in range(n_runs):
+        run_result = _single_run(
+            run_idx,
+            benchmark,
+            strategy_factory,
+            n_iterations,
+            metric,
+            initial_sampler,
+            n_candidates,
+        )
+        results.append(run_result)
+
+    return results

--- a/bofire/benchmarks/benchmark.py
+++ b/bofire/benchmarks/benchmark.py
@@ -16,7 +16,7 @@ from bofire.strategies.strategy import Strategy
 # TODO: remove reduction parameter as soon as additive/multiplicative is part of Domain
 def best(domain: Domain, reduction: Callable[[pd.DataFrame], pd.Series]):
     assert domain.experiments is not None
-    outputs_with_objectives = domain.outputs().get_by_objective(Objective)
+    outputs_with_objectives = domain.outputs.get_by_objective(Objective)
     output_values = domain.experiments[outputs_with_objectives.get_keys()]
     objective_values = list()
     for output, col_name in zip(outputs_with_objectives, output_values):
@@ -75,7 +75,7 @@ def _single_run(
     pbar = tqdm(range(n_iterations), position=run_idx)
     for i in pbar:
         X = strategy.ask(candidate_count=n_candidates_per_proposals)
-        X = X[benchmark.domain.inputs().get_keys()]
+        X = X[benchmark.domain.inputs.get_keys()]
         Y = benchmark.f(X)
         XY = pd.concat([X, Y], axis=1)
         strategy.tell(XY)

--- a/bofire/benchmarks/zdt.py
+++ b/bofire/benchmarks/zdt.py
@@ -1,0 +1,52 @@
+"""
+ZDT benchmark problem suite.
+All problems are bi-objective, have D continuous inputs and are unconstrained.
+Zitzler, Deb, Thiele 2000 - Comparison of Multiobjective Evolutionary Algorithms: Empirical Results
+http://dx.doi.org/10.1162/106365600568202
+"""
+import numpy as np
+import pandas as pd
+
+from bofire.benchmarks.benchmark import Benchmark
+from bofire.domain.domain import Domain
+from bofire.domain.features import (
+    ContinuousInput,
+    ContinuousOutput,
+    InputFeatures,
+    OutputFeatures,
+)
+from bofire.domain.objectives import MinimizeObjective
+
+
+class ZDT1(Benchmark):
+    """ZDT-1 benchmark problem."""
+
+    def __init__(self, n_inputs=30):
+        self.n_inputs = n_inputs
+        input_features = [
+            ContinuousInput(key=f"x{i+1}", lower_bound=0, upper_bound=1)
+            for i in range(n_inputs)
+        ]
+        inputs = InputFeatures(features=input_features)
+        output_features = [
+            ContinuousOutput(key=f"y{i+1}", objective=MinimizeObjective(w=1))
+            for i in range(2)
+        ]
+        outputs = OutputFeatures(features=output_features)
+        self._domain = Domain(input_features=inputs, output_features=outputs)
+
+    @property
+    def domain(self) -> Domain:
+        return self._domain
+
+    def f(self, X: pd.DataFrame) -> pd.DataFrame:
+        x = X[self._domain.input_features.get_keys()[1:]].to_numpy()
+        g = 1 + 9 / (self.n_inputs - 1) * np.sum(x, axis=1)
+        y1 = X["x1"].to_numpy()
+        y2 = g * (1 - (y1 / g) ** 0.5)
+        return pd.DataFrame({"y1": y1, "y2": y2}, index=X.index)
+
+    def get_optima(self, points=100):
+        x = np.linspace(0, 1, points)
+        y = np.stack([x, 1 - np.sqrt(x)], axis=1)
+        return pd.DataFrame(y, columns=self.domain.output_features.get_keys())

--- a/bofire/benchmarks/zdt.py
+++ b/bofire/benchmarks/zdt.py
@@ -27,12 +27,12 @@ class ZDT1(Benchmark):
             ContinuousInput(key=f"x{i+1}", lower_bound=0, upper_bound=1)
             for i in range(n_inputs)
         ]
-        inputs = InputFeatures(features=input_features)  # type: ignore
+        inputs = InputFeatures(features=input_features)
         output_features = [
             ContinuousOutput(key=f"y{i+1}", objective=MinimizeObjective(w=1))
             for i in range(2)
         ]
-        outputs = OutputFeatures(features=output_features)  # type: ignore
+        outputs = OutputFeatures(features=output_features)
         self._domain = Domain(input_features=inputs, output_features=outputs)
 
     @property
@@ -40,7 +40,7 @@ class ZDT1(Benchmark):
         return self._domain
 
     def f(self, X: pd.DataFrame) -> pd.DataFrame:
-        x = X[self._domain.input_features.get_keys()[1:]].to_numpy()
+        x = X[self._domain.inputs().get_keys()[1:]].to_numpy()
         g = 1 + 9 / (self.n_inputs - 1) * np.sum(x, axis=1)
         y1 = X["x1"].to_numpy()
         y2 = g * (1 - (y1 / g) ** 0.5)
@@ -49,4 +49,4 @@ class ZDT1(Benchmark):
     def get_optima(self, points=100):
         x = np.linspace(0, 1, points)
         y = np.stack([x, 1 - np.sqrt(x)], axis=1)
-        return pd.DataFrame(y, columns=self.domain.output_features.get_keys())
+        return pd.DataFrame(y, columns=self.domain.outputs().get_keys())

--- a/bofire/benchmarks/zdt.py
+++ b/bofire/benchmarks/zdt.py
@@ -40,7 +40,7 @@ class ZDT1(Benchmark):
         return self._domain
 
     def f(self, X: pd.DataFrame) -> pd.DataFrame:
-        x = X[self._domain.inputs().get_keys()[1:]].to_numpy()
+        x = X[self._domain.inputs.get_keys()[1:]].to_numpy()
         g = 1 + 9 / (self.n_inputs - 1) * np.sum(x, axis=1)
         y1 = X["x1"].to_numpy()
         y2 = g * (1 - (y1 / g) ** 0.5)
@@ -49,4 +49,4 @@ class ZDT1(Benchmark):
     def get_optima(self, points=100):
         x = np.linspace(0, 1, points)
         y = np.stack([x, 1 - np.sqrt(x)], axis=1)
-        return pd.DataFrame(y, columns=self.domain.outputs().get_keys())
+        return pd.DataFrame(y, columns=self.domain.outputs.get_keys())

--- a/bofire/domain/domain.py
+++ b/bofire/domain/domain.py
@@ -827,7 +827,7 @@ class Domain(BaseModel):
                 (self.experiments, experiments), ignore_index=True
             )
 
-    def set_constraints_unvalidated(
+    def _set_constraints_unvalidated(
         self, constraints: Union[Sequence[Constraint], Constraints]
     ):
         """Hack for reduce_domain"""

--- a/bofire/domain/domain.py
+++ b/bofire/domain/domain.py
@@ -1,7 +1,7 @@
 import itertools
 import typing
 from copy import deepcopy
-from typing import Any, Dict, List, Optional, Tuple, Type, Union
+from typing import Any, Dict, List, Optional, Tuple, Type, Union, cast
 
 import numpy as np
 import pandas as pd
@@ -314,11 +314,11 @@ class Domain(BaseModel):
         """
         self.constraints.add(constraint)
 
-    def add_feature(self, feature: Feature) -> None:
-        """add a feature to list domain.features
+    def add_features(self, features: Features) -> None:
+        """add a features to list domain.features
 
         Args:
-            feature (Feature): object of class Feature, which is added to the list
+            features: to be added to the input- or output-feature0-list depending on the type
 
         Raises:
             ValueError: if the feature key is already in the domain
@@ -328,14 +328,15 @@ class Domain(BaseModel):
             raise ValueError(
                 "Feature cannot be added as experiments/candidates are already set."
             )
-        if feature.key in self.get_feature_keys():
-            raise ValueError(f"Feature with key {feature.key} already in domain.")
-        if isinstance(feature, InputFeature):
-            self.input_features.add(feature)
-        elif isinstance(feature, OutputFeature):
-            self.output_features.add(feature)
+        for feature in features:
+            if feature.key in self.get_feature_keys():
+                raise ValueError(f"Feature with key {feature.key} already in domain.")
+        if isinstance(features, InputFeatures):
+            self.input_features = cast(InputFeatures, self.input_features + features)
+        elif isinstance(features, OutputFeature):
+            self.output_features = cast(OutputFeatures, self.output_features + features)
         else:
-            raise TypeError(f"Cannot add feature of type {type(feature)}")
+            raise TypeError(f"Cannot add features of type {type(features)}")
 
     def remove_feature_by_key(self, key):
         """removes a feature from domain indicated by its key

--- a/bofire/domain/domain.py
+++ b/bofire/domain/domain.py
@@ -54,14 +54,17 @@ class Domain(BaseModel):
         constraints (List[Constraint], optional): List of constraints. Defaults to [].
     """
 
+    @property
     def outputs(self) -> OutputFeatures:
         """Returns output features as OutputFeatures"""
         return cast(OutputFeatures, self.output_features)
 
+    @property
     def inputs(self) -> InputFeatures:
         """Returns input features as InputFeatures"""
         return cast(InputFeatures, self.input_features)
 
+    @property
     def cnstrs(self) -> Constraints:
         return cast(Constraints, self.constraints)
 
@@ -342,14 +345,14 @@ class Domain(BaseModel):
              unused_features_list is a list of lists containing features unused in each NChooseK combination.
         """
 
-        if len(self.cnstrs().get(NChooseKConstraint)) == 0:
+        if len(self.cnstrs.get(NChooseKConstraint)) == 0:
             used_continuous_features = self.get_feature_keys(ContinuousInput)
             return used_continuous_features, []
 
         used_features_list_all = []
 
         # loops through each NChooseK constraint
-        for con in self.cnstrs().get(NChooseKConstraint):
+        for con in self.cnstrs.get(NChooseKConstraint):
             assert isinstance(con, NChooseKConstraint)
             used_features_list = []
 
@@ -393,7 +396,7 @@ class Domain(BaseModel):
             fulfil_constraints = (
                 []
             )  # list of bools tracking if constraints are fulfilled
-            for con in self.cnstrs().get(NChooseKConstraint):
+            for con in self.cnstrs.get(NChooseKConstraint):
                 assert isinstance(con, NChooseKConstraint)
                 count = 0  # count of features in combo that are in con.features
                 for f in combo:
@@ -412,7 +415,7 @@ class Domain(BaseModel):
 
         # features unused
         features_in_cc = []
-        for con in self.cnstrs().get(NChooseKConstraint):
+        for con in self.cnstrs.get(NChooseKConstraint):
             assert isinstance(con, NChooseKConstraint)
             features_in_cc.extend(con.features)
         features_in_cc = list(set(features_in_cc))
@@ -724,7 +727,7 @@ class Domain(BaseModel):
         assert isinstance(self.input_features, InputFeatures)
         self.input_features.validate_inputs(candidates)
         # check if all constraints are fulfilled
-        if not self.cnstrs().is_fulfilled(candidates).all():
+        if not self.cnstrs.is_fulfilled(candidates).all():
             raise ValueError("Constraints not fulfilled.")
         # for each continuous output feature with an attached objective object
         if not only_inputs:

--- a/bofire/domain/domain.py
+++ b/bofire/domain/domain.py
@@ -1,7 +1,8 @@
+import collections.abc
 import itertools
 import typing
 from copy import deepcopy
-from typing import Any, Dict, List, Optional, Tuple, Type, Union, cast
+from typing import Any, Dict, List, Optional, Sequence, Tuple, Type, Union, cast
 
 import numpy as np
 import pandas as pd
@@ -29,11 +30,22 @@ from bofire.domain.util import BaseModel, is_numeric
 
 class Domain(BaseModel):
 
-    input_features: InputFeatures = Field(default_factory=lambda: InputFeatures())
-    output_features: OutputFeatures = Field(default_factory=lambda: OutputFeatures())
-    constraints: Constraints = Field(default_factory=lambda: Constraints())
+    # The types describe what we expect to be passed as arguments.
+    # They will be converted to InputFeatures and OutputFeatures, respectively.
+    input_features: Union[Sequence[InputFeature], InputFeatures] = Field(
+        default_factory=lambda: InputFeatures()
+    )
+    output_features: Union[Sequence[OutputFeature], OutputFeatures] = Field(
+        default_factory=lambda: OutputFeatures()
+    )
+
+    constraints: Union[Sequence[Constraint], Constraints] = Field(
+        default_factory=lambda: Constraints()
+    )
+
     experiments: Optional[pd.DataFrame] = None
     candidates: Optional[pd.DataFrame] = None
+
     """Representation of the optimization problem/domain
 
     Attributes:
@@ -42,9 +54,20 @@ class Domain(BaseModel):
         constraints (List[Constraint], optional): List of constraints. Defaults to [].
     """
 
+    def outputs(self) -> OutputFeatures:
+        """Returns output features as OutputFeatures"""
+        return cast(OutputFeatures, self.output_features)
+
+    def inputs(self) -> InputFeatures:
+        """Returns input features as InputFeatures"""
+        return cast(InputFeatures, self.input_features)
+
+    def cnstrs(self) -> Constraints:
+        return cast(Constraints, self.constraints)
+
     @validator("input_features", always=True, pre=True)
     def validate_input_features_list(cls, v, values):
-        if isinstance(v, list):
+        if isinstance(v, collections.abc.Sequence):
             v = InputFeatures(features=v)
             return v
         if isinstance(v, InputFeature):
@@ -54,7 +77,7 @@ class Domain(BaseModel):
 
     @validator("output_features", always=True, pre=True)
     def validate_output_features_list(cls, v, values):
-        if isinstance(v, list):
+        if isinstance(v, collections.abc.Sequence):
             return OutputFeatures(features=v)
         if isinstance(v, OutputFeature):
             return OutputFeatures(features=[v])
@@ -71,18 +94,18 @@ class Domain(BaseModel):
             return v
 
     @validator("output_features", always=True)
-    def validate_unique_output_feature_keys(cls, v, values):
-        """Validates if provided output feature keys are unique
+    def validate_unique_feature_keys(cls, v: OutputFeatures, values) -> OutputFeatures:
+        """Validates if provided input and output feature keys are unique
 
         Args:
-            v (List[OutputFeature]): List of all output features of the domain.
-            values (List[InputFeature]): Dict containing a list of input features as single entry.
+            v (OutputFeatures): List of all output features of the domain.
+            value (Dict[str, InputFeatures]): Dict containing a list of input features as single entry.
 
         Raises:
             ValueError: Feature keys are not unique.
 
         Returns:
-            List[OutputFeature]: Returns the list of output features when no error is thrown.
+            OutputFeatures: Keeps output features as given.
         """
         if "input_features" not in values:
             return v
@@ -184,6 +207,9 @@ class Domain(BaseModel):
         Returns:
             Dict: Serialized version of the domain as dictionary.
         """
+        assert isinstance(self.input_features, InputFeatures)
+        assert isinstance(self.output_features, OutputFeatures)
+        assert isinstance(self.constraints, Constraints)
         config: Dict[str, Any] = {
             "input_features": self.input_features.to_config(),
             "output_features": self.output_features.to_config(),
@@ -266,9 +292,9 @@ class Domain(BaseModel):
         Returns:
             List[Feature]: List of features in the domain fitting to the passed requirements.
         """
-        return (self.input_features + self.output_features).get(
-            includes, excludes, exact
-        )
+        assert isinstance(self.input_features, InputFeatures)
+        features = self.input_features + self.output_features
+        return features.get(includes, excludes, exact)
 
     def get_feature_keys(
         self,
@@ -304,69 +330,8 @@ class Domain(BaseModel):
         Returns:
             Feature: The feature with the passed key
         """
+        assert isinstance(self.input_features, InputFeatures)
         return {f.key: f for f in self.input_features + self.output_features}[key]
-
-    def add_constraint(self, constraint: Constraint):
-        """Add a constraint to the optimzation domain
-
-        Args:
-            constraint (Constraint): object of class Constraint, which is added to the list
-        """
-        self.constraints.add(constraint)
-
-    def add_features(self, features: Features) -> None:
-        """add a features to list domain.features
-
-        Args:
-            features: to be added to the input- or output-feature0-list depending on the type
-
-        Raises:
-            ValueError: if the feature key is already in the domain
-            TypeError: if the feature type is neither Input nor Output feature
-        """
-        if (self.experiments is not None) or (self.candidates is not None):
-            raise ValueError(
-                "Feature cannot be added as experiments/candidates are already set."
-            )
-        for feature in features:
-            if feature.key in self.get_feature_keys():
-                raise ValueError(f"Feature with key {feature.key} already in domain.")
-        if isinstance(features, InputFeatures):
-            self.input_features = cast(InputFeatures, self.input_features + features)
-        elif isinstance(features, OutputFeature):
-            self.output_features = cast(OutputFeatures, self.output_features + features)
-        else:
-            raise TypeError(f"Cannot add features of type {type(features)}")
-
-    def remove_feature_by_key(self, key):
-        """removes a feature from domain indicated by its key
-
-        Args:
-            key (str): feature key
-
-        Raises:
-            KeyError: when the key is not found in the domain
-            ValueError: when more than one feature with key is found
-        """
-        if (self.experiments is not None) or (self.candidates is not None):
-            raise ValueError(
-                f"Feature {key} cannot be removed as experiments/candidates are already set."
-            )
-        input_count = sum(1 for f in self.input_features if f.key == key)
-        output_count = sum(1 for f in self.output_features if f.key == key)
-        if input_count == 0 and output_count == 0:
-            raise KeyError(f"no feature with key {key} found")
-        if input_count + output_count > 1:
-            raise ValueError(f"more than one feature with key {key} found")
-        if input_count > 0:
-            self.input_features = InputFeatures(
-                features=[f for f in self.input_features.features if f.key != key]
-            )
-
-        if output_count > 0:
-            self.output_features = OutputFeatures(
-                features=[f for f in self.output_features.features if f.key != key]
-            )
 
     # getting list of fixed values
     def get_nchoosek_combinations(self):
@@ -377,14 +342,14 @@ class Domain(BaseModel):
              unused_features_list is a list of lists containing features unused in each NChooseK combination.
         """
 
-        if len(self.constraints.get(NChooseKConstraint)) == 0:
+        if len(self.cnstrs().get(NChooseKConstraint)) == 0:
             used_continuous_features = self.get_feature_keys(ContinuousInput)
             return used_continuous_features, []
 
         used_features_list_all = []
 
         # loops through each NChooseK constraint
-        for con in self.constraints.get(NChooseKConstraint):
+        for con in self.cnstrs().get(NChooseKConstraint):
             assert isinstance(con, NChooseKConstraint)
             used_features_list = []
 
@@ -428,7 +393,7 @@ class Domain(BaseModel):
             fulfil_constraints = (
                 []
             )  # list of bools tracking if constraints are fulfilled
-            for con in self.constraints.get(NChooseKConstraint):
+            for con in self.cnstrs().get(NChooseKConstraint):
                 assert isinstance(con, NChooseKConstraint)
                 count = 0  # count of features in combo that are in con.features
                 for f in combo:
@@ -447,7 +412,7 @@ class Domain(BaseModel):
 
         # features unused
         features_in_cc = []
-        for con in self.constraints.get(NChooseKConstraint):
+        for con in self.cnstrs().get(NChooseKConstraint):
             assert isinstance(con, NChooseKConstraint)
             features_in_cc.extend(con.features)
         features_in_cc = list(set(features_in_cc))
@@ -756,12 +721,14 @@ class Domain(BaseModel):
             pd.DataFrame: dataframe with suggested experiments (candidates)
         """
         # check that each input feature has a col and is valid in itself
+        assert isinstance(self.input_features, InputFeatures)
         self.input_features.validate_inputs(candidates)
         # check if all constraints are fulfilled
-        if not self.constraints.is_fulfilled(candidates).all():
+        if not self.cnstrs().is_fulfilled(candidates).all():
             raise ValueError("Constraints not fulfilled.")
         # for each continuous output feature with an attached objective object
         if not only_inputs:
+            assert isinstance(self.output_features, OutputFeatures)
             for key in self.output_features.get_keys_by_objective(Objective):
                 # check that pred, sd, and des cols are specified and numerical
                 for col in [f"{key}_pred", f"{key}_sd", f"{key}_des"]:
@@ -800,6 +767,7 @@ class Domain(BaseModel):
         Returns:
             List[str]: List of columns in the candidate dataframe (input feature keys + input feature keys_pred, input feature keys_sd, input feature keys_des)
         """
+        assert isinstance(self.output_features, OutputFeatures)
         return (
             self.get_feature_keys(InputFeature)
             + [
@@ -856,6 +824,15 @@ class Domain(BaseModel):
                 (self.experiments, experiments), ignore_index=True
             )
 
+    def set_constraints_unvalidated(
+        self, constraints: Union[Sequence[Constraint], Constraints]
+    ):
+        """Hack for reduce_domain"""
+        self.constraints = Constraints(constraints=[])
+        if isinstance(constraints, Constraints):
+            constraints = constraints.constraints
+        self.constraints.constraints = constraints
+
     @property
     def num_experiments(self) -> int:
         if self.experiments is None:
@@ -866,7 +843,7 @@ class Domain(BaseModel):
 def get_subdomain(
     domain: Domain,
     feature_keys: List,
-):
+) -> Domain:
     """removes all features not defined as argument creating a subdomain of the provided domain
 
     Args:
@@ -884,33 +861,31 @@ def get_subdomain(
         Domain: A new domain containing only parts of the original domain
     """
     assert len(feature_keys) >= 2, "At least two features have to be provided."
-    output_feature_keys = []
-    input_feature_keys = []
-    subdomain = deepcopy(domain)
+    output_features = []
+    input_features = []
     for key in feature_keys:
         try:
             feat = domain.get_feature(key)
         except KeyError:
             raise ValueError(f"Feature {key} not present in domain.")
         if isinstance(feat, InputFeature):
-            input_feature_keys.append(key)
+            input_features.append(feat)
         else:
-            output_feature_keys.append(key)
-    assert (
-        len(output_feature_keys) > 0
-    ), "At least one output feature has to be provided."
-    assert len(input_feature_keys) > 0, "At least one input feature has to be provided."
+            output_features.append(feat)
+    assert len(output_features) > 0, "At least one output feature has to be provided."
+    assert len(input_features) > 0, "At least one input feature has to be provided."
+    input_features = InputFeatures(features=input_features)
     # loop over constraints and make sure that all features used in constraints are in the input_feature_keys
     for c in domain.constraints:
         # TODO: fix type hint
         for key in c.features:  # type: ignore
-            if key not in input_feature_keys:
+            if key not in input_features.get_keys():
                 raise ValueError(
                     f"Removed input feature {key} is used in a constraint."
                 )
-
-    for key in set(domain.get_feature_keys(Feature)) - set(feature_keys):
-        subdomain.remove_feature_by_key(key)
+    subdomain = deepcopy(domain)
+    subdomain.input_features = input_features
+    subdomain.output_features = output_features
     return subdomain
 
 

--- a/bofire/domain/features.py
+++ b/bofire/domain/features.py
@@ -3,7 +3,18 @@ from __future__ import annotations
 import itertools
 import warnings
 from abc import abstractmethod
-from typing import Any, Dict, List, Optional, Tuple, Type, TypeVar, Union, cast
+from typing import (
+    Any,
+    Dict,
+    List,
+    Optional,
+    Sequence,
+    Tuple,
+    Type,
+    TypeVar,
+    Union,
+    cast,
+)
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -994,15 +1005,6 @@ class Features(BaseModel):
     def remove(self, feature: Feature):
         self.features.remove(feature)
 
-    def add(self, feature: Feature):
-        """Add a feature to the container.
-
-        Args:
-            feature (Feature): Feature to be added.
-        """
-        assert isinstance(feature, Feature)
-        self.features.append(feature)
-
     def get_by_key(self, key: str) -> Feature:
         """Get a feature by its key.
 
@@ -1078,7 +1080,7 @@ class InputFeatures(Features):
         features (List(InputFeatures)): list of the features.
     """
 
-    features: List[InputFeature] = Field(default_factory=lambda: [])
+    features: Sequence[InputFeature] = Field(default_factory=lambda: [])
 
     def to_config(self) -> Dict:
         return {
@@ -1167,15 +1169,6 @@ class InputFeatures(Features):
             feature.validate_candidental(inputs[feature.key])  # type: ignore
         return inputs
 
-    def add(self, feature: InputFeature):
-        """Add a input feature to the container.
-
-        Args:
-            feature (InputFeature): InputFeature to be added.
-        """
-        assert isinstance(feature, InputFeature)
-        self.features.append(feature)
-
     def get_categorical_combinations(
         self,
         include: Type[Feature] = InputFeature,
@@ -1208,7 +1201,7 @@ class OutputFeatures(Features):
         features (List(OutputFeatures)): list of the features.
     """
 
-    features: List[OutputFeature] = Field(default_factory=lambda: [])
+    features: Sequence[OutputFeature] = Field(default_factory=lambda: [])
 
     def to_config(self) -> Dict:
         return {
@@ -1222,15 +1215,6 @@ class OutputFeatures(Features):
             if not isinstance(feat, OutputFeature):
                 raise ValueError
         return v
-
-    def add(self, feature: OutputFeature):
-        """Add a output feature to the container.
-
-        Args:
-            feature (OutputFeature): OutputFeature to be added.
-        """
-        assert isinstance(feature, OutputFeature)
-        self.features.append(feature)
 
     def get_by_objective(
         self,

--- a/bofire/domain/util.py
+++ b/bofire/domain/util.py
@@ -1,4 +1,5 @@
-from typing import Any, Callable, List, Type, Union
+import collections
+from typing import Any, Callable, List, Sequence, Type, Union
 
 import pandas as pd
 from pydantic import BaseModel as _BaseModel
@@ -44,10 +45,10 @@ def is_categorical(s: pd.Series, categories: List[str]):
 
 
 def filter_by_attribute(
-    data: List,
+    data: Sequence,
     attribute_getter: Callable[[Type], Any],
-    includes: Union[Type, List[Type]] = None,
-    excludes: Union[Type, List[Type]] = None,
+    includes: Union[Type, Sequence[Type]] = None,
+    excludes: Union[Type, Sequence[Type]] = None,
     exact: bool = False,
 ) -> List:
     """Returns those data elements where the attribute is of one of the include types.
@@ -81,9 +82,9 @@ def filter_by_attribute(
 
 
 def filter_by_class(
-    data: List,
-    includes: Union[Type, List[Type]] = None,
-    excludes: Union[Type, List[Type]] = None,
+    data: Sequence,
+    includes: Union[Type, Sequence[Type]] = None,
+    excludes: Union[Type, Sequence[Type]] = None,
     exact: bool = False,
     key: Callable[[Type], Any] = lambda x: x,
 ) -> List:
@@ -101,11 +102,11 @@ def filter_by_class(
     """
     if includes is None:
         includes = []
-    if not isinstance(includes, list):
+    if not isinstance(includes, collections.Sequence):
         includes = [includes]
     if excludes is None:
         excludes = []
-    if not isinstance(excludes, list):
+    if not isinstance(excludes, collections.Sequence):
         excludes = [excludes]
 
     if len(includes) == len(excludes) == 0:

--- a/bofire/mappers/opti.py
+++ b/bofire/mappers/opti.py
@@ -95,10 +95,12 @@ def problem2domain(config: Dict):
         output_features=OutputFeatures(features=output_features),
     )
     if "constraints" in config:
+        constraints = []
         for cconfig in config["constraints"]:
-            domain.add_constraint(
+            constraints.append(
                 constraint2constraint(cconfig, domain.get_feature_keys(InputFeature))
             )
+        domain.constraints = constraints
     if "data" in config:
         experiments = pd.read_json(json.dumps(config["data"]), orient="split")
 

--- a/bofire/samplers.py
+++ b/bofire/samplers.py
@@ -125,7 +125,7 @@ class PolytopeSampler(Sampler):
 
     def _sample(self, n: Tnum_samples) -> pd.DataFrame:
         if len(self.domain.constraints) == 0:
-            return self.domain.inputs().sample(n, SamplingMethodEnum.UNIFORM)
+            return self.domain.inputs.sample(n, SamplingMethodEnum.UNIFORM)
 
         # get the bounds
         lower = [
@@ -180,7 +180,7 @@ class PolytopeSampler(Sampler):
             samples[feat.key] = feat.sample(n)  # type: ignore
 
         # setup the fixed continuous ones
-        for feat in self.domain.inputs().get_fixed():
+        for feat in self.domain.inputs.get_fixed():
             samples[feat.key] = feat.fixed_value()  # type: ignore
 
         return samples
@@ -216,17 +216,17 @@ class RejectionSampler(Sampler):
 
     def _sample(self, n: Tnum_samples) -> pd.DataFrame:
         if len(self.domain.constraints) == 0:
-            return self.domain.inputs().sample(n, self.sampling_method)
+            return self.domain.inputs.sample(n, self.sampling_method)
         n_iters = 0
         n_found = 0
         valid_samples = []
         while n_found < n:
             if n_iters > self.max_iters:
                 raise ValueError("Maximum iterations exceeded in rejection sampling.")
-            samples = self.domain.inputs().sample(
+            samples = self.domain.inputs.sample(
                 self.num_base_samples, method=self.sampling_method
             )
-            valid = self.domain.cnstrs().is_fulfilled(samples)
+            valid = self.domain.cnstrs.is_fulfilled(samples)
             n_found += np.sum(valid)
             valid_samples.append(samples[valid])
             n_iters += 1

--- a/bofire/samplers.py
+++ b/bofire/samplers.py
@@ -125,7 +125,7 @@ class PolytopeSampler(Sampler):
 
     def _sample(self, n: Tnum_samples) -> pd.DataFrame:
         if len(self.domain.constraints) == 0:
-            return self.domain.input_features.sample(n, SamplingMethodEnum.UNIFORM)
+            return self.domain.inputs().sample(n, SamplingMethodEnum.UNIFORM)
 
         # get the bounds
         lower = [
@@ -180,7 +180,7 @@ class PolytopeSampler(Sampler):
             samples[feat.key] = feat.sample(n)  # type: ignore
 
         # setup the fixed continuous ones
-        for feat in self.domain.input_features.get_fixed():
+        for feat in self.domain.inputs().get_fixed():
             samples[feat.key] = feat.fixed_value()  # type: ignore
 
         return samples
@@ -216,17 +216,17 @@ class RejectionSampler(Sampler):
 
     def _sample(self, n: Tnum_samples) -> pd.DataFrame:
         if len(self.domain.constraints) == 0:
-            return self.domain.input_features.sample(n, self.sampling_method)
+            return self.domain.inputs().sample(n, self.sampling_method)
         n_iters = 0
         n_found = 0
         valid_samples = []
         while n_found < n:
             if n_iters > self.max_iters:
                 raise ValueError("Maximum iterations exceeded in rejection sampling.")
-            samples = self.domain.input_features.sample(
+            samples = self.domain.inputs().sample(
                 self.num_base_samples, method=self.sampling_method
             )
-            valid = self.domain.constraints.is_fulfilled(samples)
+            valid = self.domain.cnstrs().is_fulfilled(samples)
             n_found += np.sum(valid)
             valid_samples.append(samples[valid])
             n_iters += 1

--- a/bofire/strategies/botorch/base.py
+++ b/bofire/strategies/botorch/base.py
@@ -152,7 +152,7 @@ class BotorchBasicBoStrategy(PredictiveStrategy):
             List[ModelSpec]: List of model specification classes
         """
         input_features = domain.get_feature_keys(InputFeature)
-        output_features = domain.outputs().get_keys_by_objective(excludes=None)
+        output_features = domain.outputs.get_keys_by_objective(excludes=None)
         if model_specs is None:
             model_specs = []
         existing_specs = [model_spec.output_feature for model_spec in model_specs]
@@ -352,7 +352,7 @@ class BotorchBasicBoStrategy(PredictiveStrategy):
         # - descriptized categoricals not yet implemented
         num_categorical_features = len(self.domain.get_features(CategoricalInput))
         num_categorical_combinations = len(
-            self.domain.inputs().get_categorical_combinations()
+            self.domain.inputs.get_categorical_combinations()
         )
         assert self.acqf is not None
 
@@ -363,7 +363,7 @@ class BotorchBasicBoStrategy(PredictiveStrategy):
                 (self.categorical_method == CategoricalMethodEnum.FREE)
                 and (self.descriptor_method == DescriptorMethodEnum.FREE)
             )
-        ) and len(self.domain.cnstrs().get(NChooseKConstraint)) == 0:
+        ) and len(self.domain.cnstrs.get(NChooseKConstraint)) == 0:
             candidates = optimize_acqf(
                 acq_function=self.acqf,
                 bounds=self.get_bounds(),
@@ -384,7 +384,7 @@ class BotorchBasicBoStrategy(PredictiveStrategy):
         elif (
             (self.categorical_method == CategoricalMethodEnum.EXHAUSTIVE)
             or (self.descriptor_method == DescriptorMethodEnum.EXHAUSTIVE)
-        ) and len(self.domain.cnstrs().get(NChooseKConstraint)) == 0:
+        ) and len(self.domain.cnstrs.get(NChooseKConstraint)) == 0:
             # TODO: marry this withe groups of XY
             candidates = optimize_acqf_mixed(
                 acq_function=self.acqf,
@@ -402,7 +402,7 @@ class BotorchBasicBoStrategy(PredictiveStrategy):
             )
             # options={"seed":self.seed})
 
-        elif len(self.domain.cnstrs().get(NChooseKConstraint)) > 0:
+        elif len(self.domain.cnstrs.get(NChooseKConstraint)) > 0:
             candidates = optimize_acqf_mixed(
                 acq_function=self.acqf,
                 bounds=self.get_bounds(),
@@ -434,20 +434,20 @@ class BotorchBasicBoStrategy(PredictiveStrategy):
             columns=self.input_feature_keys
             + [
                 i + "_pred"
-                for i in self.domain.outputs().get_keys_by_objective(excludes=None)
+                for i in self.domain.outputs.get_keys_by_objective(excludes=None)
             ]
             + [
                 i + "_sd"
-                for i in self.domain.outputs().get_keys_by_objective(excludes=None)
+                for i in self.domain.outputs.get_keys_by_objective(excludes=None)
             ]
             + [
                 i + "_des"
-                for i in self.domain.outputs().get_keys_by_objective(excludes=None)
+                for i in self.domain.outputs.get_keys_by_objective(excludes=None)
             ]
             # ["reward","acqf","strategy"]
         )
 
-        for i, feat in enumerate(self.domain.outputs().get_by_objective(excludes=None)):
+        for i, feat in enumerate(self.domain.outputs.get_by_objective(excludes=None)):
             df_candidates[feat.key + "_pred"] = preds[:, i]
             df_candidates[feat.key + "_sd"] = stds[:, i]
             df_candidates[feat.key + "_des"] = feat.objective(preds[:, i])  # type: ignore
@@ -646,7 +646,7 @@ class BotorchBasicBoStrategy(PredictiveStrategy):
         elif self.categorical_method == CategoricalMethodEnum.FREE:
             include = CategoricalDescriptorInput
 
-        combos = self.domain.inputs().get_categorical_combinations(
+        combos = self.domain.inputs.get_categorical_combinations(
             include=include, exclude=exclude
         )
         # now build up the fixed feature list

--- a/bofire/strategies/botorch/base.py
+++ b/bofire/strategies/botorch/base.py
@@ -152,7 +152,7 @@ class BotorchBasicBoStrategy(PredictiveStrategy):
             List[ModelSpec]: List of model specification classes
         """
         input_features = domain.get_feature_keys(InputFeature)
-        output_features = domain.output_features.get_keys_by_objective(excludes=None)
+        output_features = domain.outputs().get_keys_by_objective(excludes=None)
         if model_specs is None:
             model_specs = []
         existing_specs = [model_spec.output_feature for model_spec in model_specs]
@@ -352,8 +352,9 @@ class BotorchBasicBoStrategy(PredictiveStrategy):
         # - descriptized categoricals not yet implemented
         num_categorical_features = len(self.domain.get_features(CategoricalInput))
         num_categorical_combinations = len(
-            self.domain.input_features.get_categorical_combinations()
+            self.domain.inputs().get_categorical_combinations()
         )
+        assert self.acqf is not None
 
         if (
             (num_categorical_features == 0)
@@ -362,7 +363,7 @@ class BotorchBasicBoStrategy(PredictiveStrategy):
                 (self.categorical_method == CategoricalMethodEnum.FREE)
                 and (self.descriptor_method == DescriptorMethodEnum.FREE)
             )
-        ) and len(self.domain.constraints.get(NChooseKConstraint)) == 0:
+        ) and len(self.domain.cnstrs().get(NChooseKConstraint)) == 0:
             candidates = optimize_acqf(
                 acq_function=self.acqf,
                 bounds=self.get_bounds(),
@@ -383,7 +384,7 @@ class BotorchBasicBoStrategy(PredictiveStrategy):
         elif (
             (self.categorical_method == CategoricalMethodEnum.EXHAUSTIVE)
             or (self.descriptor_method == DescriptorMethodEnum.EXHAUSTIVE)
-        ) and len(self.domain.constraints.get(NChooseKConstraint)) == 0:
+        ) and len(self.domain.cnstrs().get(NChooseKConstraint)) == 0:
             # TODO: marry this withe groups of XY
             candidates = optimize_acqf_mixed(
                 acq_function=self.acqf,
@@ -401,7 +402,7 @@ class BotorchBasicBoStrategy(PredictiveStrategy):
             )
             # options={"seed":self.seed})
 
-        elif len(self.domain.constraints.get(NChooseKConstraint)) > 0:
+        elif len(self.domain.cnstrs().get(NChooseKConstraint)) > 0:
             candidates = optimize_acqf_mixed(
                 acq_function=self.acqf,
                 bounds=self.get_bounds(),
@@ -433,28 +434,20 @@ class BotorchBasicBoStrategy(PredictiveStrategy):
             columns=self.input_feature_keys
             + [
                 i + "_pred"
-                for i in self.domain.output_features.get_keys_by_objective(
-                    excludes=None
-                )
+                for i in self.domain.outputs().get_keys_by_objective(excludes=None)
             ]
             + [
                 i + "_sd"
-                for i in self.domain.output_features.get_keys_by_objective(
-                    excludes=None
-                )
+                for i in self.domain.outputs().get_keys_by_objective(excludes=None)
             ]
             + [
                 i + "_des"
-                for i in self.domain.output_features.get_keys_by_objective(
-                    excludes=None
-                )
+                for i in self.domain.outputs().get_keys_by_objective(excludes=None)
             ]
             # ["reward","acqf","strategy"]
         )
 
-        for i, feat in enumerate(
-            self.domain.output_features.get_by_objective(excludes=None)
-        ):
+        for i, feat in enumerate(self.domain.outputs().get_by_objective(excludes=None)):
             df_candidates[feat.key + "_pred"] = preds[:, i]
             df_candidates[feat.key + "_sd"] = stds[:, i]
             df_candidates[feat.key + "_des"] = feat.objective(preds[:, i])  # type: ignore
@@ -653,7 +646,7 @@ class BotorchBasicBoStrategy(PredictiveStrategy):
         elif self.categorical_method == CategoricalMethodEnum.FREE:
             include = CategoricalDescriptorInput
 
-        combos = self.domain.input_features.get_categorical_combinations(
+        combos = self.domain.inputs().get_categorical_combinations(
             include=include, exclude=exclude
         )
         # now build up the fixed feature list

--- a/bofire/strategies/botorch/base.py
+++ b/bofire/strategies/botorch/base.py
@@ -89,10 +89,10 @@ class BotorchBasicBoStrategy(PredictiveStrategy):
     descriptor_method: DescriptorMethodEnum = DescriptorMethodEnum.EXHAUSTIVE
     categorical_encoding: CategoricalEncodingEnum = CategoricalEncodingEnum.ORDINAL
     categorical_method: CategoricalMethodEnum = CategoricalMethodEnum.EXHAUSTIVE
-    model_specs: Optional[Tmodelspecs]
-    objective: Optional[MCAcquisitionObjective]
-    acqf: Optional[AcquisitionFunction]
-    model: Optional[GPyTorchModel]
+    model_specs: Optional[Tmodelspecs] = None
+    objective: Optional[MCAcquisitionObjective] = None
+    acqf: Optional[AcquisitionFunction] = None
+    model: Optional[GPyTorchModel] = None
     features2idx: Dict = Field(default_factory=lambda: {})
     input_feature_keys: List[str] = Field(default_factory=lambda: [])
     is_fitted: bool = False

--- a/bofire/strategies/botorch/qehvi.py
+++ b/bofire/strategies/botorch/qehvi.py
@@ -37,14 +37,14 @@ class BoTorchQehviStrategy(BotorchBasicBoStrategy):
         df = self.domain.preprocess_experiments_all_valid_outputs(self.experiments)
 
         train_obj = (
-            df[self.domain.outputs().get_keys_by_objective(excludes=None)].values
+            df[self.domain.outputs.get_keys_by_objective(excludes=None)].values
             * self.ref_point_mask
         )
         ref_point = self.get_adjusted_refpoint()
         weights = np.array(
             [
                 feat.objective.w  # type: ignore
-                for feat in self.domain.outputs().get_by_objective(excludes=None)
+                for feat in self.domain.outputs.get_by_objective(excludes=None)
             ]
         )
         # compute points that are better than the known reference point
@@ -76,7 +76,7 @@ class BoTorchQehviStrategy(BotorchBasicBoStrategy):
         weights = np.array(
             [
                 feat.objective.w  # type: ignore
-                for feat in self.domain.outputs().get_by_objective(excludes=None)
+                for feat in self.domain.outputs.get_by_objective(excludes=None)
             ]
         )
         weights = weights * self.ref_point_mask
@@ -87,11 +87,11 @@ class BoTorchQehviStrategy(BotorchBasicBoStrategy):
         return
 
     def _init_domain(self) -> None:
-        if len(self.domain.outputs().get_by_objective(excludes=None)) < 2:
+        if len(self.domain.outputs.get_by_objective(excludes=None)) < 2:
             raise ValueError(
                 "At least two output features has to be defined in the domain."
             )
-        for feat in self.domain.outputs().get_by_objective(excludes=None):
+        for feat in self.domain.outputs.get_by_objective(excludes=None):
             if isinstance(feat.objective, IdentityObjective) is False:  # type: ignore
                 raise ValueError(
                     "Only `MaximizeObjective` and `MinimizeObjective` supported."
@@ -100,12 +100,12 @@ class BoTorchQehviStrategy(BotorchBasicBoStrategy):
                 raise ValueError("Only objectives with weight 1 are supported.")
         if self.ref_point is not None:
             if len(self.ref_point) != len(
-                self.domain.outputs().get_by_objective(excludes=None)
+                self.domain.outputs.get_by_objective(excludes=None)
             ):
                 raise ValueError(
                     "Dimensionality of provided ref_point does not match number of output features."
                 )
-            for feat in self.domain.outputs().get_keys_by_objective(excludes=None):
+            for feat in self.domain.outputs.get_keys_by_objective(excludes=None):
                 assert (
                     feat in self.ref_point.keys()
                 ), f"No reference point defined for output feature {feat}."
@@ -120,7 +120,7 @@ class BoTorchQehviStrategy(BotorchBasicBoStrategy):
                 * np.array(
                     [
                         self.ref_point[feat]
-                        for feat in self.domain.outputs().get_keys_by_objective(
+                        for feat in self.domain.outputs.get_keys_by_objective(
                             excludes=None
                         )
                     ]
@@ -130,7 +130,7 @@ class BoTorchQehviStrategy(BotorchBasicBoStrategy):
         df = self.domain.preprocess_experiments_all_valid_outputs(self.experiments)
         return (
             (
-                df[self.domain.outputs().get_keys_by_objective(excludes=None)].values
+                df[self.domain.outputs.get_keys_by_objective(excludes=None)].values
                 * self.ref_point_mask
             )
             .min(axis=0)

--- a/bofire/strategies/botorch/qehvi.py
+++ b/bofire/strategies/botorch/qehvi.py
@@ -37,14 +37,14 @@ class BoTorchQehviStrategy(BotorchBasicBoStrategy):
         df = self.domain.preprocess_experiments_all_valid_outputs(self.experiments)
 
         train_obj = (
-            df[self.domain.output_features.get_keys_by_objective(excludes=None)].values
+            df[self.domain.outputs().get_keys_by_objective(excludes=None)].values
             * self.ref_point_mask
         )
         ref_point = self.get_adjusted_refpoint()
         weights = np.array(
             [
                 feat.objective.w  # type: ignore
-                for feat in self.domain.output_features.get_by_objective(excludes=None)
+                for feat in self.domain.outputs().get_by_objective(excludes=None)
             ]
         )
         # compute points that are better than the known reference point
@@ -55,6 +55,7 @@ class BoTorchQehviStrategy(BotorchBasicBoStrategy):
             # use observations that are better than the specified reference point and feasible
             Y=torch.from_numpy(train_obj[better_than_ref]),
         )
+        assert self.model is not None
         # setup the acqf
         self.acqf = qExpectedHypervolumeImprovement(
             model=self.model,
@@ -75,7 +76,7 @@ class BoTorchQehviStrategy(BotorchBasicBoStrategy):
         weights = np.array(
             [
                 feat.objective.w  # type: ignore
-                for feat in self.domain.output_features.get_by_objective(excludes=None)
+                for feat in self.domain.outputs().get_by_objective(excludes=None)
             ]
         )
         weights = weights * self.ref_point_mask
@@ -86,11 +87,11 @@ class BoTorchQehviStrategy(BotorchBasicBoStrategy):
         return
 
     def _init_domain(self) -> None:
-        if len(self.domain.output_features.get_by_objective(excludes=None)) < 2:
+        if len(self.domain.outputs().get_by_objective(excludes=None)) < 2:
             raise ValueError(
                 "At least two output features has to be defined in the domain."
             )
-        for feat in self.domain.output_features.get_by_objective(excludes=None):
+        for feat in self.domain.outputs().get_by_objective(excludes=None):
             if isinstance(feat.objective, IdentityObjective) is False:  # type: ignore
                 raise ValueError(
                     "Only `MaximizeObjective` and `MinimizeObjective` supported."
@@ -99,14 +100,12 @@ class BoTorchQehviStrategy(BotorchBasicBoStrategy):
                 raise ValueError("Only objectives with weight 1 are supported.")
         if self.ref_point is not None:
             if len(self.ref_point) != len(
-                self.domain.output_features.get_by_objective(excludes=None)
+                self.domain.outputs().get_by_objective(excludes=None)
             ):
                 raise ValueError(
                     "Dimensionality of provided ref_point does not match number of output features."
                 )
-            for feat in self.domain.output_features.get_keys_by_objective(
-                excludes=None
-            ):
+            for feat in self.domain.outputs().get_keys_by_objective(excludes=None):
                 assert (
                     feat in self.ref_point.keys()
                 ), f"No reference point defined for output feature {feat}."
@@ -121,7 +120,7 @@ class BoTorchQehviStrategy(BotorchBasicBoStrategy):
                 * np.array(
                     [
                         self.ref_point[feat]
-                        for feat in self.domain.output_features.get_keys_by_objective(
+                        for feat in self.domain.outputs().get_keys_by_objective(
                             excludes=None
                         )
                     ]
@@ -131,9 +130,7 @@ class BoTorchQehviStrategy(BotorchBasicBoStrategy):
         df = self.domain.preprocess_experiments_all_valid_outputs(self.experiments)
         return (
             (
-                df[
-                    self.domain.output_features.get_keys_by_objective(excludes=None)
-                ].values
+                df[self.domain.outputs().get_keys_by_objective(excludes=None)].values
                 * self.ref_point_mask
             )
             .min(axis=0)
@@ -197,6 +194,7 @@ class BoTorchQnehviStrategy(BoTorchQehviStrategy):
         train_x = torch.from_numpy(df_transform[self.input_feature_keys].values).to(
             **tkwargs
         )
+        assert self.model is not None
         # if the reference point is not defined it has to be calculated from data
         self.acqf = qNoisyExpectedHypervolumeImprovement(
             model=self.model,

--- a/bofire/strategies/botorch/qparego.py
+++ b/bofire/strategies/botorch/qparego.py
@@ -49,11 +49,11 @@ class BoTorchQparegoStrategy(BotorchBasicBoStrategy):
 
     def _init_domain(self) -> None:
         # first part of this is doubled with qehvi --> maybe create a common base class
-        if len(self.domain.outputs().get_by_objective(excludes=None)) < 2:
+        if len(self.domain.outputs.get_by_objective(excludes=None)) < 2:
             raise ValueError(
                 "At least two output features has to be defined in the domain."
             )
-        for feat in self.domain.outputs().get_by_objective(excludes=None):
+        for feat in self.domain.outputs.get_by_objective(excludes=None):
             if isinstance(feat.objective, IdentityObjective) is False:  # type: ignore
                 raise ValueError(
                     "Only `MaximizeObjective` and `MinimizeObjective` supported."
@@ -108,7 +108,7 @@ class BoTorchQparegoStrategy(BotorchBasicBoStrategy):
             ).to(**tkwargs)
             weights = (
                 sample_simplex(
-                    len(self.domain.outputs().get_keys_by_objective(excludes=None)),
+                    len(self.domain.outputs.get_keys_by_objective(excludes=None)),
                     **tkwargs
                 ).squeeze()
                 * ref_point_mask
@@ -157,20 +157,20 @@ class BoTorchQparegoStrategy(BotorchBasicBoStrategy):
             columns=self.input_feature_keys
             + [
                 i + "_pred"
-                for i in self.domain.outputs().get_keys_by_objective(excludes=None)
+                for i in self.domain.outputs.get_keys_by_objective(excludes=None)
             ]
             + [
                 i + "_sd"
-                for i in self.domain.outputs().get_keys_by_objective(excludes=None)
+                for i in self.domain.outputs.get_keys_by_objective(excludes=None)
             ]
             + [
                 i + "_des"
-                for i in self.domain.outputs().get_keys_by_objective(excludes=None)
+                for i in self.domain.outputs.get_keys_by_objective(excludes=None)
             ]
             # ["reward","acqf","strategy"]
         )
 
-        for i, feat in enumerate(self.domain.outputs().get_by_objective(excludes=None)):
+        for i, feat in enumerate(self.domain.outputs.get_by_objective(excludes=None)):
             df_candidates[feat.key + "_pred"] = preds[:, i]
             df_candidates[feat.key + "_sd"] = stds[:, i]
             df_candidates[feat.key + "_des"] = feat.objective(preds[:, i])  # type: ignore

--- a/bofire/strategies/botorch/qparego.py
+++ b/bofire/strategies/botorch/qparego.py
@@ -49,11 +49,11 @@ class BoTorchQparegoStrategy(BotorchBasicBoStrategy):
 
     def _init_domain(self) -> None:
         # first part of this is doubled with qehvi --> maybe create a common base class
-        if len(self.domain.output_features.get_by_objective(excludes=None)) < 2:
+        if len(self.domain.outputs().get_by_objective(excludes=None)) < 2:
             raise ValueError(
                 "At least two output features has to be defined in the domain."
             )
-        for feat in self.domain.output_features.get_by_objective(excludes=None):
+        for feat in self.domain.outputs().get_by_objective(excludes=None):
             if isinstance(feat.objective, IdentityObjective) is False:  # type: ignore
                 raise ValueError(
                     "Only `MaximizeObjective` and `MinimizeObjective` supported."
@@ -108,9 +108,7 @@ class BoTorchQparegoStrategy(BotorchBasicBoStrategy):
             ).to(**tkwargs)
             weights = (
                 sample_simplex(
-                    len(
-                        self.domain.output_features.get_keys_by_objective(excludes=None)
-                    ),
+                    len(self.domain.outputs().get_keys_by_objective(excludes=None)),
                     **tkwargs
                 ).squeeze()
                 * ref_point_mask
@@ -119,6 +117,7 @@ class BoTorchQparegoStrategy(BotorchBasicBoStrategy):
                 get_chebyshev_scalarization(weights=weights, Y=pred)
             )
 
+            assert self.model is not None
             acqf = get_acquisition_function(
                 acquisition_function_name="qNEI"
                 if self.acqf == AcquisitionFunctionEnum.QNEI
@@ -158,28 +157,20 @@ class BoTorchQparegoStrategy(BotorchBasicBoStrategy):
             columns=self.input_feature_keys
             + [
                 i + "_pred"
-                for i in self.domain.output_features.get_keys_by_objective(
-                    excludes=None
-                )
+                for i in self.domain.outputs().get_keys_by_objective(excludes=None)
             ]
             + [
                 i + "_sd"
-                for i in self.domain.output_features.get_keys_by_objective(
-                    excludes=None
-                )
+                for i in self.domain.outputs().get_keys_by_objective(excludes=None)
             ]
             + [
                 i + "_des"
-                for i in self.domain.output_features.get_keys_by_objective(
-                    excludes=None
-                )
+                for i in self.domain.outputs().get_keys_by_objective(excludes=None)
             ]
             # ["reward","acqf","strategy"]
         )
 
-        for i, feat in enumerate(
-            self.domain.output_features.get_by_objective(excludes=None)
-        ):
+        for i, feat in enumerate(self.domain.outputs().get_by_objective(excludes=None)):
             df_candidates[feat.key + "_pred"] = preds[:, i]
             df_candidates[feat.key + "_sd"] = stds[:, i]
             df_candidates[feat.key + "_des"] = feat.objective(preds[:, i])  # type: ignore

--- a/bofire/strategies/botorch/sobo.py
+++ b/bofire/strategies/botorch/sobo.py
@@ -100,7 +100,7 @@ class BoTorchSoboStrategy(BotorchBasicBoStrategy):
         self.objective = MultiplicativeObjective(
             targets=[
                 var.objective  # type: ignore
-                for var in self.domain.outputs().get_by_objective(excludes=None)
+                for var in self.domain.outputs.get_by_objective(excludes=None)
             ]
         )
         return
@@ -147,7 +147,7 @@ class BoTorchSoboAdditiveStrategy(BoTorchSoboStrategy):
         self.objective = AdditiveObjective(
             targets=[
                 var.objective  # type: ignore
-                for var in self.domain.outputs().get_by_objective(excludes=None)
+                for var in self.domain.outputs.get_by_objective(excludes=None)
             ]
         )
         return

--- a/bofire/strategies/botorch/sobo.py
+++ b/bofire/strategies/botorch/sobo.py
@@ -100,7 +100,7 @@ class BoTorchSoboStrategy(BotorchBasicBoStrategy):
         self.objective = MultiplicativeObjective(
             targets=[
                 var.objective  # type: ignore
-                for var in self.domain.output_features.get_by_objective(excludes=None)
+                for var in self.domain.outputs().get_by_objective(excludes=None)
             ]
         )
         return
@@ -147,7 +147,7 @@ class BoTorchSoboAdditiveStrategy(BoTorchSoboStrategy):
         self.objective = AdditiveObjective(
             targets=[
                 var.objective  # type: ignore
-                for var in self.domain.output_features.get_by_objective(excludes=None)
+                for var in self.domain.outputs().get_by_objective(excludes=None)
             ]
         )
         return

--- a/bofire/strategies/strategy.py
+++ b/bofire/strategies/strategy.py
@@ -102,8 +102,8 @@ class Strategy(BaseModel):
         arbitrary_types_allowed = True
 
     domain: Domain
-    seed: Optional[NonNegativeInt]
-    rng: Optional[np.random.Generator]
+    seed: Optional[NonNegativeInt] = None
+    rng: Optional[np.random.Generator] = None
 
     _validate_constraints = validator("domain", allow_reuse=True)(validate_constraints)
     _validate_features = validator("domain", allow_reuse=True)(validate_features)
@@ -345,7 +345,7 @@ class PredictiveStrategy(Strategy):
     """
 
     is_fitted: bool = False
-    transformer: Optional[Transformer]
+    transformer: Optional[Transformer] = None
 
     def __init__(self, **data: Any):
         super().__init__(**data)

--- a/bofire/strategies/strategy.py
+++ b/bofire/strategies/strategy.py
@@ -45,7 +45,7 @@ def validate_features(cls, domain: Domain):
     Returns:
         Domain: the domain
     """
-    for feature in domain.inputs() + domain.output_features:
+    for feature in domain.inputs + domain.output_features:
         if not cls.is_feature_implemented(type(feature)):
             raise ValueError(
                 f"feature `{type(feature)}` is not implemented for strategy `{cls.__name__}`"  # type: ignore
@@ -85,7 +85,7 @@ def validate_output_feature_count(cls, domain: Domain):
     """
     if len(domain.output_features) == 0:
         raise ValueError("no output feature specified")
-    if len(domain.outputs().get_by_objective(Objective)) == 0:
+    if len(domain.outputs.get_by_objective(Objective)) == 0:
         raise ValueError("no output feature with objective specified")
     return domain
 
@@ -136,7 +136,7 @@ class Strategy(BaseModel):
         Returns:
             Domain: the domain
         """
-        for feature in domain.outputs().get_by_objective(Objective):
+        for feature in domain.outputs.get_by_objective(Objective):
             assert isinstance(feature, OutputFeature)
             assert feature.objective is not None
             if not cls.is_objective_implemented(type(feature.objective)):
@@ -396,11 +396,11 @@ class PredictiveStrategy(Strategy):
                 data=np.hstack((preds, stds)),
                 columns=[
                     "%s_pred" % featkey
-                    for featkey in self.domain.outputs().get_by_objective(Objective)
+                    for featkey in self.domain.outputs.get_by_objective(Objective)
                 ]
                 + [
                     "%s_sd" % featkey
-                    for featkey in self.domain.outputs().get_by_objective(Objective)
+                    for featkey in self.domain.outputs.get_by_objective(Objective)
                 ],
             )
         else:
@@ -408,7 +408,7 @@ class PredictiveStrategy(Strategy):
                 data=preds,
                 columns=[
                     "%s_pred" % featkey
-                    for featkey in self.domain.outputs().get_by_objective(Objective)
+                    for featkey in self.domain.outputs.get_by_objective(Objective)
                 ],
             )
         return predictions

--- a/bofire/strategies/strategy.py
+++ b/bofire/strategies/strategy.py
@@ -45,7 +45,7 @@ def validate_features(cls, domain: Domain):
     Returns:
         Domain: the domain
     """
-    for feature in domain.input_features + domain.output_features:
+    for feature in domain.inputs() + domain.output_features:
         if not cls.is_feature_implemented(type(feature)):
             raise ValueError(
                 f"feature `{type(feature)}` is not implemented for strategy `{cls.__name__}`"  # type: ignore
@@ -85,7 +85,7 @@ def validate_output_feature_count(cls, domain: Domain):
     """
     if len(domain.output_features) == 0:
         raise ValueError("no output feature specified")
-    if len(domain.output_features.get_by_objective(Objective)) == 0:
+    if len(domain.outputs().get_by_objective(Objective)) == 0:
         raise ValueError("no output feature with objective specified")
     return domain
 
@@ -136,7 +136,7 @@ class Strategy(BaseModel):
         Returns:
             Domain: the domain
         """
-        for feature in domain.output_features.get_by_objective(Objective):
+        for feature in domain.outputs().get_by_objective(Objective):
             assert isinstance(feature, OutputFeature)
             assert feature.objective is not None
             if not cls.is_objective_implemented(type(feature.objective)):
@@ -396,15 +396,11 @@ class PredictiveStrategy(Strategy):
                 data=np.hstack((preds, stds)),
                 columns=[
                     "%s_pred" % featkey
-                    for featkey in self.domain.output_features.get_by_objective(
-                        Objective
-                    )
+                    for featkey in self.domain.outputs().get_by_objective(Objective)
                 ]
                 + [
                     "%s_sd" % featkey
-                    for featkey in self.domain.output_features.get_by_objective(
-                        Objective
-                    )
+                    for featkey in self.domain.outputs().get_by_objective(Objective)
                 ],
             )
         else:
@@ -412,9 +408,7 @@ class PredictiveStrategy(Strategy):
                 data=preds,
                 columns=[
                     "%s_pred" % featkey
-                    for featkey in self.domain.output_features.get_by_objective(
-                        Objective
-                    )
+                    for featkey in self.domain.outputs().get_by_objective(Objective)
                 ],
             )
         return predictions

--- a/bofire/utils/multiobjective.py
+++ b/bofire/utils/multiobjective.py
@@ -14,7 +14,7 @@ def get_ref_point_mask(
     domain: Domain, output_feature_keys: Optional[list] = None
 ) -> np.ndarray:
     if output_feature_keys is None:
-        output_feature_keys = domain.outputs().get_keys_by_objective(excludes=None)
+        output_feature_keys = domain.outputs.get_keys_by_objective(excludes=None)
     if len(output_feature_keys) < 2:
         raise ValueError("At least two output features have to be provided.")
     mask = []
@@ -37,7 +37,7 @@ def get_pareto_front(
     output_feature_keys: Optional[list] = None,
 ) -> pd.DataFrame:
     if output_feature_keys is None:
-        output_feature_keys = domain.outputs().get_keys_by_objective(excludes=None)
+        output_feature_keys = domain.outputs.get_keys_by_objective(excludes=None)
     assert (
         len(output_feature_keys) >= 2
     ), "At least two output features have to be provided."
@@ -62,7 +62,7 @@ def compute_hypervolume(
             np.array(
                 [
                     ref_point[feat]
-                    for feat in domain.outputs().get_keys_by_objective(excludes=None)
+                    for feat in domain.outputs.get_keys_by_objective(excludes=None)
                 ]
             )
             * ref_point_mask
@@ -71,7 +71,7 @@ def compute_hypervolume(
     return hv.compute(
         torch.from_numpy(
             optimal_experiments[
-                domain.outputs().get_keys_by_objective(excludes=None)
+                domain.outputs.get_keys_by_objective(excludes=None)
             ].values
             * ref_point_mask
         )
@@ -84,11 +84,11 @@ def infer_ref_point(
     df = domain.preprocess_experiments_all_valid_outputs(experiments)
     mask = get_ref_point_mask(domain)
     ref_point_array = (
-        df[domain.outputs().get_keys_by_objective(excludes=None)].values * mask
+        df[domain.outputs.get_keys_by_objective(excludes=None)].values * mask
     ).min(axis=0)
     if return_masked is False:
         ref_point_array /= mask
     return {
         feat: ref_point_array[i]
-        for i, feat in enumerate(domain.outputs().get_keys_by_objective(excludes=None))
+        for i, feat in enumerate(domain.outputs.get_keys_by_objective(excludes=None))
     }

--- a/bofire/utils/multiobjective.py
+++ b/bofire/utils/multiobjective.py
@@ -14,9 +14,7 @@ def get_ref_point_mask(
     domain: Domain, output_feature_keys: Optional[list] = None
 ) -> np.ndarray:
     if output_feature_keys is None:
-        output_feature_keys = domain.output_features.get_keys_by_objective(
-            excludes=None
-        )
+        output_feature_keys = domain.outputs().get_keys_by_objective(excludes=None)
     if len(output_feature_keys) < 2:
         raise ValueError("At least two output features have to be provided.")
     mask = []
@@ -39,9 +37,7 @@ def get_pareto_front(
     output_feature_keys: Optional[list] = None,
 ) -> pd.DataFrame:
     if output_feature_keys is None:
-        output_feature_keys = domain.output_features.get_keys_by_objective(
-            excludes=None
-        )
+        output_feature_keys = domain.outputs().get_keys_by_objective(excludes=None)
     assert (
         len(output_feature_keys) >= 2
     ), "At least two output features have to be provided."
@@ -66,9 +62,7 @@ def compute_hypervolume(
             np.array(
                 [
                     ref_point[feat]
-                    for feat in domain.output_features.get_keys_by_objective(
-                        excludes=None
-                    )
+                    for feat in domain.outputs().get_keys_by_objective(excludes=None)
                 ]
             )
             * ref_point_mask
@@ -77,7 +71,7 @@ def compute_hypervolume(
     return hv.compute(
         torch.from_numpy(
             optimal_experiments[
-                domain.output_features.get_keys_by_objective(excludes=None)
+                domain.outputs().get_keys_by_objective(excludes=None)
             ].values
             * ref_point_mask
         )
@@ -90,13 +84,11 @@ def infer_ref_point(
     df = domain.preprocess_experiments_all_valid_outputs(experiments)
     mask = get_ref_point_mask(domain)
     ref_point_array = (
-        df[domain.output_features.get_keys_by_objective(excludes=None)].values * mask
+        df[domain.outputs().get_keys_by_objective(excludes=None)].values * mask
     ).min(axis=0)
     if return_masked is False:
         ref_point_array /= mask
     return {
         feat: ref_point_array[i]
-        for i, feat in enumerate(
-            domain.output_features.get_keys_by_objective(excludes=None)
-        )
+        for i, feat in enumerate(domain.outputs().get_keys_by_objective(excludes=None))
     }

--- a/bofire/utils/reduce.py
+++ b/bofire/utils/reduce.py
@@ -83,8 +83,8 @@ def reduce_domain(domain: Domain) -> Tuple[Domain, AffineTransform]:
         return domain, AffineTransform([])
 
     # find linear equality constraints
-    linear_equalities = domain.cnstrs().get(LinearEqualityConstraint)
-    other_constraints = domain.cnstrs().get(
+    linear_equalities = domain.cnstrs.get(LinearEqualityConstraint)
+    other_constraints = domain.cnstrs.get(
         Constraint, excludes=[LinearEqualityConstraint]
     )
 
@@ -92,7 +92,7 @@ def reduce_domain(domain: Domain) -> Tuple[Domain, AffineTransform]:
     continuous_inputs = [
         cast(ContinuousInput, f) for f in domain.get_features(ContinuousInput)
     ]
-    other_inputs = domain.inputs().get(InputFeature, excludes=[ContinuousInput])
+    other_inputs = domain.inputs.get(InputFeature, excludes=[ContinuousInput])
 
     # assemble Matrix A from equality constraints
     N = len(linear_equalities)
@@ -140,7 +140,7 @@ def reduce_domain(domain: Domain) -> Tuple[Domain, AffineTransform]:
     new_inputs = [
         deepcopy(feat) for i, feat in enumerate(continuous_inputs) if i not in pivots
     ]
-    all_inputs = _domain.inputs() + new_inputs
+    all_inputs = _domain.inputs + new_inputs
     assert isinstance(all_inputs, InputFeatures)
     _domain.input_features = all_inputs
 
@@ -187,7 +187,7 @@ def reduce_domain(domain: Domain) -> Tuple[Domain, AffineTransform]:
                 raise Exception("There is no solution that fulfills the constraints.")
 
     if len(constraints) > 0:
-        _domain.set_constraints_unvalidated(_domain.cnstrs() + constraints)
+        _domain.set_constraints_unvalidated(_domain.cnstrs + constraints)
 
     # assemble equalities
     _equalities = []
@@ -224,12 +224,12 @@ def check_domain_for_reduction(domain: Domain) -> bool:
         return False
 
     # are there any linear equality constraints?
-    linear_equalities = domain.cnstrs().get(LinearEqualityConstraint)
+    linear_equalities = domain.cnstrs.get(LinearEqualityConstraint)
     if len(linear_equalities) == 0:
         return False
 
     # are there no NChooseKConstraint constraints?
-    if len(domain.cnstrs().get([NChooseKConstraint])) > 0:
+    if len(domain.cnstrs.get([NChooseKConstraint])) > 0:
         return False
 
     # are there continuous inputs
@@ -299,7 +299,7 @@ def remove_eliminated_inputs(domain: Domain, transform: AffineTransform) -> Doma
         coeffs_dict[e[0]] = coeffs
 
     constraints = []
-    for c in domain.cnstrs().get():
+    for c in domain.cnstrs.get():
         # Nonlinear constraints not supported
         if not isinstance(c, LinearConstraint):
             raise ValueError(

--- a/bofire/utils/reduce.py
+++ b/bofire/utils/reduce.py
@@ -13,7 +13,7 @@ from bofire.domain.constraints import (
     LinearInequalityConstraint,
     NChooseKConstraint,
 )
-from bofire.domain.features import ContinuousInput, InputFeature
+from bofire.domain.features import ContinuousInput, InputFeature, InputFeatures
 
 ### this module is based on the original implementation in basf/opti.
 
@@ -137,10 +137,13 @@ def reduce_domain(domain: Domain) -> Tuple[Domain, AffineTransform]:
         output_features=deepcopy(domain.output_features),
         constraints=deepcopy(other_constraints),
     )
-    for i, feat in enumerate(continuous_inputs):
-        # add all inputs that were not eliminated
-        if i not in pivots:
-            _domain.add_feature(deepcopy(feat))
+    new_inputs = [
+        deepcopy(feat) for i, feat in enumerate(continuous_inputs) if i not in pivots
+    ]
+    new_inputs = InputFeatures(features=new_inputs)
+    all_inputs = _domain.input_features + new_inputs
+    assert isinstance(all_inputs, InputFeatures)
+    _domain.input_features = all_inputs
 
     for i in pivots:
         # reduce equation system of upper bounds

--- a/bofire/utils/reduce.py
+++ b/bofire/utils/reduce.py
@@ -83,8 +83,8 @@ def reduce_domain(domain: Domain) -> Tuple[Domain, AffineTransform]:
         return domain, AffineTransform([])
 
     # find linear equality constraints
-    linear_equalities = domain.constraints.get(LinearEqualityConstraint)
-    other_constraints = domain.constraints.get(
+    linear_equalities = domain.cnstrs().get(LinearEqualityConstraint)
+    other_constraints = domain.cnstrs().get(
         Constraint, excludes=[LinearEqualityConstraint]
     )
 
@@ -92,7 +92,7 @@ def reduce_domain(domain: Domain) -> Tuple[Domain, AffineTransform]:
     continuous_inputs = [
         cast(ContinuousInput, f) for f in domain.get_features(ContinuousInput)
     ]
-    other_inputs = domain.input_features.get(InputFeature, excludes=[ContinuousInput])
+    other_inputs = domain.inputs().get(InputFeature, excludes=[ContinuousInput])
 
     # assemble Matrix A from equality constraints
     N = len(linear_equalities)
@@ -140,11 +140,11 @@ def reduce_domain(domain: Domain) -> Tuple[Domain, AffineTransform]:
     new_inputs = [
         deepcopy(feat) for i, feat in enumerate(continuous_inputs) if i not in pivots
     ]
-    new_inputs = InputFeatures(features=new_inputs)
-    all_inputs = _domain.input_features + new_inputs
+    all_inputs = _domain.inputs() + new_inputs
     assert isinstance(all_inputs, InputFeatures)
     _domain.input_features = all_inputs
 
+    constraints: List[Constraint] = []
     for i in pivots:
         # reduce equation system of upper bounds
         ind = np.where(B[i, :-1] != 0)[0]
@@ -155,7 +155,7 @@ def reduce_domain(domain: Domain) -> Tuple[Domain, AffineTransform]:
                     coefficients=(-1.0 * B[i, ind]).tolist(),
                     rhs=B[i, -1] * -1.0,
                 )
-                _domain.add_constraint(c)
+                constraints.append(c)
             else:
                 key = names[ind][0]
                 feat = cast(ContinuousInput, _domain.get_feature(key))
@@ -173,7 +173,7 @@ def reduce_domain(domain: Domain) -> Tuple[Domain, AffineTransform]:
                     coefficients=(-1.0 * B[i + M - 1, ind]).tolist(),
                     rhs=B[i + M - 1, -1] * -1.0,
                 )
-                _domain.add_constraint(c)
+                constraints.append(c)
             else:
                 key = names[ind][0]
                 feat = cast(ContinuousInput, _domain.get_feature(key))
@@ -185,6 +185,9 @@ def reduce_domain(domain: Domain) -> Tuple[Domain, AffineTransform]:
         else:
             if B[i + M - 1, -1] < -1e-16:
                 raise Exception("There is no solution that fulfills the constraints.")
+
+    if len(constraints) > 0:
+        _domain.set_constraints_unvalidated(_domain.cnstrs() + constraints)
 
     # assemble equalities
     _equalities = []
@@ -221,12 +224,12 @@ def check_domain_for_reduction(domain: Domain) -> bool:
         return False
 
     # are there any linear equality constraints?
-    linear_equalities = domain.constraints.get(LinearEqualityConstraint)
+    linear_equalities = domain.cnstrs().get(LinearEqualityConstraint)
     if len(linear_equalities) == 0:
         return False
 
     # are there no NChooseKConstraint constraints?
-    if len(domain.constraints.get([NChooseKConstraint])) > 0:
+    if len(domain.cnstrs().get([NChooseKConstraint])) > 0:
         return False
 
     # are there continuous inputs
@@ -296,7 +299,7 @@ def remove_eliminated_inputs(domain: Domain, transform: AffineTransform) -> Doma
         coeffs_dict[e[0]] = coeffs
 
     constraints = []
-    for c in domain.constraints.get():
+    for c in domain.cnstrs().get():
         # Nonlinear constraints not supported
         if not isinstance(c, LinearConstraint):
             raise ValueError(

--- a/bofire/utils/reduce.py
+++ b/bofire/utils/reduce.py
@@ -187,7 +187,7 @@ def reduce_domain(domain: Domain) -> Tuple[Domain, AffineTransform]:
                 raise Exception("There is no solution that fulfills the constraints.")
 
     if len(constraints) > 0:
-        _domain.set_constraints_unvalidated(_domain.cnstrs + constraints)
+        _domain._set_constraints_unvalidated(_domain.cnstrs + constraints)
 
     # assemble equalities
     _equalities = []

--- a/bofire/utils/torch_tools.py
+++ b/bofire/utils/torch_tools.py
@@ -33,7 +33,7 @@ def get_linear_constraints(
         List[Tuple[Tensor, Tensor, float]]: List of tuples, each tuple consists of a tensor with the feature indices, coefficients and a float for the rhs.
     """
     constraints = []
-    for c in domain.cnstrs().get(constraint):
+    for c in domain.cnstrs.get(constraint):
         indices = []
         coefficients = []
         lower = []

--- a/bofire/utils/torch_tools.py
+++ b/bofire/utils/torch_tools.py
@@ -33,7 +33,7 @@ def get_linear_constraints(
         List[Tuple[Tensor, Tensor, float]]: List of tuples, each tuple consists of a tensor with the feature indices, coefficients and a float for the rhs.
     """
     constraints = []
-    for c in domain.constraints.get(constraint):
+    for c in domain.cnstrs().get(constraint):
         indices = []
         coefficients = []
         lower = []

--- a/bofire/utils/transformer.py
+++ b/bofire/utils/transformer.py
@@ -492,14 +492,20 @@ class Transformer(BaseModel):
         return candidate
 
     def get_features_to_be_transformed(self):
-
         excludes = []
         if self.categorical_encoding is None:
             excludes.append(CategoricalInput)
+            features_cat_desc = self.domain.get_features(CategoricalDescriptorInput)
+        else:
+            features_cat_desc = []
+
         if self.descriptor_encoding is None:
             excludes.append(CategoricalDescriptorInput)
-
-        return self.domain.get_features(InputFeature, excludes=excludes)
+            features_cat_desc = []
+        return (
+            self.domain.get_features(InputFeature, excludes=excludes)
+            + features_cat_desc
+        )
 
     def fit_scaling(
         self,

--- a/bofire/utils/transformer.py
+++ b/bofire/utils/transformer.py
@@ -178,7 +178,7 @@ class Transformer(BaseModel):
                 isinstance(feature, CategoricalInput)
                 and self.categorical_encoding == CategoricalEncodingEnum.ORDINAL
             ):
-                enc = OrdinalEncoder(categories=[feature.categories])
+                enc = OrdinalEncoder(categories=[feature.categories])  # type: ignore
 
                 values = pd.DataFrame(experiment[feature.key], columns=[feature.key])
                 enc.fit(values)
@@ -191,7 +191,7 @@ class Transformer(BaseModel):
             ):
                 # Create one-hot encoding columns & insert to DataSet
                 # TODO: drop in oneHot encoder testen
-                enc = OneHotEncoder(categories=[feature.categories])
+                enc = OneHotEncoder(categories=[feature.categories])  # type: ignore
 
                 values = pd.DataFrame(experiment[feature.key], columns=[feature.key])
                 enc.fit(values)
@@ -492,29 +492,14 @@ class Transformer(BaseModel):
         return candidate
 
     def get_features_to_be_transformed(self):
-        features = self.domain.get_features(InputFeature)
 
+        excludes = []
         if self.categorical_encoding is None:
-
-            # removes all categorical features (incl. the descriptor ones)
-            [
-                features.remove(feat)
-                for feat in self.domain.get_features(CategoricalInput)
-            ]
-            # add categorical descriptor features again
-            features2 = self.domain.get_features(CategoricalDescriptorInput)
-
-            features = (
-                features + features2
-            )  # TODO: change, when Benjamin implemented new get_feature
-
+            excludes.append(CategoricalInput)
         if self.descriptor_encoding is None:
-            [
-                features.remove(feat)
-                for feat in self.domain.get_features(CategoricalDescriptorInput)
-            ]
+            excludes.append(CategoricalDescriptorInput)
 
-        return features
+        return self.domain.get_features(InputFeature, excludes=excludes)
 
     def fit_scaling(
         self,

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ setup(
     include_package_data=True,
     install_requires=install_requires,
     extras_require={
-        "testing": ["mock", "mopti", "pyright", "pytest"],
+        "testing": ["mock", "mopti", "pyright", "pytest", "multiprocess"],
         "docs": [
             "mkdocs",
             "mkdocs-material",

--- a/tests/bofire/domain/test_constraints.py
+++ b/tests/bofire/domain/test_constraints.py
@@ -12,6 +12,7 @@ from bofire.domain.constraints import (
     NonlinearInqualityConstraint,
 )
 from bofire.domain.features import ContinuousInput, ContinuousOutput, InputFeatures
+from bofire.utils.enum import SamplingMethodEnum
 from tests.bofire.domain.utils import INVALID_SPECS, get_invalids
 
 VALID_NCHOOSEKE_CONSTRAINT_SPEC = {
@@ -233,7 +234,7 @@ def test_constraints_plus():
     ],
 )
 def test_constraints_call(constraints, num_candidates):
-    candidates = input_features.sample(num_candidates, "UNIFORM")
+    candidates = input_features.sample(num_candidates, SamplingMethodEnum.UNIFORM)
     returned = constraints(candidates)
     assert returned.shape == (num_candidates, len(constraints))
 
@@ -246,33 +247,8 @@ def test_constraints_call(constraints, num_candidates):
     ],
 )
 def test_constraints_is_fulfilled(constraints, num_candidates, fulfilled):
-    candidates = input_features.sample(num_candidates, "UNIFORM")
+    candidates = input_features.sample(num_candidates, SamplingMethodEnum.UNIFORM)
     returned = constraints.is_fulfilled(candidates)
     assert returned.shape == (num_candidates,)
     assert returned.dtype == bool
     assert returned.all() == fulfilled
-
-
-@pytest.mark.parametrize(
-    "constraints, constraint",
-    [
-        (constraints, c4),
-        (constraints, c6),
-    ],
-)
-def test_constraints_add_valid(constraints, constraint):
-    constraints.add(constraint)
-
-
-@pytest.mark.parametrize(
-    "constraints, constraint",
-    [
-        (constraints, "a"),
-        (constraints, 5),
-    ],
-)
-def test_constraints_add_invalid(constraints, constraint):
-    with pytest.raises(
-        (ValueError, TypeError, KeyError, ValidationError, AssertionError)
-    ):
-        constraints.add(constraint)

--- a/tests/bofire/domain/test_domain.py
+++ b/tests/bofire/domain/test_domain.py
@@ -634,11 +634,13 @@ def test_get_features(domain, FeatureType, exact, expected):
 )
 def test_get_outputs_by_objective(domain: Domain, includes, excludes, exact, expected):
     assert (
-        domain.output_features.get_by_objective(
+        domain.outputs()
+        .get_by_objective(
             includes=includes,
             excludes=excludes,
             exact=exact,
-        ).features
+        )
+        .features
         == expected
     )
 
@@ -673,7 +675,7 @@ def test_get_output_keys_by_objective(
     domain: Domain, includes, excludes, exact, expected
 ):
     assert (
-        domain.output_features.get_keys_by_objective(
+        domain.outputs().get_keys_by_objective(
             includes=includes,
             excludes=excludes,
             exact=exact,

--- a/tests/bofire/domain/test_domain.py
+++ b/tests/bofire/domain/test_domain.py
@@ -634,13 +634,11 @@ def test_get_features(domain, FeatureType, exact, expected):
 )
 def test_get_outputs_by_objective(domain: Domain, includes, excludes, exact, expected):
     assert (
-        domain.outputs()
-        .get_by_objective(
+        domain.outputs.get_by_objective(
             includes=includes,
             excludes=excludes,
             exact=exact,
-        )
-        .features
+        ).features
         == expected
     )
 
@@ -675,7 +673,7 @@ def test_get_output_keys_by_objective(
     domain: Domain, includes, excludes, exact, expected
 ):
     assert (
-        domain.outputs().get_keys_by_objective(
+        domain.outputs.get_keys_by_objective(
             includes=includes,
             excludes=excludes,
             exact=exact,

--- a/tests/bofire/domain/test_features.py
+++ b/tests/bofire/domain/test_features.py
@@ -1193,30 +1193,6 @@ def test_features_get_by_key_invalid(features, key):
 
 
 @pytest.mark.parametrize(
-    "features, feature",
-    [
-        (Features(features=[if1, if2]), of1),
-    ],
-)
-def test_features_add(features, feature):
-    features.add(feature)
-    assert features.get_by_key(of1.key).key == feature.key
-
-
-@pytest.mark.parametrize(
-    "features, feature",
-    [
-        (Features(features=[if1, if2]), "of1"),
-        (InputFeatures(features=[if1, if2]), of1),
-        (OutputFeatures(features=[of1, of2]), if1),
-    ],
-)
-def test_features_add_invalid(features, feature):
-    with pytest.raises(AssertionError):
-        features.add(feature)
-
-
-@pytest.mark.parametrize(
     "features, expected",
     [
         (InputFeatures(features=[if1, if2]), []),

--- a/tests/bofire/test_benchmark.py
+++ b/tests/bofire/test_benchmark.py
@@ -1,7 +1,9 @@
-from cgi import test
 from functools import partial
-from bofire.benchmarks.zdt import ZDT1
+
+import pandas as pd
+
 import bofire.benchmarks.benchmark as benchmark
+from bofire.benchmarks.zdt import ZDT1
 from bofire.samplers import RejectionSampler
 from bofire.strategies.botorch.sobo import BoTorchSoboStrategy, qEI
 
@@ -10,19 +12,32 @@ def test_benchmark():
     zdt1 = ZDT1(n_inputs=5)
     sobo_factory = partial(BoTorchSoboStrategy, acquisition_function=qEI())
 
+    n_initial_samples = 10
+    n_runs = 3
+    n_iterations = 2
+
     def sample(domain):
-        n_initial_samples = 10
+        nonlocal n_initial_samples
+        n_initial_samples = n_initial_samples
         sampler = RejectionSampler(domain=domain)
         sampled = sampler.ask(n_initial_samples)
         return sampled
 
-    benchmark.run(
+    results = benchmark.run(
         zdt1,
         sobo_factory,
-        n_iterations=5,
+        n_iterations=n_iterations,
         metric=benchmark.best_multiplicative,
-        initial_sampler=sample
+        initial_sampler=sample,
+        n_runs=n_runs,
     )
+
+    assert len(results) == n_runs
+    for bench, best in results:
+        assert bench.domain.experiments is not None
+        assert bench.domain.experiments.shape[0] == n_initial_samples + n_iterations
+        assert best.shape[0] == n_iterations
+        assert isinstance(best, pd.Series)
 
 
 if __name__ == "__main__":

--- a/tests/bofire/test_benchmark.py
+++ b/tests/bofire/test_benchmark.py
@@ -45,7 +45,3 @@ def test_benchmark():
         assert bench.domain.experiments.shape[0] == n_initial_samples + n_iterations
         assert best.shape[0] == n_iterations
         assert isinstance(best, pd.Series)
-
-
-if __name__ == "__main__":
-    test_benchmark()

--- a/tests/bofire/test_benchmark.py
+++ b/tests/bofire/test_benchmark.py
@@ -1,0 +1,29 @@
+from cgi import test
+from functools import partial
+from bofire.benchmarks.zdt import ZDT1
+import bofire.benchmarks.benchmark as benchmark
+from bofire.samplers import RejectionSampler
+from bofire.strategies.botorch.sobo import BoTorchSoboStrategy, qEI
+
+
+def test_benchmark():
+    zdt1 = ZDT1(n_inputs=5)
+    sobo_factory = partial(BoTorchSoboStrategy, acquisition_function=qEI())
+
+    def sample(domain):
+        n_initial_samples = 10
+        sampler = RejectionSampler(domain=domain)
+        sampled = sampler.ask(n_initial_samples)
+        return sampled
+
+    benchmark.run(
+        zdt1,
+        sobo_factory,
+        n_iterations=5,
+        metric=benchmark.best_multiplicative,
+        initial_sampler=sample
+    )
+
+
+if __name__ == "__main__":
+    test_benchmark()

--- a/tests/bofire/test_benchmark.py
+++ b/tests/bofire/test_benchmark.py
@@ -13,8 +13,8 @@ def test_benchmark():
     sobo_factory = partial(BoTorchSoboStrategy, acquisition_function=qEI())
 
     n_initial_samples = 10
-    n_runs = 3
-    n_iterations = 2
+    n_runs = 2
+    n_iterations = 1
 
     def sample(domain):
         nonlocal n_initial_samples

--- a/tests/bofire/utils/test_reduce.py
+++ b/tests/bofire/utils/test_reduce.py
@@ -199,14 +199,20 @@ def test_reduce_3_independent_linear_equality_constraints():
 
 def test_doc_simple():
     domain = Domain()
-    domain.add_feature(ContinuousInput(key="x1", lower_bound=0.1, upper_bound=1.0))
-    domain.add_feature(ContinuousInput(key="x2", lower_bound=0.0, upper_bound=0.8))
-    domain.add_feature(ContinuousInput(key="x3", lower_bound=0.3, upper_bound=0.9))
-    domain.add_feature(ContinuousOutput(key="y"))
-    domain.add_constraint(
-        LinearEqualityConstraint(
-            features=["x1", "x2", "x3"], coefficients=[1.0, 1.0, 1.0], rhs=1
-        )
+    input_features = [
+        ContinuousInput(key="x1", lower_bound=0.1, upper_bound=1.0),
+        ContinuousInput(key="x2", lower_bound=0.0, upper_bound=0.8),
+        ContinuousInput(key="x3", lower_bound=0.3, upper_bound=0.9),
+    ]
+    output_features = [ContinuousOutput(key="y")]
+    domain = Domain(
+        input_features=input_features,
+        output_features=output_features,
+        constraints=[
+            LinearEqualityConstraint(
+                features=["x1", "x2", "x3"], coefficients=[1.0, 1.0, 1.0], rhs=1
+            )
+        ],
     )
 
     _domain, transform = reduce_domain(domain)
@@ -235,37 +241,31 @@ def test_doc_simple():
 def test_doc_complex():
     domain = Domain()
 
-    domain.add_feature(ContinuousInput(key="A1", lower_bound=0.0, upper_bound=0.9))
-    domain.add_feature(ContinuousInput(key="A2", lower_bound=0.0, upper_bound=0.8))
-    domain.add_feature(ContinuousInput(key="A3", lower_bound=0.0, upper_bound=0.9))
-    domain.add_feature(ContinuousInput(key="A4", lower_bound=0.0, upper_bound=0.9))
-
-    domain.add_feature(ContinuousInput(key="B1", lower_bound=0.3, upper_bound=0.9))
-    domain.add_feature(ContinuousInput(key="B2", lower_bound=0.0, upper_bound=0.8))
-    domain.add_feature(ContinuousInput(key="B3", lower_bound=0.1, upper_bound=1.0))
-
-    domain.add_feature(CategoricalInput(key="Process", categories=["p1", "p2", "p3"]))
-    domain.add_feature(CategoricalInput(key="Discrete", categories=["a1", "a2", "a3"]))
-
-    domain.add_constraint(
+    input_features = [
+        ContinuousInput(key="A1", lower_bound=0.0, upper_bound=0.9),
+        ContinuousInput(key="A2", lower_bound=0.0, upper_bound=0.8),
+        ContinuousInput(key="A3", lower_bound=0.0, upper_bound=0.9),
+        ContinuousInput(key="A4", lower_bound=0.0, upper_bound=0.9),
+        ContinuousInput(key="B1", lower_bound=0.3, upper_bound=0.9),
+        ContinuousInput(key="B2", lower_bound=0.0, upper_bound=0.8),
+        ContinuousInput(key="B3", lower_bound=0.1, upper_bound=1.0),
+        CategoricalInput(key="Process", categories=["p1", "p2", "p3"]),
+        CategoricalInput(key="Discrete", categories=["a1", "a2", "a3"]),
+    ]
+    constraints = [
         LinearEqualityConstraint(
             features=["A1", "A2", "A3", "A4"],
             coefficients=[1.0, 1.0, 1.0, 1.0],
             rhs=1.0,
-        )
-    )
-    domain.add_constraint(
+        ),
         LinearEqualityConstraint(
             features=["B1", "B2", "B3"], coefficients=[1.0, 1.0, 1], rhs=1.0
-        )
-    )
-
-    domain.add_constraint(
+        ),
         LinearInequalityConstraint.from_greater_equal(
             features=["A1", "A2"], coefficients=[-1.0, -2.0], rhs=-0.8
-        )
-    )
-
+        ),
+    ]
+    domain = Domain(input_features=input_features, constraints=constraints)
     _domain, transform = reduce_domain(domain)
 
     assert len(_domain.get_features()) == 7

--- a/tests/bofire/utils/test_torch_tools.py
+++ b/tests/bofire/utils/test_torch_tools.py
@@ -109,26 +109,20 @@ def test_get_linear_constraints():
 
 
 def test_get_linear_constraints_unit_scaled():
-    domain = Domain()
-    domain.add_feature(
-        ContinuousInput(key="base_polymer", lower_bound=0.3, upper_bound=0.7)
-    )
-    domain.add_feature(
-        ContinuousInput(key="glas_fibre", lower_bound=0.1, upper_bound=0.7)
-    )
-    domain.add_feature(
-        ContinuousInput(key="additive", lower_bound=0.1, upper_bound=0.6)
-    )
-    domain.add_feature(
-        ContinuousInput(key="temperature", lower_bound=30.0, upper_bound=700.0)
-    )
-    domain.add_constraint(
+    input_features = [
+        ContinuousInput(key="base_polymer", lower_bound=0.3, upper_bound=0.7),
+        ContinuousInput(key="glas_fibre", lower_bound=0.1, upper_bound=0.7),
+        ContinuousInput(key="additive", lower_bound=0.1, upper_bound=0.6),
+        ContinuousInput(key="temperature", lower_bound=30.0, upper_bound=700.0),
+    ]
+    constraints = [
         LinearEqualityConstraint(
             coefficients=[1.0, 1.0, 1.0],
             features=["base_polymer", "glas_fibre", "additive"],
             rhs=1.0,
         )
-    )
+    ]
+    domain = Domain(input_features=input_features, constraints=constraints)
 
     constraints = get_linear_constraints(
         domain, LinearEqualityConstraint, unit_scaled=True

--- a/tests/bofire/utils/test_transformer.py
+++ b/tests/bofire/utils/test_transformer.py
@@ -375,3 +375,19 @@ def test_transformer_dtype(
     dtypes = data_tr.dtypes
 
     assert_array_equal(dtypes.values, np.array(exp_dtype))
+
+
+if __name__ == "__main__":
+    test_transformer_dtype(
+        domain=domain,
+        df_data=df_data,
+        descriptor_encoding="DESCRIPTOR",
+        categorical_encoding=None,
+        exp_dtype=[
+            np.dtype("float64"),
+            np.dtype("float64"),
+            np.dtype("float64"),
+            np.dtype("O"),
+            np.dtype("float64"),
+        ],
+    )

--- a/tests/bofire/utils/test_transformer.py
+++ b/tests/bofire/utils/test_transformer.py
@@ -375,19 +375,3 @@ def test_transformer_dtype(
     dtypes = data_tr.dtypes
 
     assert_array_equal(dtypes.values, np.array(exp_dtype))
-
-
-if __name__ == "__main__":
-    test_transformer_dtype(
-        domain=domain,
-        df_data=df_data,
-        descriptor_encoding="DESCRIPTOR",
-        categorical_encoding=None,
-        exp_dtype=[
-            np.dtype("float64"),
-            np.dtype("float64"),
-            np.dtype("float64"),
-            np.dtype("O"),
-            np.dtype("float64"),
-        ],
-    )


### PR DESCRIPTION
I think, we have too many add features method that is part of our code-base and need to maintained by us. We could construct according lists and instantiate domains from those list instead of writing `domain.add_feature(...)`. In this PR I have looked at how regarding changes could be implemented for input and output features.

What do you think @jduerholt @R-M-Lee and all?