### PR TITLE
remove gpytorch dependency from data models

### DIFF
--- a/bofire/data_models/kernels/aggregation.py
+++ b/bofire/data_models/kernels/aggregation.py
@@ -1,7 +1,4 @@
-from typing import List, Literal, Optional, Sequence, Union
-
-import gpytorch
-import torch
+from typing import Literal, Optional, Sequence, Union
 
 from bofire.data_models.kernels.categorical import HammondDistanceKernel
 from bofire.data_models.kernels.continuous import LinearKernel, MaternKernel, RBFKernel
@@ -24,20 +21,6 @@ class AdditiveKernel(Kernel):
     ]
     type: Literal["AdditiveKernel"] = "AdditiveKernel"
 
-    def to_gpytorch(
-        self, batch_shape: torch.Size, ard_num_dims: int, active_dims: List[int]
-    ) -> gpytorch.kernels.AdditiveKernel:
-        return gpytorch.kernels.AdditiveKernel(
-            *[  # type: ignore
-                k.to_gpytorch(
-                    batch_shape=batch_shape,
-                    ard_num_dims=ard_num_dims,
-                    active_dims=active_dims,
-                )
-                for k in self.kernels
-            ]
-        )
-
 
 class MultiplicativeKernel(Kernel):
     type: Literal["MultiplicativeKernel"] = "MultiplicativeKernel"
@@ -53,20 +36,6 @@ class MultiplicativeKernel(Kernel):
         ]
     ]
 
-    def to_gpytorch(
-        self, batch_shape: torch.Size, ard_num_dims: int, active_dims: List[int]
-    ) -> gpytorch.kernels.AdditiveKernel:
-        return gpytorch.kernels.ProductKernel(
-            *[  # type: ignore
-                k.to_gpytorch(
-                    batch_shape=batch_shape,
-                    ard_num_dims=ard_num_dims,
-                    active_dims=active_dims,
-                )
-                for k in self.kernels
-            ]
-        )
-
 
 class ScaleKernel(Kernel):
     type: Literal["ScaleKernel"] = "ScaleKernel"
@@ -80,20 +49,6 @@ class ScaleKernel(Kernel):
         "ScaleKernel",
     ]
     outputscale_prior: Optional[AnyPrior] = None
-
-    def to_gpytorch(
-        self, batch_shape: torch.Size, ard_num_dims: int, active_dims: List[int]
-    ) -> gpytorch.kernels.ScaleKernel:
-        return gpytorch.kernels.ScaleKernel(
-            base_kernel=self.base_kernel.to_gpytorch(
-                batch_shape=batch_shape,
-                ard_num_dims=ard_num_dims,
-                active_dims=active_dims,
-            ),
-            outputscale_prior=self.outputscale_prior.to_gpytorch()
-            if self.outputscale_prior is not None
-            else None,
-        )
 
 
 AdditiveKernel.update_forward_refs()

--- a/bofire/data_models/kernels/categorical.py
+++ b/bofire/data_models/kernels/categorical.py
@@ -1,7 +1,4 @@
-from typing import List, Literal
-
-import torch
-from gpytorch.kernels import Kernel as GpytorchKernel
+from typing import Literal
 
 from bofire.data_models.kernels.kernel import Kernel
 
@@ -13,8 +10,3 @@ class CategoricalKernel(Kernel):
 class HammondDistanceKernel(CategoricalKernel):
     type: Literal["HammondDistanceKernel"] = "HammondDistanceKernel"
     ard: bool = True
-
-    def to_gpytorch(
-        self, batch_shape: torch.Size, ard_num_dims: int, active_dims: List[int]
-    ) -> GpytorchKernel:
-        raise NotImplementedError

--- a/bofire/data_models/kernels/continuous.py
+++ b/bofire/data_models/kernels/continuous.py
@@ -1,7 +1,4 @@
-from typing import List, Literal, Optional
-
-import gpytorch
-import torch
+from typing import Literal, Optional
 
 from bofire.data_models.kernels.kernel import Kernel
 from bofire.data_models.priors.api import AnyPrior
@@ -16,18 +13,6 @@ class RBFKernel(ContinuousKernel):
     ard: bool = True
     lengthscale_prior: Optional[AnyPrior] = None
 
