### PR TITLE
change import for gps

### DIFF
--- a/bofire/benchmarks/multi.py
+++ b/bofire/benchmarks/multi.py
@@ -24,7 +24,7 @@ from bofire.domain.objective import (
     MaximizeSigmoidObjective,
     MinimizeObjective,
 )
-from bofire.models.gps import SingleTaskGPModel
+from bofire.models.gps.gps import SingleTaskGPModel
 from bofire.utils.enum import CategoricalEncodingEnum
 
 

--- a/bofire/models/gps/__init__.py
+++ b/bofire/models/gps/__init__.py
@@ -1,3 +1,0 @@
-from bofire.models.gps.gps import MixedSingleTaskGPModel, SingleTaskGPModel
-
-__all__ = ["MixedSingleTaskGPModel", "SingleTaskGPModel"]

--- a/bofire/strategies/botorch/base.py
+++ b/bofire/strategies/botorch/base.py
@@ -26,7 +26,7 @@ from bofire.domain.feature import (
     TInputTransformSpecs,
 )
 from bofire.domain.features import OutputFeatures
-from bofire.models.gps import MixedSingleTaskGPModel, SingleTaskGPModel
+from bofire.models.gps.gps import MixedSingleTaskGPModel, SingleTaskGPModel
 from bofire.models.torch_models import BotorchModels
 from bofire.strategies.strategy import PredictiveStrategy
 from bofire.strategies.utils import is_power_of_two

--- a/tests/bofire/models/gps/test_gps.py
+++ b/tests/bofire/models/gps/test_gps.py
@@ -10,7 +10,7 @@ from botorch.models.transforms.outcome import Standardize
 
 from bofire.domain.feature import CategoricalInput, ContinuousInput, ContinuousOutput
 from bofire.domain.features import InputFeatures, OutputFeatures
-from bofire.models.gps import MixedSingleTaskGPModel, SingleTaskGPModel
+from bofire.models.gps.gps import MixedSingleTaskGPModel, SingleTaskGPModel
 from bofire.models.gps.kernels import HammondDistanceKernel, RBFKernel, ScaleKernel
 from bofire.utils.enum import CategoricalEncodingEnum, ScalerEnum
 from bofire.utils.torch_tools import OneHotToNumeric

--- a/tests/bofire/models/test_cross_validate.py
+++ b/tests/bofire/models/test_cross_validate.py
@@ -6,7 +6,7 @@ from bofire.domain.feature import (
     ContinuousOutput,
 )
 from bofire.domain.features import InputFeatures, OutputFeatures
-from bofire.models.gps import SingleTaskGPModel
+from bofire.models.gps.gps import SingleTaskGPModel
 from bofire.utils.enum import CategoricalEncodingEnum
 
 

--- a/tests/bofire/models/test_feature_importance.py
+++ b/tests/bofire/models/test_feature_importance.py
@@ -9,7 +9,7 @@ from bofire.models.feature_importance import (
     permutation_importance,
     permutation_importance_hook,
 )
-from bofire.models.gps import SingleTaskGPModel
+from bofire.models.gps.gps import SingleTaskGPModel
 
 
 def get_model_and_data():

--- a/tests/bofire/models/test_torch_models.py
+++ b/tests/bofire/models/test_torch_models.py
@@ -19,7 +19,7 @@ from bofire.domain.feature import (
     ContinuousOutput,
 )
 from bofire.domain.features import InputFeatures, OutputFeatures
-from bofire.models.gps import MixedSingleTaskGPModel, SingleTaskGPModel
+from bofire.models.gps.gps import MixedSingleTaskGPModel, SingleTaskGPModel
 from bofire.models.torch_models import BotorchModels, EmpiricalModel
 from bofire.utils.enum import CategoricalEncodingEnum, ScalerEnum
 from bofire.utils.torch_tools import OneHotToNumeric, tkwargs

--- a/tests/bofire/strategies/botorch/test_base.py
+++ b/tests/bofire/strategies/botorch/test_base.py
@@ -23,7 +23,7 @@ from bofire.domain.feature import (
 )
 from bofire.domain.objective import MaximizeObjective, MinimizeObjective
 from bofire.domain.util import KeyModel
-from bofire.models.gps import SingleTaskGPModel
+from bofire.models.gps.gps import SingleTaskGPModel
 from bofire.models.torch_models import BotorchModels
 from bofire.strategies.botorch.base import BotorchBasicBoStrategy
 from bofire.strategies.botorch.sobo import AcquisitionFunctionEnum

--- a/tests/bofire/strategies/botorch/test_model_specs_generator.py
+++ b/tests/bofire/strategies/botorch/test_model_specs_generator.py
@@ -2,7 +2,7 @@ import pytest
 
 from bofire.domain.feature import ContinuousInput, ContinuousOutput
 from bofire.domain.features import InputFeatures, OutputFeatures
-from bofire.models.gps import SingleTaskGPModel
+from bofire.models.gps.gps import SingleTaskGPModel
 from bofire.models.torch_models import BotorchModels
 from bofire.strategies.botorch.base import BotorchBasicBoStrategy
 from bofire.strategies.botorch.sobo import BoTorchSoboStrategy

--- a/tests/bofire/strategies/botorch/test_qparego.py
+++ b/tests/bofire/strategies/botorch/test_qparego.py
@@ -6,7 +6,7 @@ import torch
 
 from bofire.benchmarks.multi import DTLZ2, CrossCoupling
 from bofire.domain.features import OutputFeatures
-from bofire.models.gps import MixedSingleTaskGPModel, SingleTaskGPModel
+from bofire.models.gps.gps import MixedSingleTaskGPModel, SingleTaskGPModel
 from bofire.models.torch_models import BotorchModels
 from bofire.samplers import PolytopeSampler
 from bofire.strategies.botorch.qparego import BoTorchQparegoStrategy


### PR DESCRIPTION
When executing `from bofire.serial.deserialization import Deserialization` one got a circular import error due to the import of the GPs in `models/gps/__init__.py`. I removed this. Now it works again.