### PR TITLE
fix bug that models are fitted twice

### DIFF
--- a/bofire/models/torch_models.py
+++ b/bofire/models/torch_models.py
@@ -415,7 +415,7 @@ class SingleTaskGPModel(BotorchModel, TrainableModel):
         )
 
         mll = ExactMarginalLogLikelihood(self.model.likelihood, self.model)
-        fit_gpytorch_mll(mll, options=self.training_specs)
+        fit_gpytorch_mll(mll, options=self.training_specs, max_attempts=10)
 
 
 class MixedSingleTaskGPModel(BotorchModel, TrainableModel):

--- a/bofire/strategies/botorch/base.py
+++ b/bofire/strategies/botorch/base.py
@@ -354,11 +354,7 @@ class BotorchBasicBoStrategy(PredictiveStrategy):
         return df_candidates
 
     def _tell(self) -> None:
-        if self.has_sufficient_experiments():
-            # todo move this up to predictive strategy
-            self.fit()
-            self.init_acqf()
-        return
+        self.init_acqf()
 
     def init_acqf(self) -> None:
         self._init_acqf()

--- a/bofire/strategies/strategy.py
+++ b/bofire/strategies/strategy.py
@@ -384,11 +384,11 @@ class PredictiveStrategy(Strategy):
             self.domain.set_experiments(experiments)
         else:
             self.domain.add_experiments(experiments)
-        if retrain:
+        if retrain and self.has_sufficient_experiments():
             self.fit()
-        # we have a seperate _tell here for things that are relevant when setting up the strategy but unrelated
-        # to fitting the models like initializing the ACQF.
-        self._tell()
+            # we have a seperate _tell here for things that are relevant when setting up the strategy but unrelated
+            # to fitting the models like initializing the ACQF.
+            self._tell()
 
     def predict(self, experiments: pd.DataFrame) -> pd.DataFrame:
         """Run predictions for the provided experiments. Only input features have to be provided.


### PR DESCRIPTION
This PR fixes the bug that model are fitted twice for our botorch strategies. They were fitted in `tell` and in `_tell`. In addition, I increased the `max_attempts` in model fitting to make it more stable.