### PR TITLE
allow n-choose-k when variable bounds don't contain 0

### DIFF
--- a/bofire/data_models/domain/domain.py
+++ b/bofire/data_models/domain/domain.py
@@ -198,35 +198,6 @@ class Domain(BaseModel):
                     ), f"{f} must be continuous."
         return v
 
-    @validator("constraints", always=True)
-    def validate_lower_bounds_in_nchoosek_constraints(cls, v, values):
-        """Validate the lower bound as well if the chosen number of allowed features is continuous.
-
-        Args:
-            v (List[Constraint]): List of all constraints defined for the domain
-            values (List[Input]): _description_
-
-        Returns:
-            List[Constraint]: List of constraints defined for the domain
-        """
-        # gather continuous input_features in dictionary
-        continuous_input_features_dict = {}
-        for f in values["input_features"]:
-            if type(f) is ContinuousInput:
-                continuous_input_features_dict[f.key] = f
-
-        # check if unfixed continuous features appearing in NChooseK constraints have lower bound of 0
-        for c in v:
-            if isinstance(c, NChooseKConstraint):
-                for f in c.features:
-                    assert (
-                        f in continuous_input_features_dict
-                    ), f"{f} must be continuous."
-                    assert (
-                        continuous_input_features_dict[f].lower_bound == 0
-                    ), f"lower bound of {f} must be 0 for NChooseK constraint."
-        return v
-
     def get_feature_reps_df(self) -> pd.DataFrame:
         """Returns a pandas dataframe describing the features contained in the optimization domain."""
         df = pd.DataFrame(

--- a/tests/bofire/strategies/doe/test_utils.py
+++ b/tests/bofire/strategies/doe/test_utils.py
@@ -640,92 +640,70 @@ def test_check_nchoosek_constraints_as_bounds():
     )
     check_nchoosek_constraints_as_bounds(domain)
 
-    # define domain: possible to formulate as bounds, with NChooseK and other constraints
-    with pytest.raises(ValueError):
-        domain = Domain(
-            input_features=[
-                ContinuousInput(key=f"x{1}", bounds=(0, 1)),
-                ContinuousInput(key=f"x{2}", bounds=(-1, 1)),
-                ContinuousInput(key=f"x{3}", bounds=(-2, 1)),
-                ContinuousInput(key=f"x{4}", bounds=(-3, 1)),
-            ],
-            output_features=[ContinuousOutput(key="y")],
-            constraints=[
-                LinearEqualityConstraint(
-                    features=["x1", "x2"], coefficients=[1, 1], rhs=0
-                ),
-                LinearInequalityConstraint(
-                    features=["x3", "x4"], coefficients=[1, 1], rhs=0
-                ),
-                NChooseKConstraint(
-                    features=["x1", "x2"],
-                    max_count=1,
-                    min_count=0,
-                    none_also_valid=True,
-                ),
-                NChooseKConstraint(
-                    features=["x3", "x4"],
-                    max_count=1,
-                    min_count=0,
-                    none_also_valid=True,
-                ),
-            ],
-        )
-        check_nchoosek_constraints_as_bounds(domain)
+    # n-choose-k constraints when variables can be negative
+    domain = Domain(
+        input_features=[
+            ContinuousInput(key=f"x{1}", bounds=(0, 1)),
+            ContinuousInput(key=f"x{2}", bounds=(-1, 1)),
+            ContinuousInput(key=f"x{3}", bounds=(-2, 1)),
+            ContinuousInput(key=f"x{4}", bounds=(-3, 1)),
+        ],
+        output_features=[ContinuousOutput(key="y")],
+        constraints=[
+            LinearEqualityConstraint(features=["x1", "x2"], coefficients=[1, 1], rhs=0),
+            LinearInequalityConstraint(
+                features=["x3", "x4"], coefficients=[1, 1], rhs=0
+            ),
+            NChooseKConstraint(
+                features=["x1", "x2"], max_count=1, min_count=0, none_also_valid=True
+            ),
+            NChooseKConstraint(
+                features=["x3", "x4"], max_count=1, min_count=0, none_also_valid=True
+            ),
+        ],
+    )
+    check_nchoosek_constraints_as_bounds(domain)
 