-    def to_gpytorch(
-        self, batch_shape: torch.Size, ard_num_dims: int, active_dims: List[int]
-    ) -> gpytorch.kernels.RBFKernel:
-        return gpytorch.kernels.RBFKernel(
-            batch_shape=batch_shape,
-            ard_num_dims=len(active_dims) if self.ard else None,
-            active_dims=active_dims,  # type: ignore
-            lengthscale_prior=self.lengthscale_prior.to_gpytorch()
-            if self.lengthscale_prior is not None
-            else None,
-        )
-
 
 class MaternKernel(ContinuousKernel):
     type: Literal["MaternKernel"] = "MaternKernel"
@@ -35,26 +20,6 @@ class MaternKernel(ContinuousKernel):
     nu: float = 2.5
     lengthscale_prior: Optional[AnyPrior] = None
 
-    def to_gpytorch(
-        self, batch_shape: torch.Size, ard_num_dims: int, active_dims: List[int]
-    ) -> gpytorch.kernels.MaternKernel:
-        return gpytorch.kernels.MaternKernel(
-            batch_shape=batch_shape,
-            ard_num_dims=len(active_dims) if self.ard else None,
-            active_dims=active_dims,
-            nu=self.nu,
-            lengthscale_prior=self.lengthscale_prior.to_gpytorch()
-            if self.lengthscale_prior is not None
-            else None,
-        )
-
 
 class LinearKernel(ContinuousKernel):
     type: Literal["LinearKernel"] = "LinearKernel"
-
-    def to_gpytorch(
-        self, batch_shape: torch.Size, ard_num_dims: int, active_dims: List[int]
-    ) -> gpytorch.kernels.LinearKernel:
-        return gpytorch.kernels.LinearKernel(
-            batch_shape=batch_shape, active_dims=active_dims
-        )

--- a/bofire/data_models/kernels/kernel.py
+++ b/bofire/data_models/kernels/kernel.py
@@ -1,17 +1,5 @@
-from abc import abstractmethod
-from typing import List
-
-import torch
-from gpytorch.kernels import Kernel as GpytorchKernel
-
 from bofire.data_models.base import BaseModel
 
 
 class Kernel(BaseModel):
     type: str
-
-    @abstractmethod
-    def to_gpytorch(
-        self, batch_shape: torch.Size, ard_num_dims: int, active_dims: List[int]
-    ) -> GpytorchKernel:
-        pass

--- a/bofire/data_models/priors/api.py
+++ b/bofire/data_models/priors/api.py
@@ -1,3 +1,4 @@
+from functools import partial
 from typing import Union
 
 from bofire.data_models.priors.gamma import GammaPrior
