### PR TITLE
New input scaler, ScalerEnum.NONE

### DIFF
--- a/bofire/data_models/surrogates/scaler.py
+++ b/bofire/data_models/surrogates/scaler.py
@@ -8,4 +8,4 @@ class ScalerEnum(Enum):
 
     NORMALIZE = "NORMALIZE"
     STANDARDIZE = "STANDARDIZE"
-    NONE = "NONE"
+    IDENTITY = "IDENTITY"

--- a/bofire/data_models/surrogates/scaler.py
+++ b/bofire/data_models/surrogates/scaler.py
@@ -8,3 +8,4 @@ class ScalerEnum(Enum):
 
     NORMALIZE = "NORMALIZE"
     STANDARDIZE = "STANDARDIZE"
+    NONE = "NONE"

--- a/bofire/surrogates/mixed_single_task_gp.py
+++ b/bofire/surrogates/mixed_single_task_gp.py
@@ -72,7 +72,7 @@ class MixedSingleTaskGPSurrogate(BotorchSurrogate, TrainableSurrogate):
             categorical_features=categorical_features,
             transform_on_train=False,
         )
-        tf = ChainedInputTransform(tf1=scaler, tf2=o2n)
+        tf = ChainedInputTransform(tf1=scaler, tf2=o2n) if scaler is not None else o2n
 
         # fit the model
         self.model = botorch.models.MixedSingleTaskGP(

--- a/bofire/surrogates/mlp.py
+++ b/bofire/surrogates/mlp.py
@@ -188,7 +188,7 @@ class MLPEnsemble(BotorchSurrogate, TrainableSurrogate):
             ty = torch.from_numpy(Y.values[sample_idx]).to(**tkwargs)
 
             dataset = RegressionDataSet(
-                X=scaler.transform(tX),
+                X=scaler.transform(tX) if scaler is not None else tX,
                 y=ty,
             )
             mlp = MLP(
@@ -209,4 +209,5 @@ class MLPEnsemble(BotorchSurrogate, TrainableSurrogate):
             )
             mlps.append(mlp)
         self.model = _MLPEnsemble(mlps=mlps)
-        self.model.input_transform = scaler
+        if scaler is not None:
+            self.model.input_transform = scaler

--- a/bofire/surrogates/single_task_gp.py
+++ b/bofire/surrogates/single_task_gp.py
@@ -58,7 +58,9 @@ def get_scaler(
                 ord_dims += features2idx[feat.key]
 
         if scaler == ScalerEnum.NORMALIZE:
-            lower, upper = inputs.get_bounds(specs=input_preprocessing_specs, experiments=X)
+            lower, upper = inputs.get_bounds(
+                specs=input_preprocessing_specs, experiments=X
+            )
             scaler_transform = Normalize(
                 d=d,
                 bounds=torch.tensor([lower, upper]).to(**tkwargs),
@@ -76,6 +78,7 @@ def get_scaler(
         return scaler_transform
     else:
         return None
+
 
 class SingleTaskGPSurrogate(BotorchSurrogate, TrainableSurrogate):
     def __init__(

--- a/bofire/surrogates/single_task_gp.py
+++ b/bofire/surrogates/single_task_gp.py
@@ -39,7 +39,7 @@ def get_scaler(
     Returns:
         Union[InputStandardize, Normalize]: The instantiated scaler class
     """
-    if scaler != ScalerEnum.NONE:
+    if scaler != ScalerEnum.IDENTITY:
         features2idx, _ = inputs._get_transform_info(input_preprocessing_specs)
 
         d = 0

--- a/tests/bofire/surrogates/test_gps.py
+++ b/tests/bofire/surrogates/test_gps.py
@@ -137,21 +137,9 @@ def test_get_scaler(
     assert isinstance(scaler, expected_scaler)
     if expected_indices is not None:
         assert (scaler.indices == expected_indices).all()
-    else:
-        with pytest.raises(AttributeError):
-            scaler.indices
     if expected_offset is not None:
         assert torch.allclose(scaler.offset, expected_offset)
         assert torch.allclose(scaler.coefficient, expected_coefficient)
-    else:
-        if scaler is None:
-            with pytest.raises(AttributeError):
-                scaler.offset
-            with pytest.raises(AttributeError):
-                scaler.coefficient
-        else:
-            scaler.offset == expected_offset
-            scaler.coefficient == expected_coefficient
 
 
 @pytest.mark.parametrize(
@@ -202,9 +190,6 @@ def test_SingleTaskGPModel(kernel, scaler):
         assert isinstance(model.model.input_transform, Normalize)
     elif scaler == ScalerEnum.STANDARDIZE:
         assert isinstance(model.model.input_transform, InputStandardize)
-    else:
-        with pytest.raises(AttributeError):
-            model.model.input_transform
     assert model.is_compatibilized is False
     # reload the model from dump and check for equality in predictions
     model2 = SingleTaskGPSurrogate(

--- a/tests/bofire/surrogates/test_gps.py
+++ b/tests/bofire/surrogates/test_gps.py
@@ -135,7 +135,7 @@ def test_get_scaler(
         X=experiments[inputs.get_keys()],
     )
     assert isinstance(scaler, expected_scaler)
-    if expected_indices is not None:        
+    if expected_indices is not None:
         assert (scaler.indices == expected_indices).all()
     else:
         with pytest.raises(AttributeError):
@@ -288,14 +288,16 @@ def test_MixedGPModel(kernel, scaler):
         assert isinstance(model.model.input_transform, ChainedInputTransform)
         assert isinstance(model.model.input_transform.tf1, Normalize)
         assert torch.eq(
-        model.model.input_transform.tf1.indices, torch.tensor([0, 1], dtype=torch.int64)
+            model.model.input_transform.tf1.indices,
+            torch.tensor([0, 1], dtype=torch.int64),
         ).all()
         assert isinstance(model.model.input_transform.tf2, OneHotToNumeric)
     elif scaler == ScalerEnum.STANDARDIZE:
         assert isinstance(model.model.input_transform, ChainedInputTransform)
         assert isinstance(model.model.input_transform.tf1, InputStandardize)
         assert torch.eq(
-        model.model.input_transform.tf1.indices, torch.tensor([0, 1], dtype=torch.int64)
+            model.model.input_transform.tf1.indices,
+            torch.tensor([0, 1], dtype=torch.int64),
         ).all()
         assert isinstance(model.model.input_transform.tf2, OneHotToNumeric)
     else:

--- a/tests/bofire/surrogates/test_gps.py
+++ b/tests/bofire/surrogates/test_gps.py
@@ -135,7 +135,7 @@ def test_get_scaler(
         X=experiments[inputs.get_keys()],
     )
     assert isinstance(scaler, expected_scaler)
-    if expected_indices is not None:        
+    if expected_indices is not None:
         assert (scaler.indices == expected_indices).all()
     else:
         with pytest.raises(AttributeError):
@@ -291,14 +291,16 @@ def test_MixedGPModel(kernel, scaler):
         assert isinstance(model.model.input_transform, ChainedInputTransform)
         assert isinstance(model.model.input_transform.tf1, Normalize)
         assert torch.eq(
-        model.model.input_transform.tf1.indices, torch.tensor([0, 1], dtype=torch.int64)
+            model.model.input_transform.tf1.indices,
+            torch.tensor([0, 1], dtype=torch.int64),
         ).all()
         assert isinstance(model.model.input_transform.tf2, OneHotToNumeric)
     elif scaler == ScalerEnum.STANDARDIZE:
         assert isinstance(model.model.input_transform, ChainedInputTransform)
         assert isinstance(model.model.input_transform.tf1, InputStandardize)
         assert torch.eq(
-        model.model.input_transform.tf1.indices, torch.tensor([0, 1], dtype=torch.int64)
+            model.model.input_transform.tf1.indices,
+            torch.tensor([0, 1], dtype=torch.int64),
         ).all()
         assert isinstance(model.model.input_transform.tf2, OneHotToNumeric)
     else:

--- a/tests/bofire/surrogates/test_mlp.py
+++ b/tests/bofire/surrogates/test_mlp.py
@@ -162,7 +162,9 @@ def test_mlp_ensemble_forward():
     assert pred.shape == torch.Size((1, 2, 10, 1))
 
 
-@pytest.mark.parametrize("scaler", [ScalerEnum.NORMALIZE, ScalerEnum.STANDARDIZE, ScalerEnum.IDENTITY])
+@pytest.mark.parametrize(
+    "scaler", [ScalerEnum.NORMALIZE, ScalerEnum.STANDARDIZE, ScalerEnum.IDENTITY]
+)
 def test_mlp_ensemble_fit(scaler):
     bench = Himmelblau()
     samples = bench.domain.inputs.sample(10)
@@ -180,7 +182,7 @@ def test_mlp_ensemble_fit(scaler):
     if scaler == ScalerEnum.NORMALIZE:
         assert isinstance(surrogate.model.input_transform, Normalize)
     elif scaler == ScalerEnum.STANDARDIZE:
-        assert isinstance(surrogate.model.input_transform, InputStandardize)        
+        assert isinstance(surrogate.model.input_transform, InputStandardize)
     else:
         with pytest.raises(AttributeError):
             assert surrogate.model.input_transform is None
@@ -192,7 +194,9 @@ def test_mlp_ensemble_fit(scaler):
     assert_frame_equal(preds, preds2)
 
 
-@pytest.mark.parametrize("scaler", [ScalerEnum.NORMALIZE, ScalerEnum.STANDARDIZE, ScalerEnum.IDENTITY])
+@pytest.mark.parametrize(
+    "scaler", [ScalerEnum.NORMALIZE, ScalerEnum.STANDARDIZE, ScalerEnum.IDENTITY]
+)
 def test_mlp_ensemble_fit_categorical(scaler):
     inputs = Inputs(
         features=[
@@ -223,14 +227,16 @@ def test_mlp_ensemble_fit_categorical(scaler):
     if scaler == ScalerEnum.NORMALIZE:
         assert isinstance(surrogate.model.input_transform, Normalize)
         assert torch.eq(
-            surrogate.model.input_transform.indices, torch.tensor([0, 1], dtype=torch.int64)
-        ).all()    
-    elif scaler == ScalerEnum.STANDARDIZE:
-        assert isinstance(surrogate.model.input_transform, InputStandardize)        
-        assert torch.eq(
-            surrogate.model.input_transform.indices, torch.tensor([0, 1], dtype=torch.int64)
+            surrogate.model.input_transform.indices,
+            torch.tensor([0, 1], dtype=torch.int64),
         ).all()
-    else:    
+    elif scaler == ScalerEnum.STANDARDIZE:
+        assert isinstance(surrogate.model.input_transform, InputStandardize)
+        assert torch.eq(
+            surrogate.model.input_transform.indices,
+            torch.tensor([0, 1], dtype=torch.int64),
+        ).all()
+    else:
         with pytest.raises(AttributeError):
             assert surrogate.model.input_transform is None
     preds = surrogate.predict(experiments)

--- a/tests/bofire/surrogates/test_mlp.py
+++ b/tests/bofire/surrogates/test_mlp.py
@@ -183,9 +183,6 @@ def test_mlp_ensemble_fit(scaler):
         assert isinstance(surrogate.model.input_transform, Normalize)
     elif scaler == ScalerEnum.STANDARDIZE:
         assert isinstance(surrogate.model.input_transform, InputStandardize)
-    else:
-        with pytest.raises(AttributeError):
-            surrogate.model.input_transform
     preds = surrogate.predict(experiments)
     dump = surrogate.dumps()
     surrogate2 = surrogates.map(ens)
@@ -236,9 +233,6 @@ def test_mlp_ensemble_fit_categorical(scaler):
             surrogate.model.input_transform.indices,
             torch.tensor([0, 1], dtype=torch.int64),
         ).all()
-    else:
-        with pytest.raises(AttributeError):
-            surrogate.model.input_transform
     preds = surrogate.predict(experiments)
     dump = surrogate.dumps()
     surrogate2 = surrogates.map(ens)

--- a/tests/bofire/surrogates/test_mlp.py
+++ b/tests/bofire/surrogates/test_mlp.py
@@ -162,7 +162,9 @@ def test_mlp_ensemble_forward():
     assert pred.shape == torch.Size((1, 2, 10, 1))
 
 
-@pytest.mark.parametrize("scaler", [ScalerEnum.NORMALIZE, ScalerEnum.STANDARDIZE, ScalerEnum.NONE])
+@pytest.mark.parametrize(
+    "scaler", [ScalerEnum.NORMALIZE, ScalerEnum.STANDARDIZE, ScalerEnum.NONE]
+)
 def test_mlp_ensemble_fit(scaler):
     bench = Himmelblau()
     samples = bench.domain.inputs.sample(10)
@@ -180,7 +182,7 @@ def test_mlp_ensemble_fit(scaler):
     if scaler == ScalerEnum.NORMALIZE:
         assert isinstance(surrogate.model.input_transform, Normalize)
     elif scaler == ScalerEnum.STANDARDIZE:
-        assert isinstance(surrogate.model.input_transform, InputStandardize)        
+        assert isinstance(surrogate.model.input_transform, InputStandardize)
     else:
         with pytest.raises(AttributeError):
             surrogate.model.input_transform
@@ -192,7 +194,9 @@ def test_mlp_ensemble_fit(scaler):
     assert_frame_equal(preds, preds2)
 
 
-@pytest.mark.parametrize("scaler", [ScalerEnum.NORMALIZE, ScalerEnum.STANDARDIZE, ScalerEnum.NONE])
+@pytest.mark.parametrize(
+    "scaler", [ScalerEnum.NORMALIZE, ScalerEnum.STANDARDIZE, ScalerEnum.NONE]
+)
 def test_mlp_ensemble_fit_categorical(scaler):
     inputs = Inputs(
         features=[
@@ -223,14 +227,16 @@ def test_mlp_ensemble_fit_categorical(scaler):
     if scaler == ScalerEnum.NORMALIZE:
         assert isinstance(surrogate.model.input_transform, Normalize)
         assert torch.eq(
-            surrogate.model.input_transform.indices, torch.tensor([0, 1], dtype=torch.int64)
-        ).all()    
-    elif scaler == ScalerEnum.STANDARDIZE:
-        assert isinstance(surrogate.model.input_transform, InputStandardize)        
-        assert torch.eq(
-            surrogate.model.input_transform.indices, torch.tensor([0, 1], dtype=torch.int64)
+            surrogate.model.input_transform.indices,
+            torch.tensor([0, 1], dtype=torch.int64),
         ).all()
-    else:    
+    elif scaler == ScalerEnum.STANDARDIZE:
+        assert isinstance(surrogate.model.input_transform, InputStandardize)
+        assert torch.eq(
+            surrogate.model.input_transform.indices,
+            torch.tensor([0, 1], dtype=torch.int64),
+        ).all()
+    else:
         with pytest.raises(AttributeError):
             surrogate.model.input_transform
     preds = surrogate.predict(experiments)

--- a/tests/bofire/surrogates/test_mlp.py
+++ b/tests/bofire/surrogates/test_mlp.py
@@ -162,9 +162,7 @@ def test_mlp_ensemble_forward():
     assert pred.shape == torch.Size((1, 2, 10, 1))
 
 
-@pytest.mark.parametrize(
-    "scaler", [ScalerEnum.NORMALIZE, ScalerEnum.STANDARDIZE, ScalerEnum.NONE]
-)
+@pytest.mark.parametrize("scaler", [ScalerEnum.NORMALIZE, ScalerEnum.STANDARDIZE, ScalerEnum.IDENTITY])
 def test_mlp_ensemble_fit(scaler):
     bench = Himmelblau()
     samples = bench.domain.inputs.sample(10)
@@ -182,7 +180,10 @@ def test_mlp_ensemble_fit(scaler):
     if scaler == ScalerEnum.NORMALIZE:
         assert isinstance(surrogate.model.input_transform, Normalize)
     elif scaler == ScalerEnum.STANDARDIZE:
-        assert isinstance(surrogate.model.input_transform, InputStandardize)
+        assert isinstance(surrogate.model.input_transform, InputStandardize)        
+    else:
+        with pytest.raises(AttributeError):
+            assert surrogate.model.input_transform is None
     preds = surrogate.predict(experiments)
     dump = surrogate.dumps()
     surrogate2 = surrogates.map(ens)
@@ -191,9 +192,7 @@ def test_mlp_ensemble_fit(scaler):
     assert_frame_equal(preds, preds2)
 
 
-@pytest.mark.parametrize(
-    "scaler", [ScalerEnum.NORMALIZE, ScalerEnum.STANDARDIZE, ScalerEnum.NONE]
-)
+@pytest.mark.parametrize("scaler", [ScalerEnum.NORMALIZE, ScalerEnum.STANDARDIZE, ScalerEnum.IDENTITY])
 def test_mlp_ensemble_fit_categorical(scaler):
     inputs = Inputs(
         features=[
@@ -224,15 +223,16 @@ def test_mlp_ensemble_fit_categorical(scaler):
     if scaler == ScalerEnum.NORMALIZE:
         assert isinstance(surrogate.model.input_transform, Normalize)
         assert torch.eq(
-            surrogate.model.input_transform.indices,
-            torch.tensor([0, 1], dtype=torch.int64),
-        ).all()
+            surrogate.model.input_transform.indices, torch.tensor([0, 1], dtype=torch.int64)
+        ).all()    
     elif scaler == ScalerEnum.STANDARDIZE:
-        assert isinstance(surrogate.model.input_transform, InputStandardize)
+        assert isinstance(surrogate.model.input_transform, InputStandardize)        
         assert torch.eq(
-            surrogate.model.input_transform.indices,
-            torch.tensor([0, 1], dtype=torch.int64),
+            surrogate.model.input_transform.indices, torch.tensor([0, 1], dtype=torch.int64)
         ).all()
+    else:    
+        with pytest.raises(AttributeError):
+            assert surrogate.model.input_transform is None
     preds = surrogate.predict(experiments)
     dump = surrogate.dumps()
     surrogate2 = surrogates.map(ens)


### PR DESCRIPTION
A new type of input scaler defined that is for applying no scalarization. Works primarily by modifying `get_scaler` to return `None`. Changes downstream from there follow due to setting `scaler` to `None`