### PR TITLE
Hotfix/linear kernel

### DIFF
--- a/bofire/models/priors.py
+++ b/bofire/models/priors.py
@@ -1,0 +1,71 @@
+from abc import abstractmethod
+from typing import Literal, Union
+
+import gpytorch.priors
+import matplotlib.pyplot as plt
+import numpy as np
+import torch
+from pydantic import BaseModel, parse_obj_as
+from pydantic.types import PositiveFloat
+
+
+class Prior(BaseModel):
+
+    type: str
+
+    @abstractmethod
+    def to_gpytorch(self) -> gpytorch.priors.Prior:
+        pass
+
+    @staticmethod
+    def from_dict(dict_: dict):
+        return parse_obj_as(AnyPrior, dict_)
+
+    def plot_pdf(self, lower: float, upper: float):
+        x = np.linspace(lower, upper, 1000)
+        fig, ax = plt.subplots()
+        ax.plot(
+            x,
+            np.exp(self.to_gpytorch().log_prob(torch.from_numpy(x)).numpy()),
+            label="botorch",
+        )
+        return fig, ax
+
+
+class GammaPrior(Prior):
+
+    type: Literal["GammaPrior"] = "GammaPrior"
+    concentration: PositiveFloat
+    rate: PositiveFloat
+
+    def to_gpytorch(self) -> gpytorch.priors.GammaPrior:
+        return gpytorch.priors.GammaPrior(
+            concentration=self.concentration, rate=self.rate
+        )
+
+
+class NormalPrior(Prior):
+
+    type: Literal["NormalPrior"] = "NormalPrior"
+    loc: float
+    scale: PositiveFloat
+
+    def to_gpytorch(self) -> gpytorch.priors.NormalPrior:
+        return gpytorch.priors.NormalPrior(loc=self.loc, scale=self.scale)
+
+
+AnyPrior = Union[GammaPrior, NormalPrior]
+
+# default priors of interest
+# botorch defaults
+botorch_lengthcale_prior = GammaPrior(concentration=3.0, rate=6.0)
+# botorch_noise_prior = GammaPrior(concentration=, rate=)
+# botorch_scale_prior = GammaPrior(concentration=, rate=)
+
+# mbo priors
+# By default BoTorch places a highly informative prior on the kernel lengthscales,
+# which easily leads to overfitting. Here we set a broader prior distribution for the
+# lengthscale. The priors for the noise and signal variance are set more tightly.
+mbo_lengthcale_prior = GammaPrior(concentration=2.0, rate=0.2)
+mbo_noise_prior = GammaPrior(concentration=2.0, rate=4.0)
+mbo_outputscale_prior = GammaPrior(concentration=2.0, rate=4.0)

--- a/bofire/models/priors.py
+++ b/bofire/models/priors.py
@@ -10,18 +10,41 @@ from pydantic.types import PositiveFloat
 
 
 class Prior(BaseModel):
+    """Abstract Prior class."""
 
     type: str
 
     @abstractmethod
     def to_gpytorch(self) -> gpytorch.priors.Prior:
+        """Transform prior to a gpytorch prior.
+
+        Returns:
+            gpytorch.priors.Prior: Equivalent gpytorch prior object.
+        """
         pass
 
     @staticmethod
     def from_dict(dict_: dict):
+        """Parse object from dictionary.
+
+        Args:
+            dict_ (dict): Dictionary serialized prior class.
+
+        Returns:
+            AnyPrior: Instantiated prior class.
+        """
         return parse_obj_as(AnyPrior, dict_)
 
     def plot_pdf(self, lower: float, upper: float):