@@ -13,14 +14,14 @@ AnyPrior = Union[
 
 # default priors of interest
 # botorch defaults
-BOTORCH_LENGTHCALE_PRIOR = GammaPrior(concentration=3.0, rate=6.0)
-BOTORCH_NOISE_PRIOR = GammaPrior(concentration=1.1, rate=0.05)
-BOTORCH_SCALE_PRIOR = GammaPrior(concentration=2.0, rate=0.15)
+BOTORCH_LENGTHCALE_PRIOR = partial(GammaPrior, concentration=3.0, rate=6.0)
+BOTORCH_NOISE_PRIOR = partial(GammaPrior, concentration=1.1, rate=0.05)
+BOTORCH_SCALE_PRIOR = partial(GammaPrior, concentration=2.0, rate=0.15)
 
 # mbo priors
 # By default BoTorch places a highly informative prior on the kernel lengthscales,
 # which easily leads to overfitting. Here we set a broader prior distribution for the
 # lengthscale. The priors for the noise and signal variance are set more tightly.
-MBO_LENGTHCALE_PRIOR = GammaPrior(concentration=2.0, rate=0.2)
-MBO_NOISE_PRIOR = GammaPrior(concentration=2.0, rate=4.0)
-MBO_OUTPUTSCALE_PRIOR = GammaPrior(concentration=2.0, rate=4.0)
+MBO_LENGTHCALE_PRIOR = partial(GammaPrior, concentration=2.0, rate=0.2)
+MBO_NOISE_PRIOR = partial(GammaPrior, concentration=2.0, rate=4.0)
+MBO_OUTPUTSCALE_PRIOR = partial(GammaPrior, concentration=2.0, rate=4.0)

--- a/bofire/data_models/priors/gamma.py
+++ b/bofire/data_models/priors/gamma.py
@@ -1,6 +1,5 @@
 from typing import Literal
 
-import gpytorch
 from pydantic import PositiveFloat
 
 from bofire.data_models.priors.prior import Prior
@@ -17,8 +16,3 @@ class GammaPrior(Prior):
     type: Literal["GammaPrior"] = "GammaPrior"
     concentration: PositiveFloat
     rate: PositiveFloat
-
-    def to_gpytorch(self) -> gpytorch.priors.GammaPrior:
-        return gpytorch.priors.GammaPrior(
-            concentration=self.concentration, rate=self.rate
-        )

--- a/bofire/data_models/priors/normal.py
+++ b/bofire/data_models/priors/normal.py
@@ -1,6 +1,5 @@
 from typing import Literal
 
-import gpytorch
 from pydantic import PositiveFloat
 
 from bofire.data_models.priors.prior import Prior
@@ -17,6 +16,3 @@ class NormalPrior(Prior):
     type: Literal["NormalPrior"] = "NormalPrior"
     loc: float
     scale: PositiveFloat
-
-    def to_gpytorch(self) -> gpytorch.priors.NormalPrior:
-        return gpytorch.priors.NormalPrior(loc=self.loc, scale=self.scale)

--- a/bofire/data_models/priors/prior.py
+++ b/bofire/data_models/priors/prior.py
@@ -1,7 +1,3 @@
-from abc import abstractmethod
-
-import gpytorch
-
 from bofire.data_models.base import BaseModel
 
 
@@ -9,12 +5,3 @@ class Prior(BaseModel):
     """Abstract Prior class."""
 
     type: str
-
-    @abstractmethod
-    def to_gpytorch(self) -> gpytorch.priors.Prior:
-        """Transform prior to a gpytorch prior.
-
-        Returns:
-            gpytorch.priors.Prior: Equivalent gpytorch prior object.
-        """
-        pass

--- a/bofire/data_models/surrogates/single_task_gp.py
+++ b/bofire/data_models/surrogates/single_task_gp.py
@@ -3,7 +3,12 @@ from typing import Literal
 from pydantic import Field
 
 from bofire.data_models.kernels.api import AnyKernel, MaternKernel, ScaleKernel
-from bofire.data_models.priors.api import BOTORCH_LENGTHCALE_PRIOR, BOTORCH_SCALE_PRIOR
+from bofire.data_models.priors.api import (
+    BOTORCH_LENGTHCALE_PRIOR,
+    BOTORCH_NOISE_PRIOR,
+    BOTORCH_SCALE_PRIOR,
+    AnyPrior,
+)
 from bofire.data_models.surrogates.botorch import BotorchSurrogate
 from bofire.data_models.surrogates.scaler import ScalerEnum
 
@@ -16,9 +21,10 @@ class SingleTaskGPSurrogate(BotorchSurrogate):
             base_kernel=MaternKernel(
                 ard=True,
                 nu=2.5,
-                lengthscale_prior=BOTORCH_LENGTHCALE_PRIOR,
+                lengthscale_prior=BOTORCH_LENGTHCALE_PRIOR(),
             ),
-            outputscale_prior=BOTORCH_SCALE_PRIOR,
+            outputscale_prior=BOTORCH_SCALE_PRIOR(),
         )
     )
+    noise_prior: AnyPrior = Field(default_factory=lambda: BOTORCH_NOISE_PRIOR())
     scaler: ScalerEnum = ScalerEnum.NORMALIZE

--- a/bofire/kernels/api.py
+++ b/bofire/kernels/api.py
@@ -1,0 +1,1 @@
+from bofire.kernels.mapper import map  # noqa: F401

