### PR TITLE
Hotfix noise in inequality constraint validation

### DIFF
--- a/bofire/domain/constraints.py
+++ b/bofire/domain/constraints.py
@@ -272,7 +272,9 @@ class NonlinearInequalityConstraint(NonlinearConstraint):
     type: Literal["NonlinearInequalityConstraint"] = "NonlinearInequalityConstraint"
 
     def is_fulfilled(self, experiments: pd.DataFrame) -> pd.Series:
-        return self(experiments) <= 0
+        # we allow here for numerical noise
+        noise = 10e-6
+        return self(experiments) <= 0 + noise
 
     def __str__(self):
         return f"{self.expression}<=0"


### PR DESCRIPTION
This PR brings back the noise term in the inequality constraint validation from Everest, due to some recent problems with it.