### PR TITLE
Feature/zero also valid

### DIFF
--- a/bofire/data_models/constraints/nchoosek.py
+++ b/bofire/data_models/constraints/nchoosek.py
@@ -2,9 +2,10 @@ from typing import List, Literal
 
 import numpy as np
 import pandas as pd
-from pydantic import root_validator, validator
+from pydantic import Field, root_validator, validator
+from typing_extensions import Annotated
 
-from bofire.data_models.constraints.constraint import Constraint, FeatureKeys
+from bofire.data_models.constraints.constraint import Constraint
 
 
 def narrow_gaussian(x, ell=1e-3):
@@ -23,7 +24,7 @@ class NChooseKConstraint(Constraint):
     """
 
     type: Literal["NChooseKConstraint"] = "NChooseKConstraint"
-    features: FeatureKeys
+    features: Annotated[List[str], Field(min_items=1)]
     min_count: int
     max_count: int
     none_also_valid: bool

--- a/bofire/data_models/features/continuous.py
+++ b/bofire/data_models/features/continuous.py
@@ -23,7 +23,7 @@ class ContinuousInput(NumericalInput):
 
     bounds: Tuple[float, float]
     stepsize: Optional[float] = None
-    zero_also_valid: bool = True
+    zero_also_valid: bool = False
 
     @property
     def lower_bound(self) -> float:

--- a/bofire/data_models/features/continuous.py
+++ b/bofire/data_models/features/continuous.py
@@ -15,6 +15,7 @@ class ContinuousInput(NumericalInput):
     Attributes:
         bounds (Tuple[float, float]): A tuple that stores the lower and upper bound of the feature.
         stepsize (float, optional): Float indicating the allowed stepsize between lower and upper. Defaults to None.
+        zero_also_valid (bool, optional): Boolean indicating if a value of zero is allowed additional to the defined bounds.
     """
 
     type: Literal["ContinuousInput"] = "ContinuousInput"
@@ -22,6 +23,7 @@ class ContinuousInput(NumericalInput):
 
     bounds: Tuple[float, float]
     stepsize: Optional[float] = None
+    zero_also_valid: bool = True
 
     @property
     def lower_bound(self) -> float:
@@ -106,11 +108,15 @@ class ContinuousInput(NumericalInput):
 
         noise = 10e-6
         super().validate_candidental(values)
-        if (values < self.lower_bound - noise).any():
+        if self.zero_also_valid:
+            nonzeros = values[(values > noise) & (values < noise)]
+        else:
+            nonzeros = values
+        if (nonzeros < self.lower_bound - noise).any():
             raise ValueError(
                 f"not all values of input feature `{self.key}`are larger than lower bound `{self.lower_bound}` "
             )
-        if (values > self.upper_bound + noise).any():
+        if (nonzeros > self.upper_bound + noise).any():
             raise ValueError(
                 f"not all values of input feature `{self.key}`are smaller than upper bound `{self.upper_bound}` "
             )

--- a/tests/bofire/data_models/specs/features.py
+++ b/tests/bofire/data_models/specs/features.py
@@ -33,6 +33,7 @@ specs.add_valid(
         "bounds": (3, 5.3),
         "unit": random.choice(["°C", "mg", "mmol/l", None]),
         "stepsize": None,
+        "zero_also_valid": False,
     },
 )
 specs.add_valid(
@@ -44,6 +45,7 @@ specs.add_valid(
         "values": [1.0, 2.0],
         "unit": random.choice(["°C", "mg", "mmol/l", None]),
         "stepsize": None,
+        "zero_also_valid": False,
     },
 )
 specs.add_valid(

--- a/tests/bofire/data_models/test_features.py
+++ b/tests/bofire/data_models/test_features.py
@@ -199,6 +199,10 @@ def test_continuous_input_feature_validate_invalid(input_feature, values, strict
             specs.features.valid(ContinuousInput).obj(bounds=(3, 3)),
             pd.Series([3.0, 3.0, 3.0]),
         ),
+        (
+            ContinuousInput(key="a", bounds=(1.0, 3.0), zero_also_valid=True),
+            pd.Series([0.0, 3.0, 3.0]),
+        ),
     ],
 )
 def test_continuous_input_feature_validate_candidental_valid(input_feature, values):
@@ -223,6 +227,10 @@ def test_continuous_input_feature_validate_candidental_valid(input_feature, valu
         (
             specs.features.valid(ContinuousInput).obj(bounds=(3, 3)),
             pd.Series([3.1, 3.2, 3.4]),
+        ),
+        (
+            ContinuousInput(key="a", bounds=(1.0, 3.0), zero_also_valid=False),
+            pd.Series([0.0, 3.0, 3.0]),
         ),
     ],
 )


### PR DESCRIPTION
This PR adds the possibility to define that for a continuous input feature zero is also a valid option. For example if you have a feature which should normally be resided in the range 3 to 5 but zero would be also valid. 

Another option would be to model it via an nchoosek constraint with only one variable inside, which is a bit awkward, I a open to discussions how to handel it.

cc: @DavidWalz  @Osburg  @dlinzner-bcs  @R-M-Lee @bertiqwerty 