--- a/bofire/kernels/mapper.py
+++ b/bofire/kernels/mapper.py
@@ -1,0 +1,130 @@
+from typing import List
+
+import gpytorch
+import torch
+from gpytorch.kernels import Kernel as GpytorchKernel
+
+import bofire.data_models.kernels.api as data_models
+import bofire.priors.api as priors
+
+
+def map_RBFKernel(
+    data_model: data_models.RBFKernel,
+    batch_shape: torch.Size,
+    ard_num_dims: int,
+    active_dims: List[int],
+) -> gpytorch.kernels.RBFKernel:
+    return gpytorch.kernels.RBFKernel(
+        batch_shape=batch_shape,
+        ard_num_dims=len(active_dims) if data_model.ard else None,
+        active_dims=active_dims,  # type: ignore
+        lengthscale_prior=priors.map(data_model.lengthscale_prior)
+        if data_model.lengthscale_prior is not None
+        else None,
+    )
+
+
+def map_MaternKernel(
+    data_model: data_models.MaternKernel,
+    batch_shape: torch.Size,
+    ard_num_dims: int,
+    active_dims: List[int],
+) -> gpytorch.kernels.MaternKernel:
+    return gpytorch.kernels.MaternKernel(
+        batch_shape=batch_shape,
+        ard_num_dims=len(active_dims) if data_model.ard else None,
+        active_dims=active_dims,
+        nu=data_model.nu,
+        lengthscale_prior=priors.map(data_model.lengthscale_prior)
+        if data_model.lengthscale_prior is not None
+        else None,
+    )
+
+
+def map_LinearKernel(
+    data_model: data_models.LinearKernel,
+    batch_shape: torch.Size,
+    ard_num_dims: int,
+    active_dims: List[int],
+) -> gpytorch.kernels.LinearKernel:
+    return gpytorch.kernels.LinearKernel(
+        batch_shape=batch_shape, active_dims=active_dims
+    )
+
+
+def map_AdditiveKernel(
+    data_model: data_models.AdditiveKernel,
+    batch_shape: torch.Size,
+    ard_num_dims: int,
+    active_dims: List[int],
+) -> gpytorch.kernels.AdditiveKernel:
+    return gpytorch.kernels.AdditiveKernel(
+        *[  # type: ignore
+            map(
+                data_model=k,
+                batch_shape=batch_shape,
+                ard_num_dims=ard_num_dims,
+                active_dims=active_dims,
+            )
+            for k in data_model.kernels
+        ]
+    )
+
+
+def map_MultiplicativeKernel(
+    data_model: data_models.MultiplicativeKernel,
+    batch_shape: torch.Size,
+    ard_num_dims: int,
+    active_dims: List[int],
+) -> gpytorch.kernels.ProductKernel:
+    return gpytorch.kernels.ProductKernel(
+        *[  # type: ignore
+            map(
+                data_model=k,
+                batch_shape=batch_shape,
+                ard_num_dims=ard_num_dims,
+                active_dims=active_dims,
+            )
+            for k in data_model.kernels
+        ]
+    )
+
+
+def map_ScaleKernel(
+    data_model: data_models.ScaleKernel,
+    batch_shape: torch.Size,
+    ard_num_dims: int,
+    active_dims: List[int],
+) -> gpytorch.kernels.ScaleKernel:
+    return gpytorch.kernels.ScaleKernel(
+        base_kernel=map(
+            data_model.base_kernel,
+            batch_shape=batch_shape,
+            ard_num_dims=ard_num_dims,
+            active_dims=active_dims,
+        ),
+        outputscale_prior=priors.map(data_model.outputscale_prior)
+        if data_model.outputscale_prior is not None
+        else None,
+    )
+
+
+KERNEL_MAP = {
+    data_models.RBFKernel: map_RBFKernel,
+    data_models.MaternKernel: map_MaternKernel,
+    data_models.LinearKernel: map_LinearKernel,
+    data_models.AdditiveKernel: map_AdditiveKernel,
+    data_models.MultiplicativeKernel: map_MultiplicativeKernel,
+    data_models.ScaleKernel: map_ScaleKernel,
+}
+
+
+def map(
+    data_model: data_models.AnyKernel,
+    batch_shape: torch.Size,
+    ard_num_dims: int,
+    active_dims: List[int],
+) -> GpytorchKernel:
+    return KERNEL_MAP[data_model.__class__](  # type: ignore
+        data_model, batch_shape, ard_num_dims, active_dims
+    )

--- a/bofire/plot/prior.py
+++ b/bofire/plot/prior.py
@@ -4,6 +4,7 @@ import numpy as np
 import plotly.express as px
 import torch
 
+import bofire.priors.api as priors
 from bofire.data_models.priors.api import AnyPrior
 
 
