### PR TITLE
CV hooks

### DIFF
--- a/bofire/models/feature_importance.py
+++ b/bofire/models/feature_importance.py
@@ -1,4 +1,4 @@
-from typing import Dict, List
+from typing import Dict, Sequence
 
 import numpy as np
 import pandas as pd
@@ -107,7 +107,7 @@ def permutation_importance_hook(
 
 
 def combine_permutation_importances(
-    importances: List[Dict[str, pd.DataFrame]],
+    importances: Sequence[Dict[str, pd.DataFrame]],
     metric: RegressionMetricsEnum = RegressionMetricsEnum.R2,
 ) -> pd.DataFrame:
     """Combines feature importances of a set of folds into one data frame for a requested metric.
@@ -121,7 +121,7 @@ def combine_permutation_importances(
         pd.DataFrame: Dataframe holding the mean permutation importance per fold and feature. Can be further processed by
             `describe`.
     """
-    feature_keys = list(importances[0]["MAE"].columns)
+    feature_keys = importances[0]["MAE"].columns
     return pd.DataFrame(
         data={
             key: [fold[metric.name].loc["mean", key] for fold in importances]

--- a/bofire/models/feature_importance.py
+++ b/bofire/models/feature_importance.py
@@ -1,0 +1,100 @@
+from typing import Dict, List
+
+import numpy as np
+import pandas as pd
+
+from bofire.models.diagnostics import metrics
+from bofire.models.model import Model
+from bofire.utils.enum import RegressionMetricsEnum
+
+
+def permutation_importance(
+    model: Model, X: pd.DataFrame, y: pd.DataFrame, n_repeats: int = 5, seed: int = 42
+) -> Dict[str, pd.DataFrame]:
+    """Computus permutation feature importance for a model.
+
+    Args:
+        model (Model): Model for which the feature importances should be estimated.
+        X (pd.DataFrame): X values used to estimate the importances.
+        y (pd.DataFrame): Y values used to estimate the importances.
+        n_repeats (int, optional): Number of repeats. Defaults to 5.
+        seed (int, optional): Seed for the random sampler. Defaults to 42.
+
+    Returns:
+        Dict[str, pd.DataFrame]: keys are the metrices for which the model is evluated and value is a dataframe
+            with the feature keys as columns and the mean and std as indices.
+    """
+    assert len(model.output_features) == 1
+    assert n_repeats > 1
+    output_key = model.output_features[0].key
+    rng = np.random.default_rng(seed)
+    prelim_results = {
+        k.name: {feature.key: [] for feature in model.input_features}
+        for k in metrics.keys()
+    }
+    pred = model.predict(X)
+    original_metrics = {
+        k.name: metrics[k](y[output_key].values, pred[output_key + "_pred"].values)  # type: ignore
+        for k in metrics.keys()
+    }
+
+    for feature in model.input_features:
+        for _ in range(n_repeats):
+            # shuffle
+            X_i = X.copy()
+            X_i[feature.key] = rng.permutation(X_i[feature.key].values)  # type: ignore
+            # predict
+            pred = model.predict(X_i)
+            # compute scores
+            for metricenum, metric in metrics.items():
+                prelim_results[metricenum.name][feature.key].append(
+                    metric(y[output_key].values, pred[output_key + "_pred"].values)  # type: ignore
+                )
+    # convert dictionaries to dataframe for easier postprocessing and statistics
+    # and return
+    results = {}
+    for k in metrics.keys():
+        results[k.name] = pd.DataFrame(
+            data={
+                feature.key: [
+                    original_metrics[k.name]
+                    - np.mean(prelim_results[k.name][feature.key]),
+                    np.std(prelim_results[k.name][feature.key]),
+                ]
+                for feature in model.input_features
+            },
+            index=["mean", "std"],
+        )
+
+    return results
+
+
+def permutation_importance_hook(
+    model: Model,
+    X_train: pd.DataFrame,
+    y_train: pd.DataFrame,
+    X_test: pd.DataFrame,
+    y_test: pd.DataFrame,
+    use_test: bool = True,
+    n_repeats: int = 5,
+    seed: int = 42,
+):
+    if use_test:
+        X = X_test
+        y = y_test
+    else:
+        X = X_train
+        y = y_train
+    return permutation_importance(model=model, X=X, y=y, n_repeats=n_repeats, seed=seed)
+
+
+def combine_permutation_importances(
+    importances: List[Dict[str, pd.DataFrame]], metric: RegressionMetricsEnum
+) -> pd.DataFrame:
+    feature_keys = list(importances[0]["MAE"].columns)
+    return pd.DataFrame(
+        data={
+            key: [fold[metric.name].loc["mean", key] for fold in importances]
+            for key in feature_keys
+        }
+    )

--- a/bofire/models/feature_importance.py
+++ b/bofire/models/feature_importance.py
@@ -11,7 +11,7 @@ from bofire.utils.enum import RegressionMetricsEnum
 def permutation_importance(
     model: Model, X: pd.DataFrame, y: pd.DataFrame, n_repeats: int = 5, seed: int = 42
 ) -> Dict[str, pd.DataFrame]:
-    """Computus permutation feature importance for a model.
+    """Computes permutation feature importance for a model.
 
     Args:
         model (Model): Model for which the feature importances should be estimated.
@@ -22,7 +22,7 @@ def permutation_importance(
 
     Returns:
         Dict[str, pd.DataFrame]: keys are the metrices for which the model is evluated and value is a dataframe
-            with the feature keys as columns and the mean and std as indices.
+            with the feature keys as columns and the mean and std of the respective permutation importances as indices.
     """
     assert len(model.output_features) == 1
     assert n_repeats > 1

--- a/bofire/models/feature_importance.py
+++ b/bofire/models/feature_importance.py
@@ -24,9 +24,9 @@ def permutation_importance(
         Dict[str, pd.DataFrame]: keys are the metrices for which the model is evluated and value is a dataframe
             with the feature keys as columns and the mean and std of the respective permutation importances as rows.
     """
-    assert len(model.output_features) == 1
-    assert n_repeats > 1
-    assert seed > 0
+    assert len(model.output_features) == 1, "Only single output model supported so far."
+    assert n_repeats > 1, "Number of repeats has to be larger than 1."
+    assert seed > 0, "Seed has to be larger than zero."
     output_key = model.output_features[0].key
     rng = np.random.default_rng(seed)
     prelim_results = {

--- a/bofire/models/feature_importance.py
+++ b/bofire/models/feature_importance.py
@@ -22,7 +22,7 @@ def permutation_importance(
 
     Returns:
         Dict[str, pd.DataFrame]: keys are the metrices for which the model is evluated and value is a dataframe
-            with the feature keys as columns and the mean and std of the respective permutation importances as indices.
+            with the feature keys as columns and the mean and std of the respective permutation importances as rows.
     """
     assert len(model.output_features) == 1
     assert n_repeats > 1
@@ -79,6 +79,21 @@ def permutation_importance_hook(
     n_repeats: int = 5,
     seed: int = 42,
 ):
+    """Hook that can be used within `model.cross_validate` to compute a cross validated permutation feature importance.
+
+    Args:
+        model (Model): Predictive BoFire model.
+        X_train (pd.DataFrame):
+        y_train (pd.DataFrame): _description_
+        X_test (pd.DataFrame): _description_
+        y_test (pd.DataFrame): _description_
+        use_test (bool, optional): _description_. Defaults to True.
+        n_repeats (int, optional): _description_. Defaults to 5.
+        seed (int, optional): _description_. Defaults to 42.
+
+    Returns:
+        _type_: _description_
+    """
     if use_test:
         X = X_test
         y = y_test

--- a/bofire/models/model.py
+++ b/bofire/models/model.py
@@ -92,6 +92,7 @@ class TrainableModel:
         self,
         experiments: pd.DataFrame,
         folds: int = -1,
+        include_X: bool = False,
         hooks: Dict[
             str,
             Callable[
@@ -112,6 +113,8 @@ class TrainableModel:
         Args:
             experiments (pd.DataFrame): Data on which the cross validation should be performed.
             folds (int, optional): Number of folds. -1 is equal to LOO CV. Defaults to -1.
+            include_X (bool, optional): If true the X values of the fold are written to respective CvResult objects for
+                later analysis. Defaults ot False.
             hooks (Dict[str, Callable[[Model, pd.DataFrame, pd.DataFrame, pd.DataFrame, pd.DataFrame], Any]], optional):
                 Dictionary of callable hooks that are called within the CV loop. The callable retrieves the current trained
                 modeld and the current CV folds in the following order: X_train, y_train, X_test, y_test. Defaults to {}.
@@ -165,6 +168,7 @@ class TrainableModel:
                     observed=y_train[key],
                     predicted=y_train_pred[key + "_pred"],
                     standard_deviation=y_train_pred[key + "_sd"],
+                    X=X_train if include_X else None,
                 )
             )
             test_results.append(
@@ -173,6 +177,7 @@ class TrainableModel:
                     observed=y_test[key],
                     predicted=y_test_pred[key + "_pred"],
                     standard_deviation=y_test_pred[key + "_sd"],
+                    X=X_test if include_X else None,
                 )
             )
             # now call the hooks if available

--- a/tests/bofire/models/test_feature_importance.py
+++ b/tests/bofire/models/test_feature_importance.py
@@ -1,0 +1,94 @@
+import pandas as pd
+import pytest
+
+from bofire.domain.features import (
+    ContinuousInput,
+    ContinuousOutput,
+    InputFeatures,
+    OutputFeatures,
+)
+from bofire.models.diagnostics import metrics
+from bofire.models.feature_importance import (
+    combine_permutation_importances,
+    permutation_importance,
+    permutation_importance_hook,
+)
+from bofire.models.torch_models import SingleTaskGPModel
+
+
+def get_model_and_data():
+    input_features = InputFeatures(
+        features=[
+            ContinuousInput(key=f"x_{i+1}", lower_bound=-4, upper_bound=4)
+            for i in range(3)
+        ]
+    )
+    output_features = OutputFeatures(features=[ContinuousOutput(key="y")])
+    experiments = input_features.sample(n=20)
+    experiments.eval("y=((x_1**2 + x_2 - 11)**2+(x_1 + x_2**2 -7)**2)", inplace=True)
+    experiments["valid_y"] = 1
+    model = SingleTaskGPModel(
+        input_features=input_features,
+        output_features=output_features,
+    )
+    return model, experiments
+
+
+def test_permutation_importance_invalid():
+    model, experiments = get_model_and_data()
+    X = experiments[model.input_features.get_keys()]
+    y = experiments[["y"]]
+    model.fit(experiments=experiments)
+    with pytest.raises(AssertionError):
+        permutation_importance(model=model, X=X, y=y, n_repeats=1)
+    with pytest.raises(AssertionError):
+        permutation_importance(model=model, X=X, y=y, n_repeats=2, seed=-1)
+
+
+def test_permutation_importance():
+    model, experiments = get_model_and_data()
+    X = experiments[model.input_features.get_keys()]
+    y = experiments[["y"]]
+    model.fit(experiments=experiments)
+    results = permutation_importance(model=model, X=X, y=y, n_repeats=5)
+    assert isinstance(results, dict)
+    assert len(results) == len(metrics)
+    for m in metrics.keys():
+        assert m.name in results.keys()
+        assert isinstance(results[m.name], pd.DataFrame)
+        assert list(results[m.name].columns) == model.input_features.get_keys()
+        assert list(results[m.name].index) == ["mean", "std"]
+
+
+@pytest.mark.parametrize("use_test", [True, False])
+def test_permutation_importance_hook(use_test):
+    model, experiments = get_model_and_data()
+    X = experiments[model.input_features.get_keys()]
+    y = experiments[["y"]]
+    model.fit(experiments=experiments)
+    results = permutation_importance_hook(
+        model=model, X_train=X, y_train=y, X_test=X, y_test=y, use_test=use_test
+    )
+    assert isinstance(results, dict)
+    assert len(results) == len(metrics)
+    for m in metrics.keys():
+        assert m.name in results.keys()
+        assert isinstance(results[m.name], pd.DataFrame)
+        assert list(results[m.name].columns) == model.input_features.get_keys()
+        assert list(results[m.name].index) == ["mean", "std"]
+
+
+@pytest.mark.parametrize("n_folds", [5, 3])
+def test_combine_permutation_importances(n_folds):
+    model, experiments = get_model_and_data()
+    _, _, pi = model.cross_validate(
+        experiments,
+        folds=n_folds,
+        hooks={"pemutation_importance": permutation_importance_hook},
+    )
+    for m in metrics.keys():
+        importance = combine_permutation_importances(
+            importances=pi["pemutation_importance"], metric=m
+        )
+        list(importance.columns) == model.input_features.get_keys()
+        assert len(importance) == n_folds

--- a/tests/bofire/models/test_torch_models.py
+++ b/tests/bofire/models/test_torch_models.py
@@ -197,10 +197,67 @@ def test_model_cross_validate(folds):
         input_features=input_features,
         output_features=output_features,
     )
-    train_cv, test_cv = model.cross_validate(experiments, folds=folds)
+    train_cv, test_cv, _ = model.cross_validate(experiments, folds=folds)
     efolds = folds if folds != -1 else 10
     assert len(train_cv.results) == efolds
     assert len(test_cv.results) == efolds
+
+
+def test_model_cross_validate_hooks():
+    def hook1(model, X_train, y_train, X_test, y_test):
+        assert isinstance(model, SingleTaskGPModel)
+        assert y_train.shape == (8, 1)
+        assert y_test.shape == (2, 1)
+        return X_train.shape
+
+    def hook2(model, X_train, y_train, X_test, y_test, return_test=True):
+        if return_test:
+            return X_test.shape
+        return X_train.shape
+
+    input_features = InputFeatures(
+        features=[
+            ContinuousInput(key=f"x_{i+1}", lower_bound=-4, upper_bound=4)
+            for i in range(2)
+        ]
+    )
+    output_features = OutputFeatures(features=[ContinuousOutput(key="y")])
+    experiments = input_features.sample(n=10)
+    experiments.eval("y=((x_1**2 + x_2 - 11)**2+(x_1 + x_2**2 -7)**2)", inplace=True)
+    experiments["valid_y"] = 1
+    #
+    model = SingleTaskGPModel(
+        input_features=input_features,
+        output_features=output_features,
+    )
+    # first test with one hook
+    _, _, hook_results = model.cross_validate(
+        experiments, folds=5, hooks={"hook1": hook1}
+    )
+    assert len(hook_results.keys()) == 1
+    assert len(hook_results["hook1"]) == 5
+    assert hook_results["hook1"] == [(8, 2), (8, 2), (8, 2), (8, 2), (8, 2)]
+    # now test with two hooks
+    _, _, hook_results = model.cross_validate(
+        experiments, folds=5, hooks={"hook1": hook1, "hook2": hook2}
+    )
+    assert len(hook_results.keys()) == 2
+    assert len(hook_results["hook1"]) == 5
+    assert hook_results["hook1"] == [(8, 2), (8, 2), (8, 2), (8, 2), (8, 2)]
+    assert len(hook_results["hook2"]) == 5
+    assert hook_results["hook2"] == [(2, 2), (2, 2), (2, 2), (2, 2), (2, 2)]
+    # now test with two hooks and keyword arguments
+    _, _, hook_results = model.cross_validate(
+        experiments,
+        folds=5,
+        hooks={"hook1": hook1, "hook2": hook2},
+        hook_kwargs={"hook2": {"return_test": False}},
+    )
+    assert len(hook_results.keys()) == 2
+    assert len(hook_results["hook1"]) == 5
+    assert hook_results["hook1"] == [(8, 2), (8, 2), (8, 2), (8, 2), (8, 2)]
+    assert len(hook_results["hook2"]) == 5
+    assert hook_results["hook2"] == [(8, 2), (8, 2), (8, 2), (8, 2), (8, 2)]
 
 
 @pytest.mark.parametrize("folds", [-2, 0, 1, 11])

--- a/tutorials/models.ipynb
+++ b/tutorials/models.ipynb
@@ -20,7 +20,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -31,7 +31,8 @@
     "    OutputFeatures,\n",
     ")\n",
     "from bofire.models.torch_models import SingleTaskGPModel\n",
-    "from bofire.utils.enum import RegressionMetricsEnum"
+    "from bofire.utils.enum import RegressionMetricsEnum\n",
+    "from bofire.models.feature_importance import permutation_importance_hook, combine_permutation_importances"
    ]
   },
   {
@@ -46,7 +47,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -54,11 +55,11 @@
     "input_features = InputFeatures(\n",
     "        features=[\n",
     "            ContinuousInput(key=f\"x_{i+1}\", lower_bound=-4, upper_bound=4)\n",
-    "            for i in range(2)\n",
+    "            for i in range(3)\n",
     "        ]\n",
     "    )\n",
     "output_features = OutputFeatures(features=[ContinuousOutput(key=\"y\")])\n",
-    "experiments = input_features.sample(n=50)\n",
+    "experiments = input_features.sample(n=100)\n",
     "experiments.eval(\"y=((x_1**2 + x_2 - 11)**2+(x_1 + x_2**2 -7)**2)\", inplace=True)\n",
     "experiments[\"valid_y\"] = 1"
    ]
@@ -74,7 +75,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -82,7 +83,132 @@
     "    input_features=input_features,\n",
     "    output_features=output_features,\n",
     ")\n",
-    "train_cv, test_cv = model.cross_validate(experiments, folds=5)"
+    "train_cv, test_cv, pi = model.cross_validate(experiments, folds=5, hooks={\"pemutation_imprtance\": permutation_importance_hook})"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>x_1</th>\n",
+       "      <th>x_2</th>\n",
+       "      <th>x_3</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>count</th>\n",
+       "      <td>5.000000</td>\n",
+       "      <td>5.000000</td>\n",
+       "      <td>5.000000</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>mean</th>\n",
+       "      <td>1.537801</td>\n",
+       "      <td>1.173164</td>\n",
+       "      <td>0.000005</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>std</th>\n",
+       "      <td>0.223171</td>\n",
+       "      <td>0.159047</td>\n",
+       "      <td>0.000054</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>min</th>\n",
+       "      <td>1.265870</td>\n",
+       "      <td>1.010769</td>\n",
+       "      <td>-0.000063</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>25%</th>\n",
+       "      <td>1.441756</td>\n",
+       "      <td>1.093007</td>\n",
+       "      <td>-0.000022</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>50%</th>\n",
+       "      <td>1.460236</td>\n",
+       "      <td>1.143335</td>\n",
+       "      <td>-0.000010</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>75%</th>\n",
+       "      <td>1.687154</td>\n",
+       "      <td>1.186061</td>\n",
+       "      <td>0.000049</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>max</th>\n",
+       "      <td>1.833988</td>\n",
+       "      <td>1.432646</td>\n",
+       "      <td>0.000069</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "            x_1       x_2       x_3\n",
+       "count  5.000000  5.000000  5.000000\n",
+       "mean   1.537801  1.173164  0.000005\n",
+       "std    0.223171  0.159047  0.000054\n",
+       "min    1.265870  1.010769 -0.000063\n",
+       "25%    1.441756  1.093007 -0.000022\n",
+       "50%    1.460236  1.143335 -0.000010\n",
+       "75%    1.687154  1.186061  0.000049\n",
+       "max    1.833988  1.432646  0.000069"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "combine_permutation_importances(pi[\"pemutation_imprtance\"], RegressionMetricsEnum.R2).describe()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "-34.63896550422625"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "pi[\"pemutation_imprtance\"][1][\"MAE\"].loc[\"mean\", \"x_1\"]"
    ]
   },
   {


### PR DESCRIPTION
This PR adds cross validation hooks. By this it is possible to call callables from inside the CV loop. This can be used for example to compute cross validated feature importances.