### PR TITLE
Feature/constrained qehvi

### DIFF
--- a/bofire/domain/features.py
+++ b/bofire/domain/features.py
@@ -13,7 +13,12 @@ from pydantic.class_validators import root_validator
 from pydantic.types import conint, conlist
 from scipy.stats.qmc import LatinHypercube, Sobol
 
-from bofire.domain.objectives import AnyObjective, MaximizeObjective, Objective
+from bofire.domain.objectives import (
+    AnyAbstractObjective,
+    AnyObjective,
+    MaximizeObjective,
+    Objective,
+)
 from bofire.domain.util import (
     KeyModel,
     PydanticBaseModel,
@@ -1610,9 +1615,15 @@ class OutputFeatures(Features):
     def get_by_objective(
         self,
         includes: Union[
-            List[Type[AnyObjective]], Type[AnyObjective], Type[Objective]
+            List[Type[AnyAbstractObjective]],
+            Type[AnyAbstractObjective],
+            Type[Objective],
         ] = Objective,
-        excludes: Union[List[Type[AnyObjective]], Type[AnyObjective], None] = None,
+        excludes: Union[
+            List[Type[AnyAbstractObjective]],
+            Type[AnyAbstractObjective],
+            None,
+        ] = None,
         exact: bool = False,
     ) -> "OutputFeatures":
         """Get output features filtered by the type of the attached objective.
@@ -1645,9 +1656,13 @@ class OutputFeatures(Features):
     def get_keys_by_objective(
         self,
         includes: Union[
-            List[Type[AnyObjective]], Type[AnyObjective], Type[Objective]
+            List[Type[AnyAbstractObjective]],
+            Type[AnyAbstractObjective],
+            Type[Objective],
         ] = Objective,
-        excludes: Union[List[Type[AnyObjective]], Type[AnyObjective], None] = None,
+        excludes: Union[
+            List[Type[AnyAbstractObjective]], Type[AnyAbstractObjective], None
+        ] = None,
         exact: bool = False,
     ) -> List[str]:
         """Get keys of output features filtered by the type of the attached objective.

--- a/bofire/strategies/botorch/qehvi.py
+++ b/bofire/strategies/botorch/qehvi.py
@@ -18,14 +18,17 @@ from botorch.utils.multi_objective.box_decompositions.non_dominated import (
 from bofire.domain.constraints import Constraint, NChooseKConstraint
 from bofire.domain.features import Feature
 from bofire.domain.objectives import (
-    IdentityObjective,
+    BotorchConstrainedObjective,
     MaximizeObjective,
+    MaximizeSigmoidObjective,
     MinimizeObjective,
+    MinimizeSigmoidObjective,
     Objective,
+    TargetObjective,
 )
 from bofire.strategies.botorch.base import BotorchBasicBoStrategy
 from bofire.utils.multiobjective import get_ref_point_mask
-from bofire.utils.torch_tools import tkwargs
+from bofire.utils.torch_tools import get_output_constraints, tkwargs
 
 
 # TODO: unite this by using get_acquisiton
@@ -80,39 +83,51 @@ class BoTorchQehviStrategy(BotorchBasicBoStrategy):
         return
 
     def _init_objective(self) -> None:
-        weights = np.array(
-            [
-                feat.objective.w  # type: ignore
-                for feat in self.domain.outputs.get_by_objective(excludes=None)
-            ]
-        )
-        weights = weights * self.ref_point_mask
+        weights, indices = [], []
+        for idx, feat in enumerate(self.domain.outputs.get()):
+            if feat.objective is not None and not isinstance(  # type: ignore
+                feat.objective, BotorchConstrainedObjective  # type: ignore
+            ):
+                weights.append(feat.objective.w)  # type: ignore
+                indices.append(idx)
+
+        weights = np.array(weights) * self.ref_point_mask
         self.objective = WeightedMCMultiOutputObjective(
-            outcomes=list(range(len(weights))),
+            outcomes=indices,
             weights=torch.from_numpy(weights).to(**tkwargs),
         )
         return
 
     def _init_domain(self) -> None:
-        if len(self.domain.outputs.get_by_objective(excludes=None)) < 2:
+        # TODO: check for None
+        if (
+            len(
+                self.domain.outputs.get_by_objective(
+                    excludes=BotorchConstrainedObjective
+                )
+            )
+            < 2
+        ):
             raise ValueError(
                 "At least two output features has to be defined in the domain."
             )
-        for feat in self.domain.outputs.get_by_objective(excludes=None):
-            if isinstance(feat.objective, IdentityObjective) is False:  # type: ignore
-                raise ValueError(
-                    "Only `MaximizeObjective` and `MinimizeObjective` supported."
-                )
+        for feat in self.domain.outputs.get_by_objective(
+            excludes=BotorchConstrainedObjective
+        ):
             if feat.objective.w != 1.0:  # type: ignore
                 raise ValueError("Only objectives with weight 1 are supported.")
         if self.ref_point is not None:
             if len(self.ref_point) != len(
-                self.domain.outputs.get_by_objective(excludes=None)
+                self.domain.outputs.get_by_objective(
+                    excludes=BotorchConstrainedObjective
+                )
             ):
                 raise ValueError(
                     "Dimensionality of provided ref_point does not match number of output features."
                 )
-            for feat in self.domain.outputs.get_keys_by_objective(excludes=None):
+            for feat in self.domain.outputs.get_keys_by_objective(
+                excludes=BotorchConstrainedObjective
+            ):
                 assert (
                     feat in self.ref_point.keys()
                 ), f"No reference point defined for output feature {feat}."
@@ -128,7 +143,7 @@ class BoTorchQehviStrategy(BotorchBasicBoStrategy):
                     [
                         self.ref_point[feat]
                         for feat in self.domain.outputs.get_keys_by_objective(
-                            excludes=None
+                            excludes=BotorchConstrainedObjective
                         )
                     ]
                 )
@@ -139,7 +154,11 @@ class BoTorchQehviStrategy(BotorchBasicBoStrategy):
         )
         return (
             (
-                df[self.domain.outputs.get_keys_by_objective(excludes=None)].values
+                df[
+                    self.domain.outputs.get_keys_by_objective(
+                        excludes=BotorchConstrainedObjective
+                    )
+                ].values
                 * self.ref_point_mask
             )
             .min(axis=0)
@@ -192,6 +211,13 @@ class BoTorchQnehviStrategy(BoTorchQehviStrategy):
 
         X_train, X_pending = self.get_acqf_input_tensors()
 
+        # get etas and constraints
+        constraints, etas = get_output_constraints(self.domain.outputs)
+        if len(constraints) == 0:
+            constraints, etas = None, 1e-3
+        else:
+            etas = torch.tensor(etas).to(**tkwargs)
+
         assert self.model is not None
         # if the reference point is not defined it has to be calculated from data
         self.acqf = qNoisyExpectedHypervolumeImprovement(
@@ -203,7 +229,29 @@ class BoTorchQnehviStrategy(BoTorchQehviStrategy):
             objective=self.objective,
             cache_root=True if isinstance(self.model, GPyTorchModel) else False,
             X_pending=X_pending,
+            constraints=constraints,
+            eta=etas,
         )
         # todo comment in after new botorch deployment
         # self.acqf._default_sample_shape = torch.Size([self.num_sobol_samples])
         return
+
+    @classmethod
+    def is_objective_implemented(cls, my_type: Type[Objective]) -> bool:
+        """Method to check if a objective type is implemented for the strategy
+
+        Args:
+            my_type (Type[Objective]): Objective class
+
+        Returns:
+            bool: True if the objective type is valid for the strategy chosen, False otherwise
+        """
+        if my_type not in [
+            MaximizeObjective,
+            MinimizeObjective,
+            MinimizeSigmoidObjective,
+            MaximizeSigmoidObjective,
+            TargetObjective,
+        ]:
+            return False
+        return True

--- a/bofire/utils/multiobjective.py
+++ b/bofire/utils/multiobjective.py
@@ -13,8 +13,22 @@ from bofire.domain.objectives import MaximizeObjective, MinimizeObjective
 def get_ref_point_mask(
     domain: Domain, output_feature_keys: Optional[list] = None
 ) -> np.ndarray:
+    """Method to get a mask for the reference points taking into account if we
+    want to maximize or minimize an objective. In case it is maximize the value
+    in the mask is 1, in case we want to minimize it is -1.
+
+    Args:
+        domain (Domain): Domain for which the mask should be generated.
+        output_feature_keys (Optional[list], optional): Name of output feature keys
+            that should be considered in the mask. Defaults to None.
+
+    Returns:
+        np.ndarray: _description_
+    """
     if output_feature_keys is None:
-        output_feature_keys = domain.outputs.get_keys_by_objective(excludes=None)
+        output_feature_keys = domain.outputs.get_keys_by_objective(
+            includes=[MaximizeObjective, MinimizeObjective]
+        )
     if len(output_feature_keys) < 2:
         raise ValueError("At least two output features have to be provided.")
     mask = []
@@ -26,7 +40,7 @@ def get_ref_point_mask(
             mask.append(-1.0)
         else:
             raise ValueError(
-                "Only `MaximizeObjective` and `MinimizeObjective` supported."
+                "Only `MaximizeObjective` and `MinimizeObjective` supported"
             )
     return np.array(mask)
 
@@ -37,7 +51,9 @@ def get_pareto_front(
     output_feature_keys: Optional[list] = None,
 ) -> pd.DataFrame:
     if output_feature_keys is None:
-        output_feature_keys = domain.outputs.get_keys_by_objective(excludes=None)
+        output_feature_keys = domain.outputs.get_keys_by_objective(
+            includes=[MaximizeObjective, MinimizeObjective]
+        )
     assert (
         len(output_feature_keys) >= 2
     ), "At least two output features have to be provided."
@@ -62,7 +78,9 @@ def compute_hypervolume(
             np.array(
                 [
                     ref_point[feat]
-                    for feat in domain.outputs.get_keys_by_objective(excludes=None)
+                    for feat in domain.outputs.get_keys_by_objective(
+                        includes=[MaximizeObjective, MinimizeObjective]
+                    )
                 ]
             )
             * ref_point_mask
@@ -71,7 +89,9 @@ def compute_hypervolume(
     return hv.compute(
         torch.from_numpy(
             optimal_experiments[
-                domain.outputs.get_keys_by_objective(excludes=None)
+                domain.outputs.get_keys_by_objective(
+                    includes=[MaximizeObjective, MinimizeObjective]
+                )
             ].values
             * ref_point_mask
         )
@@ -81,14 +101,14 @@ def compute_hypervolume(
 def infer_ref_point(
     domain: Domain, experiments: pd.DataFrame, return_masked: bool = False
 ):
-    df = domain.outputs.preprocess_experiments_all_valid_outputs(experiments)
+    keys = domain.outputs.get_keys_by_objective(
+        includes=[MaximizeObjective, MinimizeObjective]
+    )
+    df = domain.outputs.preprocess_experiments_all_valid_outputs(
+        experiments, output_feature_keys=keys
+    )
     mask = get_ref_point_mask(domain)
-    ref_point_array = (
-        df[domain.outputs.get_keys_by_objective(excludes=None)].values * mask
-    ).min(axis=0)
+    ref_point_array = (df[keys].values * mask).min(axis=0)
     if return_masked is False:
         ref_point_array /= mask
-    return {
-        feat: ref_point_array[i]
-        for i, feat in enumerate(domain.outputs.get_keys_by_objective(excludes=None))
-    }
+    return {feat: ref_point_array[i] for i, feat in enumerate(keys)}

--- a/tests/bofire/benchmarks/test_multi.py
+++ b/tests/bofire/benchmarks/test_multi.py
@@ -1,6 +1,6 @@
 import pytest
 
-from bofire.benchmarks.multi import DTLZ2, ZDT1, CrossCoupling, SnarBenchmark
+from bofire.benchmarks.multi import C2DTLZ2, DTLZ2, ZDT1, CrossCoupling, SnarBenchmark
 
 
 @pytest.mark.parametrize(
@@ -22,6 +22,8 @@ from bofire.benchmarks.multi import DTLZ2, ZDT1, CrossCoupling, SnarBenchmark
             False,
             {},
         ),
+        (C2DTLZ2, True, {"dim": 4}),
+        (C2DTLZ2, False, {"dim": 4}),
     ],
 )
 def test_multi_objective_benchmarks(cls_benchmark, return_complete, kwargs):

--- a/tests/bofire/domain/test_objectives.py
+++ b/tests/bofire/domain/test_objectives.py
@@ -213,13 +213,13 @@ def test_invalid_desirability_function_specs(cls, spec):
     ],
 )
 def test_maximize_sigmoid_objective_to_constraints(objective):
-    cs = objective.to_constraints(idx=0)
+    cs, etas = objective.to_constraints(idx=0)
 
     x = torch.from_numpy(np.linspace(0, 30, 500)).unsqueeze(-1)
     y = torch.ones([500])
 
-    for c in cs:
+    for c, eta in zip(cs, etas):
         xtt = c(x)
-        y *= soft_eval_constraint(xtt, 1.0 / objective.steepness)
+        y *= soft_eval_constraint(xtt, eta)
 
     assert np.allclose(objective.__call__(np.linspace(0, 30, 500)), y.numpy().ravel())

--- a/tests/bofire/utils/test_multiobjective.py
+++ b/tests/bofire/utils/test_multiobjective.py
@@ -8,6 +8,7 @@ from bofire.domain.objectives import (
     MaximizeObjective,
     MaximizeSigmoidObjective,
     MinimizeObjective,
+    MinimizeSigmoidObjective,
 )
 from bofire.utils.multiobjective import (
     compute_hypervolume,
@@ -55,6 +56,10 @@ of5 = ContinuousOutput(
     objective=MaximizeSigmoidObjective(w=1, tp=1, steepness=1),
     key="of5",
 )
+of6 = ContinuousOutput(
+    objective=MinimizeSigmoidObjective(w=1, tp=1, steepness=1),
+    key="of6",
+)
 
 valid_domains = [
     Domain(input_features=[if1, if2], output_features=[of1, of2]),
@@ -62,6 +67,12 @@ valid_domains = [
     Domain(input_features=[if1, if2], output_features=[of1, of2, of3, of4]),
     Domain(input_features=[if1, if2], output_features=[of2, of4]),
     Domain(input_features=[if1, if2], output_features=[of2, of1, of3, of4]),
+]
+
+valid_constrained_domains = [
+    Domain(input_features=[if1, if2], output_features=[of1, of2, of5]),
+    Domain(input_features=[if1, if2], output_features=[of1, of2, of6]),
+    Domain(input_features=[if1, if2], output_features=[of1, of2, of5, of6]),
 ]
 
 invalid_domains = [
@@ -137,6 +148,7 @@ dfs = [
     "domain, expected",
     [
         (valid_domains[0], np.array([1.0, -1.0])),
+        (valid_constrained_domains[0], np.array([1.0, -1.0])),
         (valid_domains[1], np.array([1.0, 1.0])),
         (valid_domains[2], np.array([1.0, -1.0, 1.0, -1.0])),
         (valid_domains[3], np.array([-1.0, -1.0])),
@@ -169,6 +181,7 @@ def test_invalid_get_ref_point_mask(domain):
     "domain, experiments, expected_indices",
     [
         (valid_domains[0], dfs[0], np.array([1, 2], dtype="int64")),
+        (valid_constrained_domains[0], dfs[0], np.array([1, 2], dtype="int64")),
         (valid_domains[1], dfs[1], np.array([1, 3], dtype="int64")),
     ],
 )
@@ -181,6 +194,7 @@ def test_get_pareto_front(domain, experiments, expected_indices):
     "domain, experiments, ref_point",
     [
         (valid_domains[0], dfs[0], {"of1": 0.0, "of2": 20.0}),
+        (valid_constrained_domains[0], dfs[0], {"of1": 0.0, "of2": 20.0}),
         (valid_domains[1], dfs[1], {"of1": 0.0, "of3": 0.0}),
     ],
 )
@@ -197,21 +211,16 @@ def test_compute_hypervolume(domain, experiments, ref_point):
         (valid_domains[0], dfs[0], False, {"of1": 1.0, "of2": 5.0}),
         (valid_domains[1], dfs[1], True, {"of1": 1.0, "of3": 2.0}),
         (valid_domains[1], dfs[1], False, {"of1": 1.0, "of3": 2.0}),
+        (valid_constrained_domains[0], dfs[0], True, {"of1": 1.0, "of2": -5.0}),
+        (valid_constrained_domains[0], dfs[0], False, {"of1": 1.0, "of2": 5.0}),
     ],
 )
 def test_infer_ref_point(domain, experiments, return_masked, expected):
     ref_point = infer_ref_point(domain, experiments, return_masked)
+    keys = domain.outputs.get_keys_by_objective(
+        includes=[MaximizeObjective, MinimizeObjective]
+    )
     assert np.allclose(
-        np.array(
-            [
-                ref_point[feat]
-                for feat in domain.output_features.get_keys_by_objective(excludes=None)
-            ]
-        ),
-        np.array(
-            [
-                expected[feat]
-                for feat in domain.output_features.get_keys_by_objective(excludes=None)
-            ]
-        ),
+        np.array([ref_point[feat] for feat in keys]),
+        np.array([expected[feat] for feat in keys]),
     )

--- a/tests/bofire/utils/test_torch_tools.py
+++ b/tests/bofire/utils/test_torch_tools.py
@@ -1,3 +1,5 @@
+import numpy as np
+import pytest
 import torch
 
 from bofire.domain import Domain
@@ -5,8 +7,22 @@ from bofire.domain.constraints import (
     LinearEqualityConstraint,
     LinearInequalityConstraint,
 )
-from bofire.domain.features import CategoricalInput, ContinuousInput
-from bofire.utils.torch_tools import get_linear_constraints, tkwargs
+from bofire.domain.features import (
+    CategoricalInput,
+    ContinuousInput,
+    ContinuousOutput,
+    OutputFeatures,
+)
+from bofire.domain.objectives import (
+    MaximizeObjective,
+    MaximizeSigmoidObjective,
+    TargetObjective,
+)
+from bofire.utils.torch_tools import (
+    get_linear_constraints,
+    get_output_constraints,
+    tkwargs,
+)
 
 if1 = ContinuousInput(
     lower_bound=0.0,
@@ -135,3 +151,31 @@ def test_get_linear_constraints_unit_scaled():
         constraints[0][1], torch.tensor([0.4, 0.6, 0.5]).to(**tkwargs) * -1
     )
     assert torch.allclose(constraints[0][0], torch.tensor([1, 2, 0]))
+
+
+of1 = ContinuousOutput(key="of1", objective=MaximizeObjective(w=1.0))
+of2 = ContinuousOutput(
+    key="of2",
+    objective=MaximizeSigmoidObjective(
+        w=1.0,
+        tp=0,
+        steepness=2,
+    ),
+)
+of3 = ContinuousOutput(
+    key="of3",
+    objective=TargetObjective(w=1.0, tolerance=2, target_value=5, steepness=4),
+)
+
+
+@pytest.mark.parametrize(
+    "output_features",
+    [
+        OutputFeatures(features=[of1, of2, of3]),
+        OutputFeatures(features=[of2, of1, of3]),
+    ],
+)
+def test_get_output_constraints(output_features):
+    constraints, etas = get_output_constraints(output_features=output_features)
+    assert len(constraints) == len(etas)
+    assert np.allclose(etas, [0.5, 0.25, 0.25])


### PR DESCRIPTION
This PR adds output constraints of type `MaximizeSigmoidObjective`, `MinimizeSigmoidObjective` and `TargetObjective` for the qnehvi strategy to botorch. In addition also the C2DTLZ2 Benchmark is added.

@jkleinekorte: I focused on qnehvi as qehvi seems to be a bit deprecated and qnehvi should deliver the same performace without the memory problems of qehvi. So we should discuss if we also port it to qehvi. We should definitely port it to qPAREGO but this will be easy when we just do the botorch objective refactoring.

@evo-nlueck: This might be interesting for you ;)