### PR TITLE
remove version reading

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,9 +2,6 @@
 requires = ["setuptools", "setuptools_scm[toml]", "wheel"]
 build-backend = "setuptools.build_meta"
 
-[project]
-dynamic = ["version"]
-
 [tool.setuptools_scm]
 local_scheme = "node-and-date"
 write_to = "./bofire/version.py"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,6 +2,9 @@
 requires = ["setuptools", "setuptools_scm[toml]", "wheel"]
 build-backend = "setuptools.build_meta"
 
+[project]
+dynamic = ["version"]
+
 [tool.setuptools_scm]
 local_scheme = "node-and-date"
 write_to = "./bofire/version.py"

--- a/setup.py
+++ b/setup.py
@@ -4,16 +4,6 @@ from setuptools import find_packages, setup
 
 sklearn_dependency = "scikit-learn>=1.0.0"
 
-
-def get_version():
-    here = os.path.abspath(os.path.dirname(__file__))
-    fp = os.path.join(here, "bofire/__init__.py")
-    for line in open(fp).readlines():
-        if line.startswith("__version__"):
-            return line.split('"')[1]
-    return ""
-
-
 root_dir = os.path.dirname(__file__)
 with open(os.path.join(root_dir, "README.md"), "r") as f:
     long_description = f.read()
@@ -40,7 +30,6 @@ setup(
     ],
     long_description=long_description,
     long_description_content_type="text/markdown",
-    version=get_version(),
     python_requires=">=3.9",
     packages=find_packages(),
     include_package_data=True,


### PR DESCRIPTION
In `setup.py` we were reading the version erroneously from `__init__.py`. This is obsolete as we are using `pyproject.toml` and `setuptools_scm`.

Maybe we could also get rid of the complete `setup.py`. In this project, it looks for me that they also have optional dependecies in the `pyproject.toml` (https://github.com/datamol-io/molfeat/blob/main/pyproject.toml) Maybe we have to revise ours to. @bertiqwerty : what to you think? 