+        """Plot the probability density function of the prior with matplotlib.
+
+        Args:
+            lower (float): lower bound for computing the prior pdf.
+            upper (float): upper bound for computing the prior pdf.
+
+        Returns:
+            fig, ax objects of the plot.
+        """
         x = np.linspace(lower, upper, 1000)
         fig, ax = plt.subplots()
         ax.plot(
@@ -33,6 +56,12 @@ class Prior(BaseModel):
 
 
 class GammaPrior(Prior):
+    """Gamma prior based on the gamma distribution
+
+    Attributes:
+        concentration(PostiveFloat): concentration of the gamma distribution
+        rate(PositiveFloat): rate of the gamma prior.
+    """
 
     type: Literal["GammaPrior"] = "GammaPrior"
     concentration: PositiveFloat
@@ -45,6 +74,12 @@ class GammaPrior(Prior):
 
 
 class NormalPrior(Prior):
+    """Normal prior based on the normal distribution
+
+    Attributes:
+        loc(float): mean/center of the normal distribution
+        scale(PositiveFloat): width of the normal distribution
+    """
 
     type: Literal["NormalPrior"] = "NormalPrior"
     loc: float
@@ -59,8 +94,8 @@ AnyPrior = Union[GammaPrior, NormalPrior]
 # default priors of interest
 # botorch defaults
 botorch_lengthcale_prior = GammaPrior(concentration=3.0, rate=6.0)
-# botorch_noise_prior = GammaPrior(concentration=, rate=)
-# botorch_scale_prior = GammaPrior(concentration=, rate=)
+botorch_noise_prior = GammaPrior(concentration=1.1, rate=0.05)
+botorch_scale_prior = GammaPrior(concentration=2.0, rate=0.15)
 
 # mbo priors
 # By default BoTorch places a highly informative prior on the kernel lengthscales,

--- a/bofire/models/torch_models.py
+++ b/bofire/models/torch_models.py
@@ -21,7 +21,6 @@ from gpytorch.kernels import Kernel as GpytorchKernel
 from gpytorch.kernels import LinearKernel, MaternKernel, RBFKernel
 from gpytorch.kernels.scale_kernel import ScaleKernel
 from gpytorch.mlls import ExactMarginalLogLikelihood
-from gpytorch.priors.torch_priors import GammaPrior
 from pydantic import validator
 
 from bofire.domain.features import (
@@ -34,6 +33,7 @@ from bofire.domain.features import (
 )
 from bofire.domain.util import PydanticBaseModel
 from bofire.models.model import Model, TrainableModel
+from bofire.models.priors import GammaPrior, Prior
 from bofire.utils.enum import CategoricalEncodingEnum, OutputFilteringEnum, ScalerEnum
 from bofire.utils.torch_tools import OneHotToNumeric, tkwargs
 
@@ -93,6 +93,7 @@ class HammondDistanceKernel(CategoricalKernel):
 
 class RBF(ContinuousKernel):
     ard: bool = True
+    length_scale_prior: Optional[Prior] = None
 
     def to_gpytorch(
         self, batch_shape: torch.Size, ard_num_dims: int, active_dims: List[int]
@@ -101,12 +102,16 @@ class RBF(ContinuousKernel):
             batch_shape=batch_shape,
             ard_num_dims=len(active_dims) if self.ard else None,
             active_dims=active_dims,  # type: ignore
+            lengthscale_prior=self.length_scale_prior.to_gpytorch()
+            if self.length_scale_prior is not None
+            else None,
         )
 
 
 class Matern(ContinuousKernel):
     ard: bool = True
     nu: float = 2.5
+    length_scale_prior: Optional[Prior] = None
 
     def to_gpytorch(
         self, batch_shape: torch.Size, ard_num_dims: int, active_dims: List[int]
@@ -116,6 +121,9 @@ class Matern(ContinuousKernel):
             ard_num_dims=len(active_dims) if self.ard else None,
             active_dims=active_dims,
             nu=self.nu,
+            lengthscale_prior=self.length_scale_prior.to_gpytorch()
+            if self.length_scale_prior is not None
+            else None,
         )
 
 

--- a/bofire/models/torch_models.py
+++ b/bofire/models/torch_models.py
@@ -93,7 +93,7 @@ class HammondDistanceKernel(CategoricalKernel):
 
 class RBF(ContinuousKernel):
     ard: bool = True
-    length_scale_prior: Optional[Prior] = None
+    lengthscale_prior: Optional[Prior] = None
 
     def to_gpytorch(
         self, batch_shape: torch.Size, ard_num_dims: int, active_dims: List[int]
@@ -102,8 +102,8 @@ class RBF(ContinuousKernel):
             batch_shape=batch_shape,
             ard_num_dims=len(active_dims) if self.ard else None,
             active_dims=active_dims,  # type: ignore
-            lengthscale_prior=self.length_scale_prior.to_gpytorch()
-            if self.length_scale_prior is not None
+            lengthscale_prior=self.lengthscale_prior.to_gpytorch()
+            if self.lengthscale_prior is not None
             else None,
         )
 
@@ -111,7 +111,7 @@ class RBF(ContinuousKernel):
 class Matern(ContinuousKernel):
     ard: bool = True
     nu: float = 2.5
-    length_scale_prior: Optional[Prior] = None
+    lengthscale_prior: Optional[Prior] = None
 
     def to_gpytorch(
         self, batch_shape: torch.Size, ard_num_dims: int, active_dims: List[int]
@@ -121,8 +121,8 @@ class Matern(ContinuousKernel):
             ard_num_dims=len(active_dims) if self.ard else None,
             active_dims=active_dims,
             nu=self.nu,
-            lengthscale_prior=self.length_scale_prior.to_gpytorch()
-            if self.length_scale_prior is not None
+            lengthscale_prior=self.lengthscale_prior.to_gpytorch()
+            if self.lengthscale_prior is not None
             else None,
         )
 
@@ -405,7 +405,9 @@ class SingleTaskGPModel(BotorchModel, TrainableModel):
                     active_dims=list(range(d)),
                     ard_num_dims=1,
                 ),
-                outputscale_prior=GammaPrior(2.0, 0.15),
+                outputscale_prior=GammaPrior(
+                    concentration=2.0, rate=0.15
+                ).to_gpytorch(),
             ),
             outcome_transform=Standardize(m=tY.shape[-1]),
             input_transform=scaler,

