### PR TITLE
Hotfix/predict

### DIFF
--- a/bofire/surrogates/surrogate.py
+++ b/bofire/surrogates/surrogate.py
@@ -38,6 +38,9 @@ class Surrogate(ABC):
         X = self.input_features.validate_experiments(X, strict=False)
         # transform
         Xt = self.input_features.transform(X, self.input_preprocessing_specs)
+        # make sure that all is float64
+        for c in Xt.columns:
+            Xt[c] = pd.to_numeric(Xt[c], errors="raise")
         # predict
         preds, stds = self._predict(Xt)
         # postprocess

--- a/tests/bofire/surrogates/test_gps.py
+++ b/tests/bofire/surrogates/test_gps.py
@@ -63,7 +63,9 @@ def test_SingleTaskGPModel(kernel, scaler):
     # dump the model
     dump = model.dumps()
     # make predictions
-    preds = model.predict(samples)
+    samples2 = samples.copy()
+    samples2 = samples2.astype({"x_1": "object"})
+    preds = model.predict(samples2)
     assert preds.shape == (5, 2)
     # check that model is composed correctly
     assert isinstance(model.model, SingleTaskGP)


### PR DESCRIPTION
This PR adds the possibility to provide dataframes to the predict method that have columns with dtype 'object'.