-    # define domain: not possible to formulate as bounds, invalid bounds
+    # It should be allowed to have n-choose-k constraints when 0 is not in the bounds.
+    domain = Domain(
+        input_features=[
+            ContinuousInput(key=f"x{i+1}", bounds=(0.1, 1)) for i in range(4)
+        ],
+        output_features=[ContinuousOutput(key="y")],
+        constraints=[
+            NChooseKConstraint(
+                features=["x1", "x2"],
+                max_count=1,
+                min_count=0,
+                none_also_valid=True,
+            ),
+        ],
+    )
     with pytest.raises(ValueError):
-        domain = Domain(
-            input_features=[
-                ContinuousInput(key=f"x{i+1}", bounds=(0.1, 1)) for i in range(4)
-            ],
-            output_features=[ContinuousOutput(key="y")],
-            constraints=[
-                NChooseKConstraint(
-                    features=["x1", "x2"],
-                    max_count=1,
-                    min_count=0,
-                    none_also_valid=True,
-                ),
-            ],
-        )
-        with pytest.raises(ValueError):
-            check_nchoosek_constraints_as_bounds(domain)
+        check_nchoosek_constraints_as_bounds(domain)  # FIXME: should be allowed
 
+    # It should be allowed to have n-choose-k constraints when 0 is not in the bounds.
+    domain = Domain(
+        input_features=[
+            ContinuousInput(key=f"x{1}", bounds=(-1, -0.1)),
+            ContinuousInput(key=f"x{2}", bounds=(-1, -0.1)),
+            ContinuousInput(key=f"x{3}", bounds=(-1, -0.1)),
+            ContinuousInput(key=f"x{4}", bounds=(-1, -0.1)),
+        ],
+        output_features=[ContinuousOutput(key="y")],
+        constraints=[
+            NChooseKConstraint(
+                features=["x1", "x2"],
+                max_count=1,
+                min_count=0,
+                none_also_valid=True,
+            ),
+        ],
+    )
     with pytest.raises(ValueError):
-        domain = Domain(
-            input_features=[
-                ContinuousInput(
-                    key=f"x{1}",
-                    bounds=(-1, -0.1),
-                ),
-                ContinuousInput(
-                    key=f"x{2}",
-                    bounds=(-1, -0.1),
-                ),
-                ContinuousInput(
-                    key=f"x{3}",
-                    bounds=(-1, -0.1),
-                ),
-                ContinuousInput(
-                    key=f"x{4}",
-                    bounds=(-1, -0.1),
-                ),
-            ],
-            output_features=[ContinuousOutput(key="y")],
-            constraints=[
-                NChooseKConstraint(
-                    features=["x1", "x2"],
-                    max_count=1,
-                    min_count=0,
-                    none_also_valid=True,
-                ),
-            ],
-        )
-        with pytest.raises(ValueError):
-            check_nchoosek_constraints_as_bounds(domain)
+        check_nchoosek_constraints_as_bounds(domain)  # FIXME: should be allowed
 
-    # define domain: not possible to formulate as bounds, names parameters of two NChooseK overlap
+    # Not allowed: names parameters of two NChooseK overlap
     domain = Domain(
         input_features=[
             ContinuousInput(key=f"x{i+1}", bounds=(0, 1)) for i in range(4)


### PR DESCRIPTION
As discussed we want to allow n-choose-k over variables whose bounds don't contain 0.

Example:

* x1 in [0.1, 1]
* x2 in [0.2, 1]
* x3 in [0.3, 1]
* n-choose-k([x1, x,2, x3], min_count=1, max_count=2)

means that 1-2 out 3 variables should be active, and when they are active their bounds apply.

DOE does not require this. BoTorch apparently does, so a check needs to be placed in the right place.

Closes #118 



