### PR TITLE
Fix bug in metrics calculation 

### DIFF
--- a/bofire/surrogates/diagnostics.py
+++ b/bofire/surrogates/diagnostics.py
@@ -1,3 +1,4 @@
+import warnings
 from typing import Dict, List, Optional, Sequence
 
 import numpy as np
@@ -262,7 +263,10 @@ class CvResult(BaseModel):
             float: Metric value.
         """
         if self.n_samples == 1:
-            raise ValueError("Metric cannot be calculated for only one sample.")
+            warnings.warn(
+                "Metric cannot be calculated for only one sample. Null value will be returned"
+            )
+            return np.nan
         return metrics[metric](self.observed.values, self.predicted.values, self.standard_deviation)  # type: ignore
 
 
@@ -431,7 +435,7 @@ def CvResults2CrossValidationValues(
                 standardDeviation=fold.standard_deviation.tolist()
                 if fold.standard_deviation is not None
                 else None,
-                metrics=metrics.loc[i].to_dict(),
+                metrics=metrics.loc[i].to_dict() if fold.n_samples > 1 else None,
             )
         )
     return cvResults

--- a/bofire/surrogates/trainable.py
+++ b/bofire/surrogates/trainable.py
@@ -1,3 +1,4 @@
+import warnings
 from abc import ABC, abstractmethod
 from typing import Any, Callable, Dict, List, Optional, Tuple
 
@@ -95,9 +96,10 @@ class TrainableSurrogate(ABC):
             )
         n = len(experiments)
         if folds > n:
-            raise ValueError(
-                f"Training data only has {n} experiments, which is less than folds"
+            warnings.warn(
+                f"Training data only has {n} experiments, which is less than folds, fallback to LOOCV."
             )
+            folds = n
         elif n == 0:
             raise ValueError("Experiments is empty.")
         elif folds < 2 and folds != -1:

--- a/tests/bofire/surrogates/test_cross_validate.py
+++ b/tests/bofire/surrogates/test_cross_validate.py
@@ -179,7 +179,7 @@ def test_model_cross_validate_hooks():
     assert hook_results["hook2"] == [(8, 2), (8, 2), (8, 2), (8, 2), (8, 2)]
 
 
-@pytest.mark.parametrize("folds", [-2, 0, 1, 11])
+@pytest.mark.parametrize("folds", [-2, 0, 1])
 def test_model_cross_validate_invalid(folds):
     inputs = Inputs(
         features=[

--- a/tests/bofire/surrogates/test_diagnostics.py
+++ b/tests/bofire/surrogates/test_diagnostics.py
@@ -202,8 +202,7 @@ def test_cvresult_get_metric_invalid():
     predicted = observed + np.random.normal(loc=0, scale=1, size=n_samples)
     cv = CvResult(key=feature.key, observed=observed, predicted=predicted)
     for metric in metrics.keys():
-        with pytest.raises(ValueError):
-            cv.get_metric(metric)
+        np.isnan(cv.get_metric(metric=metric))
 
 
 def test_cvresults_invalid():
@@ -421,3 +420,16 @@ def test_CvResults2CrossValidationValues(cv_results):
             assert transformed["a"][i].standardDeviation is None
         for m in metrics.columns:
             assert metrics.loc[i, m] == transformed["a"][i].metrics[m]
+
+
+def test_CvResults2CrossValidationValues_minimal():
+    cv_results = CvResults(
+        results=[generate_cvresult(key="a", n_samples=2) for _ in range(4)]
+        + [generate_cvresult(key="a", n_samples=1)]
+    )
+    transformed = CvResults2CrossValidationValues(cv_results)
+    for i in range(5):
+        if i < 4:
+            assert transformed["a"][i].metrics is not None
+        else:
+            assert transformed["a"][i].metrics is None


### PR DESCRIPTION
This PR fixes a bug when one cv fold contains only one sample and then metrics are requested to calculate. The behavior is changed from raising an error to raising a warning and returning `nan`. This should solve then the problem with our worker in this case.