### PR TITLE
Add release milestone information

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,13 @@
 
 Contributions to BoFire are highly welcome!
 
-## Development Enviromnent
+## Release roadmap
+
+The features for the next release are tracked in the [milestones](https://github.com/experimental-design/bofire/milestones).
+
+When supporting BoFire, feel free to suggest if the change should be incorporated into the next release.
+
+## Development Environment
 
 We recommend an editable installation. After cloning the repository via
 ```

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ BoFire is a **B**ayesian **O**ptimization **F**ramework **I**ntended for **R**ea
 
 Why BoFire?
 
-Bofire ...
+BoFire ...
 
 - supports mixed continuous, discrete and categorical parameter spaces for system inputs and outputs,
 - separates objectives (minimize, maximize, close-to-target) from the outputs on which they operate,
@@ -46,7 +46,15 @@ pip install -e .[testing]
 
 Documentation including a section on how to get started can be found under https://experimental-design.github.io/bofire/.
 
-## Pull Requests
+## Contributing
+
+> TL;DR of the [Contributing](./CONTRIBUTING.md) guidelines.
+
+### Release roadmap
+
+The features for the next release are tracked in the [milestones](https://github.com/experimental-design/bofire/milestones).
+
+### Pull Requests
 
 Pull requests are highly welcome:
 
@@ -55,10 +63,10 @@ Pull requests are highly welcome:
 3. Add doc-strings and update the documentation. You might consider contributing to the tutorials section.
 4. Make sure that the GitHub pipeline passes.
 
-## Issues
+### Issues
 
 If you find any issues, Bugs, or not sure about something -  feel free to create an Issue.
 
 ## License
 
-By contributing you agree that your contributions will be licensed under the same license as BoFire.
+By contributing you agree that your contributions will be licensed under the same license as BoFire: [BSD 3-Clause License](./LICENSE).


### PR DESCRIPTION
Closes #88 

Added directly into main README and uses GitHub Milestones functionality instead of a manually curated markdown file.