--- a/bofire/models/torch_models.py
+++ b/bofire/models/torch_models.py
@@ -123,7 +123,7 @@ class Linear(ContinuousKernel):
     def to_gpytorch(
         self, batch_shape: torch.Size, ard_num_dims: int, active_dims: List[int]
     ) -> GpytorchKernel:
-        return LinearKernel(batch_shape=batch_shape)
+        return LinearKernel(batch_shape=batch_shape, active_dims=active_dims)
 
 
 class BotorchModel(Model):

--- a/tests/bofire/models/test_priors.py
+++ b/tests/bofire/models/test_priors.py
@@ -1,0 +1,99 @@
+import gpytorch.priors
+import pytest
+from pydantic.error_wrappers import ValidationError
+
+from bofire.models.priors import GammaPrior, NormalPrior, Prior
+from tests.bofire.domain.utils import get_invalids
+
+VALID_GAMMA_PRIOR_SPEC = {"type": "GammaPrior", "concentration": 2.0, "rate": 0.2}
+
+VALID_NORMAL_PRIOR_SPEC = {"type": "NormalPrior", "loc": 2.0, "scale": 0.2}
+
+PRIOR_SPECS = {
+    GammaPrior: {
+        "valids": [
+            VALID_GAMMA_PRIOR_SPEC,
+        ],
+        "invalids": [
+            *get_invalids(VALID_GAMMA_PRIOR_SPEC),
+            *[
+                {
+                    **VALID_GAMMA_PRIOR_SPEC,
+                    "concentration": concentration,
+                    "rate": rate,
+                }
+                for rate in [-1.0, 0]
+                for concentration in [-5, 6]
+            ],
+        ],
+    },
+    NormalPrior: {
+        "valids": [
+            VALID_NORMAL_PRIOR_SPEC,
+        ],
+        "invalids": [
+            *get_invalids(VALID_NORMAL_PRIOR_SPEC),
+            *[
+                {
+                    **VALID_NORMAL_PRIOR_SPEC,
+                    "loc": 0,
+                    "scale": scale,
+                }
+                for scale in [-1.0, 0]
+            ],
+        ],
+    },
+}
+
+
+@pytest.mark.parametrize(
+    "cls, spec",
+    [(cls, valid) for cls, data in PRIOR_SPECS.items() for valid in data["valids"]],
+)
+def test_valid_prior_specs(cls, spec):
+    res = cls(**spec)
+    assert isinstance(res, cls)
+    assert isinstance(res.__str__(), str)
+
+
+@pytest.mark.parametrize(
+    "cls, spec",
+    [
+        (cls, invalid)
+        for cls, data in PRIOR_SPECS.items()
+        for invalid in data["invalids"]
+    ],
+)
+def test_invalid_prior_specs(cls, spec):
+    with pytest.raises((ValueError, TypeError, KeyError, ValidationError)):
+        _ = cls(**spec)
+
+
+@pytest.mark.parametrize(
+    "prior, expected_prior",
+    [
+        (GammaPrior(concentration=2.0, rate=0.2), gpytorch.priors.GammaPrior),
+        (NormalPrior(loc=0, scale=0.5), gpytorch.priors.NormalPrior),
+    ],
+)
+def test_prior(prior, expected_prior):
+    gprior = prior.to_gpytorch()
+    assert isinstance(gprior, expected_prior)
+    for key, value in prior.dict().items():
+        if key == "type":
+            continue
+        assert value == getattr(gprior, key)
+    prior.plot_pdf(lower=-5, upper=5)
+
+
+@pytest.mark.parametrize(
+    "prior",
+    [
+        GammaPrior(concentration=2.0, rate=0.2),
+        NormalPrior(loc=0, scale=0.5),
+    ],
+)
+def test_prior_from_dict(prior):
+    d = prior.dict()
+    prior2 = Prior.from_dict(d)
+    assert prior == prior2


### PR DESCRIPTION
This PR adds:
- Bugfix regarding the active dimensions in the linear kernel. This keyword was previously ignored which could lead to unintended behavior with the Mixed GP.
- In addition, priors are added, so far they are only usable for the lenghtscale of RBF/Matern. This has to be extended and a bit refactored in the hackathon.