@@ -29,7 +30,7 @@ def plot_prior_pdf_plotly(
 
     fig = px.line(
         x=x,
-        y=np.exp(prior.to_gpytorch().log_prob(torch.from_numpy(x)).numpy()),
+        y=np.exp(priors.map(prior).log_prob(torch.from_numpy(x)).numpy()),
     )
 
     if len(layout_options) > 0:

--- a/bofire/priors/api.py
+++ b/bofire/priors/api.py
@@ -1,0 +1,1 @@
+from bofire.priors.mapper import map  # noqa: F401

--- a/bofire/priors/mapper.py
+++ b/bofire/priors/mapper.py
@@ -1,0 +1,25 @@
+import gpytorch
+
+import bofire.data_models.priors.api as data_models
+
+
+def map_NormalPrior(data_model: data_models.NormalPrior) -> gpytorch.priors.NormalPrior:
+    return gpytorch.priors.NormalPrior(loc=data_model.loc, scale=data_model.scale)
+
+
+def map_GammaPrior(data_model: data_models.GammaPrior) -> gpytorch.priors.GammaPrior:
+    return gpytorch.priors.GammaPrior(
+        concentration=data_model.concentration, rate=data_model.rate
+    )
+
+
+PRIOR_MAP = {
+    data_models.NormalPrior: map_NormalPrior,
+    data_models.GammaPrior: map_GammaPrior,
+}
+
+
+def map(
+    data_model: data_models.AnyPrior,
+) -> gpytorch.priors.Prior:
+    return PRIOR_MAP[data_model.__class__](data_model)

--- a/bofire/surrogates/mixed_single_task_gp.py
+++ b/bofire/surrogates/mixed_single_task_gp.py
@@ -1,3 +1,4 @@
+from functools import partial
 from typing import Dict, Optional
 
 import botorch
@@ -8,6 +9,7 @@ from botorch.models.transforms.input import ChainedInputTransform, OneHotToNumer
 from botorch.models.transforms.outcome import Standardize
 from gpytorch.mlls import ExactMarginalLogLikelihood
 
+import bofire.kernels.api as kernels
 from bofire.data_models.enum import CategoricalEncodingEnum, OutputFilteringEnum
 from bofire.data_models.surrogates.api import MixedSingleTaskGPSurrogate as DataModel
 from bofire.surrogates.botorch import BotorchSurrogate
@@ -77,7 +79,8 @@ class MixedSingleTaskGPSurrogate(BotorchSurrogate, TrainableSurrogate):
             train_X=o2n.transform(tX),
             train_Y=tY,
             cat_dims=cat_dims,
-            cont_kernel_factory=self.continuous_kernel.to_gpytorch,
+            # cont_kernel_factory=self.continuous_kernel.to_gpytorch,
+            cont_kernel_factory=partial(kernels.map, data_model=self.continuous_kernel),
             outcome_transform=Standardize(m=tY.shape[-1]),
             input_transform=tf,
         )

--- a/bofire/surrogates/single_task_gp.py
+++ b/bofire/surrogates/single_task_gp.py
@@ -8,6 +8,7 @@ from botorch.models.transforms.input import InputStandardize, Normalize
 from botorch.models.transforms.outcome import Standardize
 from gpytorch.mlls import ExactMarginalLogLikelihood
 
+import bofire.kernels.api as kernels
 from bofire.data_models.domain.api import Inputs
 from bofire.data_models.enum import CategoricalEncodingEnum, OutputFilteringEnum
 from bofire.data_models.surrogates.api import SingleTaskGPSurrogate as DataModel
