### PR TITLE
simplify annotated by using `typing_extensions` directly

### DIFF
--- a/bofire/data_models/constraints/constraint.py
+++ b/bofire/data_models/constraints/constraint.py
@@ -3,9 +3,9 @@ from typing import List, Optional
 
 import pandas as pd
 from pydantic import Field
+from typing_extensions import Annotated
 
 from bofire.data_models.base import BaseModel
-from bofire.utils.annotated import Annotated
 
 
 class Constraint(BaseModel):

--- a/bofire/data_models/features/categorical.py
+++ b/bofire/data_models/features/categorical.py
@@ -3,6 +3,7 @@ from typing import ClassVar, Dict, List, Literal, Optional, Tuple, Union
 import numpy as np
 import pandas as pd
 from pydantic import Field, root_validator, validator
+from typing_extensions import Annotated
 
 from bofire.data_models.enum import CategoricalEncodingEnum
 from bofire.data_models.features.feature import (
@@ -13,7 +14,6 @@ from bofire.data_models.features.feature import (
     TCategoryVals,
     TTransform,
 )
-from bofire.utils.annotated import Annotated
 
 
 class CategoricalInput(Input):

--- a/bofire/data_models/features/feature.py
+++ b/bofire/data_models/features/feature.py
@@ -3,11 +3,11 @@ from typing import ClassVar, Dict, List, Optional, Tuple, Union
 
 import pandas as pd
 from pydantic import Field
+from typing_extensions import Annotated
 
 from bofire.data_models.base import BaseModel
 from bofire.data_models.enum import CategoricalEncodingEnum
 from bofire.data_models.surrogates.scaler import ScalerEnum
-from bofire.utils.annotated import Annotated
 
 TTransform = Union[CategoricalEncodingEnum, ScalerEnum]
 

--- a/bofire/data_models/objectives/objective.py
+++ b/bofire/data_models/objectives/objective.py
@@ -4,9 +4,9 @@ from typing import Union
 import numpy as np
 import pandas as pd
 from pydantic import Field
+from typing_extensions import Annotated
 
 from bofire.data_models.base import BaseModel
-from bofire.utils.annotated import Annotated
 
 
 class Objective(BaseModel):

--- a/bofire/data_models/surrogates/random_forest.py
+++ b/bofire/data_models/surrogates/random_forest.py
@@ -1,9 +1,9 @@
 from typing import Literal, Optional, Union
 
 from pydantic import Field
+from typing_extensions import Annotated
 
 from bofire.data_models.surrogates.botorch import BotorchSurrogate
-from bofire.utils.annotated import Annotated
 
 
 class RandomForestSurrogate(BotorchSurrogate):

--- a/bofire/data_models/surrogates/xgb.py
+++ b/bofire/data_models/surrogates/xgb.py
@@ -1,6 +1,7 @@
 from typing import Literal, Optional
 
 from pydantic import Field, validator
+from typing_extensions import Annotated
 
 from bofire.data_models.enum import CategoricalEncodingEnum
 from bofire.data_models.features.api import (
@@ -9,7 +10,6 @@ from bofire.data_models.features.api import (
     NumericalInput,
 )
 from bofire.data_models.surrogates.botorch import BotorchSurrogate
-from bofire.utils.annotated import Annotated
 
 
 class XGBoostSurrogate(BotorchSurrogate):

--- a/bofire/strategies/data_models/values.py
+++ b/bofire/strategies/data_models/values.py
@@ -1,9 +1,9 @@
 from typing import Union
 
 from pydantic import Field
+from typing_extensions import Annotated
 
 from bofire.data_models.base import BaseModel
-from bofire.utils.annotated import Annotated
 
 Value = Union[float, str, int]
 

--- a/bofire/utils/annotated.py
+++ b/bofire/utils/annotated.py
@@ -1,4 +1,0 @@
-try:
-    from typing import Annotated
-except ImportError:
-    from typing_extensions import Annotated


### PR DESCRIPTION
`typing_extensions` already checks if `Annotated` is part of `typing`. No need to re-implement the logic, since we now have `typing_extensions` as dependency anyway.