### PR TITLE
introduce stepsize for continuous inputs

### DIFF
--- a/bofire/data_models/features/continuous.py
+++ b/bofire/data_models/features/continuous.py
@@ -33,14 +33,18 @@ class ContinuousInput(NumericalInput):
 
     @validator("stepsize")
     def validate_step_size(cls, v, values):
+        if v is None:
+            return v
         lower, upper = values["bounds"]
         if lower == upper and v is not None:
             raise ValueError(
                 "Stepsize cannot be provided for a fixed continuous input."
             )
         range = upper - lower
-        if range % v != 0:
-            raise ValueError("Stepsize does not match the provided interval.")
+        if np.arange(lower, upper + v, v)[-1] != upper:
+            raise ValueError(
+                f"Stepsize of {v} does not match the provided interval [{lower},{upper}]."
+            )
         if range // v == 1:
             raise ValueError("Stepsize is too big, only one value allowed.")
         return v

--- a/bofire/data_models/features/continuous.py
+++ b/bofire/data_models/features/continuous.py
@@ -2,7 +2,7 @@ from typing import ClassVar, Literal, Optional, Tuple
 
 import numpy as np
 import pandas as pd
-from pydantic import Field, root_validator
+from pydantic import Field, root_validator, validator
 
 from bofire.data_models.features.feature import Output
 from bofire.data_models.features.numerical import NumericalInput
@@ -14,12 +14,14 @@ class ContinuousInput(NumericalInput):
 
     Attributes:
         bounds (Tuple[float, float]): A tuple that stores the lower and upper bound of the feature.
+        stepsize (float, optional): Float indicating the allowed stepsize between lower and upper. Defaults to None.
     """
 
     type: Literal["ContinuousInput"] = "ContinuousInput"
     order_id: ClassVar[int] = 1
 
     bounds: Tuple[float, float]
+    stepsize: Optional[float] = None
 
     @property
     def lower_bound(self) -> float:
@@ -28,6 +30,41 @@ class ContinuousInput(NumericalInput):
     @property
     def upper_bound(self) -> float:
         return self.bounds[1]
+
+    @validator("stepsize")
+    def validate_step_size(cls, v, values):
+        lower, upper = values["bounds"]
+        if lower == upper and v is not None:
+            raise ValueError(
+                "Stepsize cannot be provided for a fixed continuous input."
+            )
+        range = upper - lower
+        if range % v != 0:
+            raise ValueError("Stepsize does not match the provided interval.")
+        if range // v == 1:
+            raise ValueError("Stepsize is too big, only one value allowed.")
+        return v
+
+    def round(self, values: pd.Series) -> pd.Series:
+        """Round values to the stepsize of the feature. If no stepsize is provided return the
+        provided values.
+
+        Args:
+            values (pd.Series): The values that should be rounded.
+
+        Returns:
+            pd.Series: The rounded values
+        """
+        if self.stepsize is None:
+            return values
+        self.validate_candidental(values=values)
+        allowed_values = np.arange(
+            self.lower_bound, self.upper_bound + self.stepsize, self.stepsize
+        )
+        idx = abs(values.values.reshape([3, 1]) - allowed_values).argmin(axis=1)  # type: ignore
+        return pd.Series(
+            data=self.lower_bound + idx * self.stepsize, index=values.index
+        )
 
     @root_validator(pre=False, skip_on_failure=True)
     def validate_lower_upper(cls, values):

--- a/tests/bofire/data_models/serialization/test_serialization.py
+++ b/tests/bofire/data_models/serialization/test_serialization.py
@@ -28,6 +28,7 @@ def test_objective_should_be_serializable(objective_spec: Spec):
 def test_feature_should_be_serializable(feature_spec: Spec):
     spec = feature_spec.typed_spec()
     obj = feature_spec.cls(**spec)
+    print(spec)
     assert obj.dict() == spec
 
 

--- a/tests/bofire/data_models/specs/features.py
+++ b/tests/bofire/data_models/specs/features.py
@@ -32,6 +32,7 @@ specs.add_valid(
         "key": str(uuid.uuid4()),
         "bounds": (3, 5.3),
         "unit": random.choice(["°C", "mg", "mmol/l", None]),
+        "stepsize": None,
     },
 )
 specs.add_valid(
@@ -42,6 +43,7 @@ specs.add_valid(
         "descriptors": ["d1", "d2"],
         "values": [1.0, 2.0],
         "unit": random.choice(["°C", "mg", "mmol/l", None]),
+        "stepsize": None,
     },
 )
 specs.add_valid(

--- a/tests/bofire/data_models/test_features.py
+++ b/tests/bofire/data_models/test_features.py
@@ -84,6 +84,23 @@ def test_continuous_input_feature_is_fixed(input_feature, expected, expected_val
     assert input_feature.fixed_value() == expected_value
 
 
+def test_continuous_input_invalid_stepsize():
+    with pytest.raises(ValueError):
+        ContinuousInput(key="a", bounds=(1, 1), stepsize=0)
+    with pytest.raises(ValueError):
+        ContinuousInput(key="a", bounds=(0, 5), stepsize=0.3)
+    with pytest.raises(ValueError):
+        ContinuousInput(key="a", bounds=(0, 1), stepsize=1)
+
+
+def test_continuous_input_round():
+    feature = ContinuousInput(key="a", bounds=(0, 5))
+    values = pd.Series([1.0, 1.3, 0.55])
+    assert_series_equal(values, feature.round(values))
+    feature = ContinuousInput(key="a", bounds=(0, 5), stepsize=0.25)
+    assert_series_equal(pd.Series([1.0, 1.25, 0.5]), feature.round(values))
+
+
 @pytest.mark.parametrize(
     "input_feature, expected",
     [

--- a/tests/bofire/data_models/test_features.py
+++ b/tests/bofire/data_models/test_features.py
@@ -99,6 +99,8 @@ def test_continuous_input_round():
     assert_series_equal(values, feature.round(values))
     feature = ContinuousInput(key="a", bounds=(0, 5), stepsize=0.25)
     assert_series_equal(pd.Series([1.0, 1.25, 0.5]), feature.round(values))
+    feature = ContinuousInput(key="a", bounds=(0, 5), stepsize=0.1)
+    assert_series_equal(pd.Series([1.0, 1.3, 0.5]), feature.round(values))
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
This PR introduces a `stepsize` attribute for the continuous input feature. This touches the smart rounding PR of @dlinzner-bcs: https://github.com/experimental-design/bofire/pull/178

I thought about precision vs stepsize again this morning and find the stepsize more intuitive for the user and more expressive. Furthermore, we can then also catch that the upper bound is allowed by the step size and raise an error if not. For the other PR, this means that we have to implement it there on a per feature basis and slightly change it to the stepsize definition, which should be very easy.