@@ -98,7 +99,8 @@ class SingleTaskGPSurrogate(BotorchSurrogate, TrainableSurrogate):
         self.model = botorch.models.SingleTaskGP(  # type: ignore
             train_X=tX,
             train_Y=tY,
-            covar_module=self.kernel.to_gpytorch(
+            covar_module=kernels.map(
+                self.kernel,
                 batch_shape=torch.Size(),
                 active_dims=list(range(tX.shape[1])),
                 ard_num_dims=1,  # this keyword is ingored

--- a/tests/bofire/data_models/specs/surrogates.py
+++ b/tests/bofire/data_models/specs/surrogates.py
@@ -13,7 +13,11 @@ from bofire.data_models.kernels.api import (
     MaternKernel,
     ScaleKernel,
 )
-from bofire.data_models.priors.api import BOTORCH_LENGTHCALE_PRIOR, BOTORCH_SCALE_PRIOR
+from bofire.data_models.priors.api import (
+    BOTORCH_LENGTHCALE_PRIOR,
+    BOTORCH_NOISE_PRIOR,
+    BOTORCH_SCALE_PRIOR,
+)
 from bofire.data_models.surrogates.api import ScalerEnum
 from tests.bofire.data_models.specs.features import specs as features
 from tests.bofire.data_models.specs.specs import Specs
@@ -79,11 +83,12 @@ specs.add_valid(
         ),
         "kernel": ScaleKernel(
             base_kernel=MaternKernel(
-                ard=True, nu=2.5, lengthscale_prior=BOTORCH_LENGTHCALE_PRIOR
+                ard=True, nu=2.5, lengthscale_prior=BOTORCH_LENGTHCALE_PRIOR()
             ),
-            outputscale_prior=BOTORCH_SCALE_PRIOR,
+            outputscale_prior=BOTORCH_SCALE_PRIOR(),
         ),
         "scaler": ScalerEnum.NORMALIZE,
+        "noise_prior": BOTORCH_NOISE_PRIOR(),
         "input_preprocessing_specs": {},
         "dump": None,
     },

--- a/tests/bofire/data_models/test_kernels.py
+++ b/tests/bofire/data_models/test_kernels.py
@@ -119,7 +119,9 @@ def test_valid_kernel_specs(cls, spec):
 
 
 def test_scale_kernel():
-    kernel = ScaleKernel(base_kernel=RBFKernel(), outputscale_prior=BOTORCH_SCALE_PRIOR)
+    kernel = ScaleKernel(
+        base_kernel=RBFKernel(), outputscale_prior=BOTORCH_SCALE_PRIOR()
+    )
     k = kernels.map(
         kernel,
         batch_shape=torch.Size(),

--- a/tests/bofire/data_models/test_priors.py
+++ b/tests/bofire/data_models/test_priors.py
@@ -1,6 +1,5 @@
 from typing import List
 
-import gpytorch.priors
 import pytest
 from pydantic.error_wrappers import ValidationError
 
@@ -77,19 +76,3 @@ def test_valid_prior_specs(cls, spec):
 def test_invalid_prior_specs(cls, spec):
     with pytest.raises((ValueError, TypeError, KeyError, ValidationError)):
         _ = cls(**spec)
-
-
-@pytest.mark.parametrize(
-    "prior, expected_prior",
-    [
-        (GammaPrior(concentration=2.0, rate=0.2), gpytorch.priors.GammaPrior),
-        (NormalPrior(loc=0, scale=0.5), gpytorch.priors.NormalPrior),
-    ],
-)
-def test_prior(prior, expected_prior):
-    gprior = prior.to_gpytorch()
-    assert isinstance(gprior, expected_prior)
-    for key, value in prior.dict().items():
-        if key == "type":
-            continue
-        assert value == getattr(gprior, key)

--- a/tests/bofire/plot/test_plot_prior.py
+++ b/tests/bofire/plot/test_plot_prior.py
@@ -3,4 +3,4 @@ from bofire.plot.api import plot_prior_pdf_plotly
 
 
 def test_plot_prior_pdf_plotly():
-    plot_prior_pdf_plotly(BOTORCH_LENGTHCALE_PRIOR, lower=0, upper=10)
+    plot_prior_pdf_plotly(BOTORCH_LENGTHCALE_PRIOR(), lower=0, upper=10)

--- a/tests/bofire/priors/test_priors.py
+++ b/tests/bofire/priors/test_priors.py
@@ -1,0 +1,21 @@
+import gpytorch.priors
+import pytest
+
+import bofire.priors.api as priors
+from bofire.data_models.priors.api import GammaPrior, NormalPrior
+
+
+@pytest.mark.parametrize(
+    "prior, expected_prior",
+    [
+        (GammaPrior(concentration=2.0, rate=0.2), gpytorch.priors.GammaPrior),
+        (NormalPrior(loc=0, scale=0.5), gpytorch.priors.NormalPrior),
+    ],
+)
+def test_map(prior, expected_prior):
+    gprior = priors.map(prior)
+    assert isinstance(gprior, expected_prior)
+    for key, value in prior.dict().items():
+        if key == "type":
+            continue
+        assert value == getattr(gprior, key)


### PR DESCRIPTION
This PR removes the `to_gpytorch` methods for `Prior`s and `Kernel`s and replace it with a `map` method as for the other `data_models`.

This was necessary in-order to implement custom kernels at the correct place without circular imports (have a look at PR https://github.com/experimental-design/bofire/pull/194). 

Furthermore, this has the advantage that there is no pytorch/gpytorch/botorch dependency anymore in `bofire.data_models`. 

