### PR TITLE
Add option not to raise validation error in strategy.ask()

### DIFF
--- a/bofire/data_models/constraints/api.py
+++ b/bofire/data_models/constraints/api.py
@@ -1,6 +1,6 @@
 from typing import Union
 
-from bofire.data_models.constraints.constraint import Constraint
+from bofire.data_models.constraints.constraint import Constraint, ConstraintNotFulfilledError
 from bofire.data_models.constraints.linear import (
     LinearConstraint,
     LinearEqualityConstraint,
@@ -26,3 +26,5 @@ AnyConstraint = Union[
     NonlinearInequalityConstraint,
     NChooseKConstraint,
 ]
+
+# %%

--- a/bofire/data_models/constraints/api.py
+++ b/bofire/data_models/constraints/api.py
@@ -1,6 +1,10 @@
 from typing import Union
 
-from bofire.data_models.constraints.constraint import Constraint, ConstraintNotFulfilledError
+from bofire.data_models.constraints.constraint import (
+    Constraint,
+    ConstraintError,
+    ConstraintNotFulfilledError,
+)
 from bofire.data_models.constraints.linear import (
     LinearConstraint,
     LinearEqualityConstraint,
@@ -26,5 +30,7 @@ AnyConstraint = Union[
     NonlinearInequalityConstraint,
     NChooseKConstraint,
 ]
+
+AnyConstraintError = Union[ConstraintError, ConstraintNotFulfilledError]
 
 # %%

--- a/bofire/data_models/constraints/constraint.py
+++ b/bofire/data_models/constraints/constraint.py
@@ -53,11 +53,13 @@ class Constraint(BaseModel):
 
 class ConstraintError(Exception):
     """Base Error for Constraints"""
+
     pass
 
 
 class ConstraintNotFulfilledError(ConstraintError):
     """Raised when an constraint is not fulfilled."""
+
     pass
 
 

--- a/bofire/data_models/constraints/constraint.py
+++ b/bofire/data_models/constraints/constraint.py
@@ -51,5 +51,15 @@ class Constraint(BaseModel):
         pass
 
 
+class ConstraintError(Exception):
+    """Base Error for Constraints"""
+    pass
+
+
+class ConstraintNotFulfilledError(ConstraintError):
+    """Raised when an constraint is not fulfilled."""
+    pass
+
+
 FeatureKeys = Annotated[List[str], Field(min_items=2)]
 Coefficients = Annotated[List[float], Field(min_items=2)]

--- a/bofire/data_models/constraints/nonlinear.py
+++ b/bofire/data_models/constraints/nonlinear.py
@@ -23,7 +23,6 @@ class NonlinearConstraint(Constraint):
         return experiments.eval(self.expression)
 
     def jacobian(self, experiments: pd.DataFrame) -> pd.DataFrame:
-
         if self.jacobian_expression is not None:
             res = experiments.eval(self.jacobian_expression)
             for i, col in enumerate(res):

--- a/bofire/data_models/domain/domain.py
+++ b/bofire/data_models/domain/domain.py
@@ -21,9 +21,9 @@ from pydantic import Field, validator
 from bofire.data_models.base import BaseModel
 from bofire.data_models.constraints.api import (
     AnyConstraint,
+    ConstraintNotFulfilledError,
     LinearConstraint,
     NChooseKConstraint,
-    ConstraintNotFulfilledError
 )
 from bofire.data_models.domain.constraints import Constraints
 from bofire.data_models.domain.features import Features, Inputs, Outputs
@@ -583,7 +583,9 @@ class Domain(BaseModel):
         self.inputs.validate_inputs(candidates)
         # check if all constraints are fulfilled
         if not self.constraints.is_fulfilled(candidates, tol=tol).all():
-            raise ConstraintNotFulfilledError(f"Constraints not fulfilled: {candidates}")
+            raise ConstraintNotFulfilledError(
+                f"Constraints not fulfilled: {candidates}"
+            )
         # for each continuous output feature with an attached objective object
         if not only_inputs:
             assert isinstance(self.outputs, Outputs)

--- a/bofire/data_models/domain/domain.py
+++ b/bofire/data_models/domain/domain.py
@@ -23,6 +23,7 @@ from bofire.data_models.constraints.api import (
     AnyConstraint,
     LinearConstraint,
     NChooseKConstraint,
+    ConstraintNotFulfilledError
 )
 from bofire.data_models.domain.constraints import Constraints
 from bofire.data_models.domain.features import Features, Inputs, Outputs
@@ -571,8 +572,8 @@ class Domain(BaseModel):
             ValueError: when a column is missing for a defined input feature
             ValueError: when a column is missing for a defined output feature
             ValueError: when a non-numerical value is proposed
-            ValueError: when the constraints are not fulfilled
             ValueError: when an additional column is found
+            ConstraintNotFulfilledError: when the constraints are not fulfilled
 
         Returns:
             pd.DataFrame: dataframe with suggested experiments (candidates)
@@ -582,7 +583,7 @@ class Domain(BaseModel):
         self.inputs.validate_inputs(candidates)
         # check if all constraints are fulfilled
         if not self.constraints.is_fulfilled(candidates, tol=tol).all():
-            raise ValueError(f"Constraints not fulfilled: {candidates}")
+            raise ConstraintNotFulfilledError(f"Constraints not fulfilled: {candidates}")
         # for each continuous output feature with an attached objective object
         if not only_inputs:
             assert isinstance(self.outputs, Outputs)

--- a/bofire/strategies/predictives/predictive.py
+++ b/bofire/strategies/predictives/predictive.py
@@ -1,4 +1,3 @@
-import warnings
 from abc import abstractmethod
 from typing import List, Optional, Tuple
 
@@ -6,7 +5,6 @@ import numpy as np
 import pandas as pd
 from pydantic import PositiveInt
 
-from bofire.data_models.constraints.api import ConstraintNotFulfilledError
 from bofire.data_models.features.api import TInputTransformSpecs
 from bofire.data_models.strategies.api import Strategy as DataModel
 from bofire.strategies.data_models.candidate import Candidate
@@ -55,12 +53,9 @@ class PredictiveStrategy(Strategy):
             add_pending=add_pending,
             raise_validation_error=raise_validation_error,
         )
-        try:
-            self.domain.validate_candidates(candidates=candidates)
-        except ConstraintNotFulfilledError as e:
-            if raise_validation_error:
-                raise e
-            warnings.warn("Not all constraints are fulfilled for the candidates.")
+        self.domain.validate_candidates(
+            candidates=candidates, raise_validation_error=raise_validation_error
+        )
         return candidates
 
     def tell(

--- a/bofire/strategies/strategy.py
+++ b/bofire/strategies/strategy.py
@@ -1,4 +1,3 @@
-import warnings
 from abc import ABC, abstractmethod
 from typing import List, Optional
 
@@ -6,7 +5,6 @@ import numpy as np
 import pandas as pd
 from pydantic import PositiveInt
 
-from bofire.data_models.constraints.api import ConstraintNotFulfilledError
 from bofire.data_models.strategies.api import Strategy as DataModel
 from bofire.strategies.data_models.candidate import Candidate
 from bofire.strategies.data_models.values import InputValue
@@ -120,12 +118,11 @@ class Strategy(ABC):
 
         candidates = self._ask(candidate_count=candidate_count)
 
-        try:
-            self.domain.validate_candidates(candidates=candidates, only_inputs=True)
-        except ConstraintNotFulfilledError as e:
-            if raise_validation_error:
-                raise e
-            warnings.warn("Not all constraints are fulfilled for the candidates.")
+        self.domain.validate_candidates(
+            candidates=candidates,
+            only_inputs=True,
+            raise_validation_error=raise_validation_error,
+        )
 
         if candidate_count is not None:
             if len(candidates) != candidate_count:

--- a/bofire/strategies/strategy.py
+++ b/bofire/strategies/strategy.py
@@ -1,10 +1,10 @@
+import warnings
 from abc import ABC, abstractmethod
 from typing import List, Optional
 
 import numpy as np
 import pandas as pd
 from pydantic import PositiveInt
-import warnings
 
 from bofire.data_models.constraints.api import ConstraintNotFulfilledError
 from bofire.data_models.strategies.api import Strategy as DataModel
@@ -89,7 +89,7 @@ class Strategy(ABC):
         self,
         candidate_count: Optional[PositiveInt] = None,
         add_pending: bool = False,
-        raise_validation_error: bool = True
+        raise_validation_error: bool = True,
     ) -> pd.DataFrame:
         """Function to generate new candidates.
 

--- a/tests/bofire/data_models/test_domain_validators.py
+++ b/tests/bofire/data_models/test_domain_validators.py
@@ -346,8 +346,25 @@ def test_domain_validate_candidates_not_numerical(
 
 
 @pytest.mark.parametrize(
-    "domain, candidates", [(d, generate_candidates(d)) for d in [domain7]]
+    "domain, candidates, raise_validation_error",
+    [
+        (d, generate_candidates(d), raise_validation_error)
+        for d in [domain7]
+        for raise_validation_error in [True, False]
+    ],
 )
-def test_domain_validate_candidates_constraint_not_fulfilled(domain, candidates):
-    with pytest.raises(ConstraintNotFulfilledError):
-        domain.validate_candidates(candidates)
+def test_domain_validate_candidates_constraint_not_fulfilled(
+    domain, candidates, raise_validation_error
+):
+    if raise_validation_error:
+        with pytest.raises(ConstraintNotFulfilledError):
+            domain.validate_candidates(
+                candidates, raise_validation_error=raise_validation_error
+            )
+    else:
+        assert isinstance(
+            domain.validate_candidates(
+                candidates, raise_validation_error=raise_validation_error
+            ),
+            pd.DataFrame,
+        )

--- a/tests/bofire/data_models/test_domain_validators.py
+++ b/tests/bofire/data_models/test_domain_validators.py
@@ -7,7 +7,10 @@ import pandas as pd
 import pytest
 
 import tests.bofire.data_models.specs.api as specs
-from bofire.data_models.constraints.api import LinearEqualityConstraint
+from bofire.data_models.constraints.api import (
+    ConstraintNotFulfilledError,
+    LinearEqualityConstraint,
+)
 from bofire.data_models.domain.api import Domain
 from bofire.data_models.features.api import (
     CategoricalDescriptorInput,
@@ -346,5 +349,5 @@ def test_domain_validate_candidates_not_numerical(
     "domain, candidates", [(d, generate_candidates(d)) for d in [domain7]]
 )
 def test_domain_validate_candidates_constraint_not_fulfilled(domain, candidates):
-    with pytest.raises(ValueError):
+    with pytest.raises(ConstraintNotFulfilledError):
         domain.validate_candidates(candidates)

--- a/tests/bofire/strategies/test_ask.py
+++ b/tests/bofire/strategies/test_ask.py
@@ -1,4 +1,5 @@
 import random
+from unittest import mock
 
 import pandas as pd
 import pytest
@@ -7,6 +8,7 @@ import bofire.data_models.strategies.api as data_models
 import bofire.strategies.api as strategies
 from bofire.benchmarks.multi import DTLZ2
 from bofire.benchmarks.single import Ackley
+from bofire.data_models.constraints.api import ConstraintNotFulfilledError
 from bofire.data_models.strategies.api import (
     PolytopeSampler as PolytopeSamplerDataModel,
 )
@@ -95,3 +97,48 @@ def test_ask_multi_objective(cls, spec, use_ref_point, candidate_count):
     assert len(candidates) == candidate_count
 
     # TODO: add check of convergence towards the optimum (0)
+
+
+@pytest.mark.parametrize(
+    "cls, spec, raise_validation_error, candidate_count",
+    [
+        (cls, specs, raise_validation_error, random.randint(1, 2))
+        for cls, specs in STRATEGY_SPECS_SINGLE_OBJECTIVE.items()
+        for raise_validation_error in [True, False]
+    ],
+)
+def test_ask_candidate_validation(cls, spec, raise_validation_error, candidate_count):
+    # generate data
+    benchmark = Ackley(categorical=False, descriptor=False)
+    random_strategy = PolytopeSampler(
+        data_model=PolytopeSamplerDataModel(domain=benchmark.domain)
+    )
+    experiments = benchmark.f(random_strategy.ask(10), return_complete=True)
+
+    # set up of the strategy
+    data_model = cls(**{**spec, "domain": benchmark.domain})
+    print("data_model:", type(data_model))
+    strategy = strategies.map(data_model)
+    strategy.tell(experiments)
+
+    # mock validation method to always raise ConstraintNotFulfilledError
+    # use __setattr__ for pydantic reasons
+    object.__setattr__(
+        strategy.domain,
+        "validate_candidates",
+        mock.MagicMock(side_effect=ConstraintNotFulfilledError("test error")),
+    )
+
+    # ask
+    if raise_validation_error:
+        with pytest.raises(ConstraintNotFulfilledError):
+            candidates = strategy.ask(
+                candidate_count=candidate_count,
+                raise_validation_error=raise_validation_error,
+            )
+    else:
+        candidates = strategy.ask(
+            candidate_count=candidate_count,
+            raise_validation_error=raise_validation_error,
+        )
+        assert isinstance(candidates, pd.DataFrame)


### PR DESCRIPTION
Sometimes `strategy.ask()` raises errors during the validation of the generated candidates in `self.domain.validate_candidates(...)` with the explanation that some constraint is violated. In some cases it might still be useful to return the candidates, though. Therefore I added a boolean argument `raise_validation_error` to `strategy.ask()`. If it is `True` an error will still be raised (default behaviour). If it is `False` only a warning will be displayed and the candidates will be returned regardless of the constraint violations.

To achieve this, I created a new class of `ConstraintNotFulfilledError` to differentiate it from other errors that can be raised in `validate_candidates`. Other `ConstraintErrors` might be worth a thought as well.  I could think of a `ConstraintInfeasibleError` for cases where multiple constraints contradict each other (e.g. $x > 1$ and $x < 0$ where no value for $x$ is possible).