### PR TITLE
Hyperparameter Optimization for Trainable Surrogates

### DIFF
--- a/bofire/benchmarks/api.py
+++ b/bofire/benchmarks/api.py
@@ -1,0 +1,10 @@
+from typing import Union
+
+from bofire.benchmarks.aspen_benchmark import Aspen_benchmark
+from bofire.benchmarks.benchmark import Benchmark
+from bofire.benchmarks.hyperopt import Hyperopt, hyperoptimize
+from bofire.benchmarks.multi import C2DTLZ2, DTLZ2, ZDT1, CrossCoupling, SnarBenchmark
+from bofire.benchmarks.single import Ackley, Branin, Branin30, Hartmann, Himmelblau
+
+AnyMultiBenchmark = Union[C2DTLZ2, DTLZ2, ZDT1, CrossCoupling, SnarBenchmark]
+AnySingleBenchmark = Union[Ackley, Branin, Branin30, Hartmann, Himmelblau]

--- a/bofire/benchmarks/hyperopt.py
+++ b/bofire/benchmarks/hyperopt.py
@@ -1,0 +1,126 @@
+import warnings
+from typing import Tuple
+
+import pandas as pd
+
+import bofire.strategies.api as strategies
+import bofire.surrogates.api as surrogates
+from bofire.benchmarks.benchmark import Benchmark, run
+from bofire.data_models.domain.api import Domain
+from bofire.data_models.enum import RegressionMetricsEnum
+from bofire.data_models.objectives.api import MinimizeObjective
+from bofire.data_models.strategies.api import (
+    FactorialStrategy,
+    RandomStrategy,
+    SoboStrategy,
+)
+from bofire.data_models.surrogates.api import AnyTrainableSurrogate
+
+
+class Hyperopt(Benchmark):
+    def __init__(
+        self,
+        surrogate_data: AnyTrainableSurrogate,
+        training_data: pd.DataFrame,
+        folds: int,
+    ) -> None:
+        super().__init__()
+        if surrogate_data.hyperconfig is None:
+            raise ValueError("No hyperoptimization configuration found.")
+        self.surrogate_data = surrogate_data
+        self.training_data = training_data
+        self.folds = folds
+        self.results = None
+
+    @property
+    def domain(self) -> Domain:
+        return self.surrogate_data.hyperconfig.domain  # type: ignore
+
+    @property
+    def target_metric(self):
+        return self.surrogate_data.hyperconfig.target_metric  # type: ignore
+
+    def _f(self, candidates: pd.DataFrame) -> pd.DataFrame:
+        for i, candidate in candidates.iterrows():
+            self.surrogate_data.update_hyperparameters(candidate)
+            surrogate = surrogates.map(self.surrogate_data)
+            _, cv_test, _ = surrogate.cross_validate(self.training_data, folds=self.folds)  # type: ignore
+            if i == 0:
+                results = cv_test.get_metrics(combine_folds=True)
+            else:
+                results = pd.concat(
+                    [results, cv_test.get_metrics(combine_folds=True)],  # type: ignore
+                    ignore_index=True,
+                    axis=0,
+                )
+        results[f"valid_{self.target_metric.value}"] = 1  # type: ignore
+        return results  # type: ignore
+
+
+def hyperoptimize(
+    surrogate_data: AnyTrainableSurrogate,
+    training_data: pd.DataFrame,
+    folds: int,
+) -> Tuple[AnyTrainableSurrogate, pd.DataFrame]:
+    if surrogate_data.hyperconfig is None:
+        warnings.warn(
+            "No hyperopt is possible as no hyperopt config is available. Returning initial config."
+        )
+        return surrogate_data, pd.DataFrame({e.name: [] for e in RegressionMetricsEnum})
+
+    def best(domain: Domain, experiments: pd.DataFrame) -> float:
+        return (
+            experiments[domain.outputs[0].key].min()
+            if isinstance(domain.outputs[0].objective, MinimizeObjective)
+            else experiments[domain.outputs[0].key].max()
+        )
+
+    def sample(domain):
+        datamodel = RandomStrategy(domain=domain)
+        sampler = strategies.map(data_model=datamodel)
+        sampled = sampler.ask(len(domain.inputs) + 1)
+        return sampled
+
+    benchmark = Hyperopt(
+        surrogate_data=surrogate_data,
+        training_data=training_data,
+        folds=folds,
+    )
+
+    if surrogate_data.hyperconfig.hyperstrategy == "FactorialStrategy":  # type: ignore
+        strategy = strategies.map(FactorialStrategy(domain=benchmark.domain))
+        experiments = benchmark.f(
+            strategy.ask(candidate_count=None), return_complete=True
+        )
+    else:
+        experiments = run(
+            benchmark=benchmark,
+            strategy_factory=RandomStrategy
+            if surrogate_data.hyperconfig.hyperstrategy == "RandomStrategy"  # type: ignore
+            else SoboStrategy,  # type: ignore
+            metric=best,
+            n_runs=1,
+            n_iterations=surrogate_data.hyperconfig.n_iterations  # type: ignore
+            - len(benchmark.domain.inputs)
+            - 1,
+            initial_sampler=sample,
+            n_procs=1,
+        )[0][0]
+
+    # analyze the results and get the best
+    experiments = experiments.sort_values(
+        by=benchmark.target_metric.name,
+        ascending=True
+        if isinstance(benchmark.domain.outputs[0].objective, MinimizeObjective)
+        else False,
+    )
+
+    surrogate_data.update_hyperparameters(experiments.iloc[0])
+
+    return (
+        surrogate_data,
+        experiments[
+            surrogate_data.hyperconfig.domain.inputs.get_keys()
+            + [e.name for e in RegressionMetricsEnum]
+        ],
+    )

--- a/bofire/data_models/domain/domain.py
+++ b/bofire/data_models/domain/domain.py
@@ -499,7 +499,6 @@ class Domain(BaseModel):
             if valid_key not in experiments:
                 experiments[valid_key] = True
         # check all cols
-        expected = feature_keys + valid_keys
         cols = list(experiments.columns)
         # we allow here for a column named labcode used to identify experiments
         if "labcode" in cols:
@@ -516,10 +515,6 @@ class Domain(BaseModel):
                 raise ValueError("labcodes are not unique")
             # we remove the labcode from the cols list to proceed as before
             cols.remove("labcode")
-        if len(expected) != len(cols):
-            raise ValueError(f"expected the following cols: `{expected}`, got `{cols}`")
-        if len(set(expected + cols)) != len(cols):
-            raise ValueError(f"expected the following cols: `{expected}`, got `{cols}`")
         # check values of continuous input features
         if experiments[self.get_feature_keys(Input)].isnull().to_numpy().any():
             raise ValueError("there are null values")

--- a/bofire/data_models/kernels/continuous.py
+++ b/bofire/data_models/kernels/continuous.py
@@ -23,3 +23,4 @@ class MaternKernel(ContinuousKernel):
 
 class LinearKernel(ContinuousKernel):
     type: Literal["LinearKernel"] = "LinearKernel"
+    variance_prior: Optional[AnyPrior] = None

--- a/bofire/data_models/strategies/api.py
+++ b/bofire/data_models/strategies/api.py
@@ -1,6 +1,7 @@
 from typing import Union
 
 from bofire.data_models.strategies.doe import DoEStrategy
+from bofire.data_models.strategies.factorial import FactorialStrategy
 from bofire.data_models.strategies.predictives.botorch import BotorchStrategy
 from bofire.data_models.strategies.predictives.multiobjective import (
     MultiobjectiveStrategy,
@@ -51,6 +52,7 @@ AnyStrategy = Union[
     RandomStrategy,
     DoEStrategy,
     StepwiseStrategy,
+    FactorialStrategy,
 ]
 
 AnyPredictive = Union[
@@ -63,14 +65,7 @@ AnyPredictive = Union[
     QparegoStrategy,
 ]
 
-AnySampler = Union[
-    PolytopeSampler,
-    RejectionSampler,
-]
+AnySampler = Union[PolytopeSampler, RejectionSampler]
 
-AnySampler = Union[
-    PolytopeSampler,
-    RejectionSampler,
-]
 
 AnyCondition = Union[NumberOfExperimentsCondition, CombiCondition, AlwaysTrueCondition]

--- a/bofire/data_models/strategies/factorial.py
+++ b/bofire/data_models/strategies/factorial.py
@@ -1,0 +1,25 @@
+from typing import Literal, Type
+
+from bofire.data_models.features.api import (
+    CategoricalDescriptorInput,
+    CategoricalInput,
+    DiscreteInput,
+    Feature,
+)
+from bofire.data_models.strategies.strategy import Strategy
+
+
+class FactorialStrategy(Strategy):
+    type: Literal["FactorialStrategy"] = "FactorialStrategy"
+
+    @classmethod
+    def is_constraint_implemented(cls, my_type: Type[Feature]) -> bool:
+        return False
+
+    @classmethod
+    def is_feature_implemented(cls, my_type: Type[Feature]) -> bool:
+        return my_type in [
+            CategoricalInput,
+            DiscreteInput,
+            CategoricalDescriptorInput,
+        ]

--- a/bofire/data_models/strategies/factorial.py
+++ b/bofire/data_models/strategies/factorial.py
@@ -3,6 +3,7 @@ from typing import Literal, Type
 from bofire.data_models.features.api import (
     CategoricalDescriptorInput,
     CategoricalInput,
+    ContinuousOutput,
     DiscreteInput,
     Feature,
 )
@@ -22,4 +23,5 @@ class FactorialStrategy(Strategy):
             CategoricalInput,
             DiscreteInput,
             CategoricalDescriptorInput,
+            ContinuousOutput,
         ]

--- a/bofire/data_models/strategies/predictives/sobo.py
+++ b/bofire/data_models/strategies/predictives/sobo.py
@@ -1,15 +1,15 @@
 from typing import Literal, Optional, Type
 
-from pydantic import validator
+from pydantic import Field, validator
 
-from bofire.data_models.acquisition_functions.api import AnyAcquisitionFunction
+from bofire.data_models.acquisition_functions.api import AnyAcquisitionFunction, qNEI
 from bofire.data_models.features.api import CategoricalOutput, Feature
 from bofire.data_models.objectives.api import ConstrainedObjective, Objective
 from bofire.data_models.strategies.predictives.botorch import BotorchStrategy
 
 
 class SoboBaseStrategy(BotorchStrategy):
-    acquisition_function: AnyAcquisitionFunction
+    acquisition_function: AnyAcquisitionFunction = Field(default_factory=lambda: qNEI())
 
     @classmethod
     def is_feature_implemented(cls, my_type: Type[Feature]) -> bool:

--- a/bofire/data_models/surrogates/api.py
+++ b/bofire/data_models/surrogates/api.py
@@ -10,6 +10,7 @@ try:
     )
     from bofire.data_models.surrogates.empirical import EmpiricalSurrogate
     from bofire.data_models.surrogates.fully_bayesian import SaasSingleTaskGPSurrogate
+    from bofire.data_models.surrogates.linear import LinearSurrogate
     from bofire.data_models.surrogates.mixed_single_task_gp import (
         MixedSingleTaskGPSurrogate,
     )
@@ -32,9 +33,18 @@ try:
         MLPEnsemble,
         SaasSingleTaskGPSurrogate,
         XGBoostSurrogate,
+        LinearSurrogate,
     ]
 
-    AnyTrainableSurrogate = SingleTaskGPSurrogate
+    AnyTrainableSurrogate = Union[
+        RandomForestSurrogate,
+        SingleTaskGPSurrogate,
+        MixedSingleTaskGPSurrogate,
+        MLPEnsemble,
+        SaasSingleTaskGPSurrogate,
+        XGBoostSurrogate,
+        LinearSurrogate,
+    ]
 except ImportError:
     # with the minimal installationwe don't have botorch
     pass

--- a/bofire/data_models/surrogates/api.py
+++ b/bofire/data_models/surrogates/api.py
@@ -1,21 +1,24 @@
 from typing import Union
 
-from bofire.data_models.surrogates.scaler import ScalerEnum  # noqa: F401
+from bofire.data_models.surrogates.scaler import ScalerEnum
 
 try:
     from bofire.data_models.surrogates.botorch import BotorchSurrogate
-    from bofire.data_models.surrogates.botorch_surrogates import (  # noqa: F401
+    from bofire.data_models.surrogates.botorch_surrogates import (
         AnyBotorchSurrogate,
         BotorchSurrogates,
     )
     from bofire.data_models.surrogates.empirical import EmpiricalSurrogate
     from bofire.data_models.surrogates.fully_bayesian import SaasSingleTaskGPSurrogate
-    from bofire.data_models.surrogates.mixed_single_task_gp import (  # noqa: F401
+    from bofire.data_models.surrogates.mixed_single_task_gp import (
         MixedSingleTaskGPSurrogate,
     )
     from bofire.data_models.surrogates.mlp import MLPEnsemble
     from bofire.data_models.surrogates.random_forest import RandomForestSurrogate
-    from bofire.data_models.surrogates.single_task_gp import SingleTaskGPSurrogate
+    from bofire.data_models.surrogates.single_task_gp import (
+        SingleTaskGPHyperconfig,
+        SingleTaskGPSurrogate,
+    )
     from bofire.data_models.surrogates.surrogate import Surrogate
     from bofire.data_models.surrogates.xgb import XGBoostSurrogate
 
@@ -30,6 +33,8 @@ try:
         SaasSingleTaskGPSurrogate,
         XGBoostSurrogate,
     ]
+
+    AnyTrainableSurrogate = SingleTaskGPSurrogate
 except ImportError:
     # with the minimal installationwe don't have botorch
     pass

--- a/bofire/data_models/surrogates/fully_bayesian.py
+++ b/bofire/data_models/surrogates/fully_bayesian.py
@@ -4,9 +4,10 @@ from pydantic import conint, validator
 
 from bofire.data_models.surrogates.botorch import BotorchSurrogate
 from bofire.data_models.surrogates.scaler import ScalerEnum
+from bofire.data_models.surrogates.trainable import TrainableSurrogate
 
 
-class SaasSingleTaskGPSurrogate(BotorchSurrogate):
+class SaasSingleTaskGPSurrogate(BotorchSurrogate, TrainableSurrogate):
     type: Literal["SaasSingleTaskGPSurrogate"] = "SaasSingleTaskGPSurrogate"
     warmup_steps: conint(ge=1) = 256  # type: ignore
     num_samples: conint(ge=1) = 128  # type: ignore

--- a/bofire/data_models/surrogates/linear.py
+++ b/bofire/data_models/surrogates/linear.py
@@ -1,0 +1,25 @@
+from typing import Literal
+
+from pydantic import Field
+
+from bofire.data_models.kernels.api import LinearKernel
+from bofire.data_models.priors.api import (
+    BOTORCH_NOISE_PRIOR,
+    BOTORCH_SCALE_PRIOR,
+    AnyPrior,
+)
+
+# from bofire.data_models.strategies.api import FactorialStrategy
+from bofire.data_models.surrogates.botorch import BotorchSurrogate
+from bofire.data_models.surrogates.scaler import ScalerEnum
+from bofire.data_models.surrogates.trainable import TrainableSurrogate
+
+
+class LinearSurrogate(BotorchSurrogate, TrainableSurrogate):
+    type: Literal["LinearSurrogate"] = "LinearSurrogate"
+
+    kernel: LinearKernel = Field(
+        default_factory=lambda: LinearKernel(variance_prior=BOTORCH_SCALE_PRIOR())
+    )
+    noise_prior: AnyPrior = Field(default_factory=lambda: BOTORCH_NOISE_PRIOR())
+    scaler: ScalerEnum = ScalerEnum.NORMALIZE

--- a/bofire/data_models/surrogates/mixed_single_task_gp.py
+++ b/bofire/data_models/surrogates/mixed_single_task_gp.py
@@ -11,9 +11,10 @@ from bofire.data_models.kernels.api import (
 )
 from bofire.data_models.surrogates.botorch import BotorchSurrogate
 from bofire.data_models.surrogates.single_task_gp import ScalerEnum
+from bofire.data_models.surrogates.trainable import TrainableSurrogate
 
 
-class MixedSingleTaskGPSurrogate(BotorchSurrogate):
+class MixedSingleTaskGPSurrogate(BotorchSurrogate, TrainableSurrogate):
     type: Literal["MixedSingleTaskGPSurrogate"] = "MixedSingleTaskGPSurrogate"
     continuous_kernel: AnyContinuousKernel = Field(
         default_factory=lambda: MaternKernel(ard=True, nu=2.5)

--- a/bofire/data_models/surrogates/mlp.py
+++ b/bofire/data_models/surrogates/mlp.py
@@ -2,9 +2,10 @@ from typing import Literal, Sequence
 
 from bofire.data_models.surrogates.botorch import BotorchSurrogate
 from bofire.data_models.surrogates.scaler import ScalerEnum
+from bofire.data_models.surrogates.trainable import TrainableSurrogate
 
 
-class MLPEnsemble(BotorchSurrogate):
+class MLPEnsemble(BotorchSurrogate, TrainableSurrogate):
     type: Literal["MLPEnsemble"] = "MLPEnsemble"
     n_estimators: int
     hidden_layer_sizes: Sequence = (100,)

--- a/bofire/data_models/surrogates/random_forest.py
+++ b/bofire/data_models/surrogates/random_forest.py
@@ -4,9 +4,10 @@ from pydantic import Field
 from typing_extensions import Annotated
 
 from bofire.data_models.surrogates.botorch import BotorchSurrogate
+from bofire.data_models.surrogates.trainable import TrainableSurrogate
 
 
-class RandomForestSurrogate(BotorchSurrogate):
+class RandomForestSurrogate(BotorchSurrogate, TrainableSurrogate):
     type: Literal["RandomForestSurrogate"] = "RandomForestSurrogate"
 
     # hyperparams passed down to `RandomForestRegressor`

--- a/bofire/data_models/surrogates/single_task_gp.py
+++ b/bofire/data_models/surrogates/single_task_gp.py
@@ -1,19 +1,98 @@
-from typing import Literal
+from typing import Literal, Optional
 
+import pandas as pd
 from pydantic import Field
 
-from bofire.data_models.kernels.api import AnyKernel, MaternKernel, ScaleKernel
+from bofire.data_models.domain.api import Inputs
+from bofire.data_models.enum import RegressionMetricsEnum
+from bofire.data_models.features.api import CategoricalInput
+from bofire.data_models.kernels.api import (
+    AnyKernel,
+    MaternKernel,
+    RBFKernel,
+    ScaleKernel,
+)
 from bofire.data_models.priors.api import (
     BOTORCH_LENGTHCALE_PRIOR,
     BOTORCH_NOISE_PRIOR,
     BOTORCH_SCALE_PRIOR,
+    MBO_LENGTHCALE_PRIOR,
+    MBO_NOISE_PRIOR,
+    MBO_OUTPUTSCALE_PRIOR,
     AnyPrior,
 )
+
+# from bofire.data_models.strategies.api import FactorialStrategy
 from bofire.data_models.surrogates.botorch import BotorchSurrogate
 from bofire.data_models.surrogates.scaler import ScalerEnum
+from bofire.data_models.surrogates.trainable import Hyperconfig, TrainableSurrogate
 
 
-class SingleTaskGPSurrogate(BotorchSurrogate):
+class SingleTaskGPHyperconfig(Hyperconfig):
+    type: Literal["SingleTaskGPHyperconfig"] = "SingleTaskGPHyperconfig"
+    inputs: Inputs = Inputs(
+        features=[
+            CategoricalInput(
+                key="kernel", categories=["rbf", "matern_1.5", "matern_2.5"]
+            ),
+            CategoricalInput(key="prior", categories=["mbo", "botorch"]),
+            CategoricalInput(key="ard", categories=["True", "False"]),
+        ]
+    )
+    target_metric = RegressionMetricsEnum.MAE
+    hyperstrategy: Literal[
+        "FactorialStrategy", "SoboStrategy", "RandomStrategy"
+    ] = "FactorialStrategy"
+
+    @staticmethod
+    def _update_hyperparameters(
+        surrogate_data: "SingleTaskGPSurrogate", hyperparameters: pd.Series
+    ):
+        def matern_25(ard: bool, lenghtscale_prior: AnyPrior) -> MaternKernel:
+            return MaternKernel(nu=2.5, lengthscale_prior=lenghtscale_prior, ard=ard)
+
+        def matern_15(ard: bool, lenghtscale_prior: AnyPrior) -> MaternKernel:
+            return MaternKernel(nu=1.5, lengthscale_prior=lenghtscale_prior, ard=ard)
+
+        if hyperparameters.prior == "mbo":
+            noise_prior, lengthscale_prior, outputscale_prior = (
+                MBO_NOISE_PRIOR(),
+                MBO_LENGTHCALE_PRIOR(),
+                MBO_OUTPUTSCALE_PRIOR(),
+            )
+        else:
+            noise_prior, lengthscale_prior, outputscale_prior = (
+                BOTORCH_NOISE_PRIOR(),
+                BOTORCH_LENGTHCALE_PRIOR(),
+                BOTORCH_SCALE_PRIOR(),
+            )
+        surrogate_data.noise_prior = noise_prior
+        if hyperparameters.kernel == "rbf":
+            surrogate_data.kernel = ScaleKernel(
+                base_kernel=RBFKernel(
+                    ard=hyperparameters.ard, lengthscale_prior=lengthscale_prior
+                ),
+                outputscale_prior=outputscale_prior,
+            )
+        elif hyperparameters.kernel == "matern_2.5":
+            surrogate_data.kernel = ScaleKernel(
+                base_kernel=matern_25(
+                    ard=hyperparameters.ard, lenghtscale_prior=lengthscale_prior
+                ),
+                outputscale_prior=outputscale_prior,
+            )
+        elif hyperparameters.kernel == "matern_1.5":
+            surrogate_data.kernel = ScaleKernel(
+                base_kernel=matern_15(
+                    ard=hyperparameters.ard, lenghtscale_prior=lengthscale_prior
+                ),
+                outputscale_prior=outputscale_prior,
+            )
+        else:
+            raise ValueError(f"Kernel {hyperparameters.kernel} not known.")
+
+
+class SingleTaskGPSurrogate(BotorchSurrogate, TrainableSurrogate):
     type: Literal["SingleTaskGPSurrogate"] = "SingleTaskGPSurrogate"
 
     kernel: AnyKernel = Field(
@@ -28,3 +107,6 @@ class SingleTaskGPSurrogate(BotorchSurrogate):
     )
     noise_prior: AnyPrior = Field(default_factory=lambda: BOTORCH_NOISE_PRIOR())
     scaler: ScalerEnum = ScalerEnum.NORMALIZE
+    hyperconfig: Optional[SingleTaskGPHyperconfig] = Field(
+        default_factory=lambda: SingleTaskGPHyperconfig()
+    )

--- a/bofire/data_models/surrogates/single_task_gp.py
+++ b/bofire/data_models/surrogates/single_task_gp.py
@@ -48,11 +48,11 @@ class SingleTaskGPHyperconfig(Hyperconfig):
     def _update_hyperparameters(
         surrogate_data: "SingleTaskGPSurrogate", hyperparameters: pd.Series
     ):
-        def matern_25(ard: bool, lenghtscale_prior: AnyPrior) -> MaternKernel:
-            return MaternKernel(nu=2.5, lengthscale_prior=lenghtscale_prior, ard=ard)
+        def matern_25(ard: bool, lengthscale_prior: AnyPrior) -> MaternKernel:
+            return MaternKernel(nu=2.5, lengthscale_prior=lengthscale_prior, ard=ard)
 
-        def matern_15(ard: bool, lenghtscale_prior: AnyPrior) -> MaternKernel:
-            return MaternKernel(nu=1.5, lengthscale_prior=lenghtscale_prior, ard=ard)
+        def matern_15(ard: bool, lengthscale_prior: AnyPrior) -> MaternKernel:
+            return MaternKernel(nu=1.5, lengthscale_prior=lengthscale_prior, ard=ard)
 
         if hyperparameters.prior == "mbo":
             noise_prior, lengthscale_prior, outputscale_prior = (
@@ -77,14 +77,14 @@ class SingleTaskGPHyperconfig(Hyperconfig):
         elif hyperparameters.kernel == "matern_2.5":
             surrogate_data.kernel = ScaleKernel(
                 base_kernel=matern_25(
-                    ard=hyperparameters.ard, lenghtscale_prior=lengthscale_prior
+                    ard=hyperparameters.ard, lengthscale_prior=lengthscale_prior
                 ),
                 outputscale_prior=outputscale_prior,
             )
         elif hyperparameters.kernel == "matern_1.5":
             surrogate_data.kernel = ScaleKernel(
                 base_kernel=matern_15(
-                    ard=hyperparameters.ard, lenghtscale_prior=lengthscale_prior
+                    ard=hyperparameters.ard, lengthscale_prior=lengthscale_prior
                 ),
                 outputscale_prior=outputscale_prior,
             )

--- a/bofire/data_models/surrogates/trainable.py
+++ b/bofire/data_models/surrogates/trainable.py
@@ -1,0 +1,83 @@
+from abc import abstractmethod
+from typing import Literal, Optional
+
+import pandas as pd
+from pydantic import Field, validator
+from typing_extensions import Annotated
+
+from bofire.data_models.base import BaseModel
+from bofire.data_models.domain.api import Domain, Inputs, Outputs
+from bofire.data_models.enum import RegressionMetricsEnum
+from bofire.data_models.features.api import ContinuousOutput
+from bofire.data_models.objectives.api import MaximizeObjective, MinimizeObjective
+
+metrics2objectives = {
+    RegressionMetricsEnum.MAE: MinimizeObjective,
+    RegressionMetricsEnum.MAPE: MinimizeObjective,
+    RegressionMetricsEnum.MSD: MinimizeObjective,
+    RegressionMetricsEnum.R2: MaximizeObjective,
+    RegressionMetricsEnum.PEARSON: MaximizeObjective,
+    RegressionMetricsEnum.SPEARMAN: MaximizeObjective,
+    RegressionMetricsEnum.FISHER: MaximizeObjective,
+}
+
+
+class Hyperconfig(BaseModel):
+    type: str
+    hyperstrategy: Literal["RandomStrategy", "FactorialStrategy", "SoboStrategy"]
+    inputs: Inputs
+    n_iterations: Optional[Annotated[int, Field(ge=1)]] = None
+    target_metric: RegressionMetricsEnum = RegressionMetricsEnum.MAE
+
+    @validator("n_iterations", always=True)
+    def validate_n_iterations(cls, v, values):
+        if v is None:
+            if values["hyperstrategy"] == "FactorialStrategy":
+                return v
+            return len(values["inputs"]) + 10
+        else:
+            if values["hyperstrategy"] == "FactorialStrategy":
+                raise ValueError(
+                    "It is not allowed to scpecify the number of its for FactorialStrategy"
+                )
+            if v < len(values["inputs"]) + 2:
+                raise ValueError(
+                    "At least number of hyperparams plus 2 iterations has to be specified"
+                )
+        return v
+
+    @property
+    def domain(self) -> Domain:
+        return Domain(
+            inputs=self.inputs,
+            outputs=Outputs(
+                features=[
+                    ContinuousOutput(
+                        key=self.target_metric.name,
+                        objective=metrics2objectives[self.target_metric](),
+                    )
+                ]
+            ),
+        )
+
+    @staticmethod
+    @abstractmethod
+    def _update_hyperparameters(surrogate_data, hyperparameters: pd.Series):
+        pass
+
+
+class TrainableSurrogate(BaseModel):
+    hyperconfig: Optional[Hyperconfig] = None
+
+    def update_hyperparameters(self, hyperparameters: pd.Series):
+        if self.hyperconfig is not None:
+            self.hyperconfig.domain.validate_candidates(
+                pd.DataFrame(hyperparameters).T,
+                only_inputs=True,
+                raise_validation_error=True,
+            )
+            self.hyperconfig._update_hyperparameters(
+                self, hyperparameters=hyperparameters
+            )
+        else:
+            raise ValueError("No hyperconfig available.")

--- a/bofire/data_models/surrogates/xgb.py
+++ b/bofire/data_models/surrogates/xgb.py
@@ -9,10 +9,11 @@ from bofire.data_models.features.api import (
     CategoricalInput,
     NumericalInput,
 )
-from bofire.data_models.surrogates.botorch import BotorchSurrogate
+from bofire.data_models.surrogates.surrogate import Surrogate
+from bofire.data_models.surrogates.trainable import TrainableSurrogate
 
 
-class XGBoostSurrogate(BotorchSurrogate):
+class XGBoostSurrogate(Surrogate, TrainableSurrogate):
     type: Literal["XGBoostSurrogate"] = "XGBoostSurrogate"
     n_estimators: int
     max_depth: Annotated[int, Field(ge=0)] = 6

--- a/bofire/kernels/mapper.py
+++ b/bofire/kernels/mapper.py
@@ -48,7 +48,11 @@ def map_LinearKernel(
     active_dims: List[int],
 ) -> gpytorch.kernels.LinearKernel:
     return gpytorch.kernels.LinearKernel(
-        batch_shape=batch_shape, active_dims=active_dims
+        batch_shape=batch_shape,
+        active_dims=active_dims,
+        variance_prior=priors.map(data_model.variance_prior)
+        if data_model.variance_prior is not None
+        else None,
     )
 
 

--- a/bofire/strategies/factorial.py
+++ b/bofire/strategies/factorial.py
@@ -1,0 +1,40 @@
+from typing import Optional
+
+import pandas as pd
+
+from bofire.data_models.strategies.api import FactorialStrategy as DataModel
+from bofire.strategies.strategy import Strategy
+
+
+class FactorialStrategy(Strategy):
+    """Sampler that generates samples from a Polytope defined by linear equality and ineqality constraints.
+
+    Attributes:
+        domain (Domain): Domain defining the constrained input space
+        fallback_sampling_method: SamplingMethodEnum, optional): Method to use for sampling when no
+            constraints are present. Defaults to UNIFORM.
+    """
+
+    def __init__(
+        self,
+        data_model: DataModel,
+        **kwargs,
+    ):
+        super().__init__(data_model=data_model, **kwargs)
+
+    def _ask(self, candidate_count: Optional[int] = None) -> pd.DataFrame:
+        if candidate_count is not None:
+            raise ValueError(
+                "FactorialStrategy will ignore the specified value of candidate_count. "
+                "The strategy automatically determines how many candidates to "
+                "propose."
+            )
+        return pd.DataFrame.from_dict(
+            [
+                {e[0]: e[1] for e in combi}  # type: ignore
+                for combi in self.domain.inputs.get_categorical_combinations()
+            ]
+        )
+
+    def has_sufficient_experiments(self) -> bool:
+        return True

--- a/bofire/strategies/mapper.py
+++ b/bofire/strategies/mapper.py
@@ -2,6 +2,7 @@ from typing import Dict, Type
 
 import bofire.data_models.strategies.api as data_models
 from bofire.strategies.doe_strategy import DoEStrategy  # noqa: F401
+from bofire.strategies.factorial import FactorialStrategy
 from bofire.strategies.predictives.botorch import BotorchStrategy  # noqa: F401
 from bofire.strategies.predictives.predictive import PredictiveStrategy  # noqa: F401
 from bofire.strategies.predictives.qehvi import QehviStrategy  # noqa: F401
@@ -33,6 +34,7 @@ STRATEGY_MAP: Dict[Type[data_models.Strategy], Type[Strategy]] = {
     data_models.RejectionSampler: RejectionSampler,
     data_models.DoEStrategy: DoEStrategy,
     data_models.StepwiseStrategy: StepwiseStrategy,
+    data_models.FactorialStrategy: FactorialStrategy,
 }
 
 

--- a/bofire/surrogates/mapper.py
+++ b/bofire/surrogates/mapper.py
@@ -18,6 +18,7 @@ SURROGATE_MAP: Dict[Type[data_models.Surrogate], Type[Surrogate]] = {
     data_models.MLPEnsemble: MLPEnsemble,
     data_models.SaasSingleTaskGPSurrogate: SaasSingleTaskGPSurrogate,
     data_models.XGBoostSurrogate: XGBoostSurrogate,
+    data_models.LinearSurrogate: SingleTaskGPSurrogate,
 }
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,3 +25,5 @@ max-complexity = 18
 "bofire/utils/annotated.py" = ["F401"]
 "tests/bofire/data_models/specs/api.py" = ["F401"]
 "bofire/data_models/api.py" = ["F401"]
+"bofire/data_models/surrogates/api.py" = ["F401"]
+"bofire/benchmarks/api.py" = ["F401"]

--- a/tests/bofire/benchmarks/test_hyperopt.py
+++ b/tests/bofire/benchmarks/test_hyperopt.py
@@ -1,0 +1,87 @@
+import pytest
+
+from bofire.benchmarks.api import Himmelblau, Hyperopt, hyperoptimize
+from bofire.data_models.enum import RegressionMetricsEnum
+from bofire.data_models.kernels.api import MaternKernel, RBFKernel
+from bofire.data_models.surrogates.api import SingleTaskGPSurrogate
+
+benchmark = Himmelblau()
+experiments = benchmark.f(benchmark.domain.inputs.sample(9), return_complete=True)
+
+
+def test_Hyperopt_invalid():
+    surrogate_data = SingleTaskGPSurrogate(
+        inputs=benchmark.domain.inputs,
+        outputs=benchmark.domain.outputs,
+        hyperconfig=None,
+    )
+    with pytest.raises(ValueError, match="No hyperoptimization configuration found."):
+        Hyperopt(surrogate_data=surrogate_data, training_data=experiments, folds=5)
+
+
+@pytest.mark.parametrize("n_candidates", [1, 2])
+def test_Hyperopt(n_candidates: int):
+    surrogate_data = SingleTaskGPSurrogate(
+        inputs=benchmark.domain.inputs,
+        outputs=benchmark.domain.outputs,
+    )
+    hy = Hyperopt(surrogate_data=surrogate_data, training_data=experiments, folds=3)
+    assert hy.target_metric == surrogate_data.hyperconfig.target_metric
+    assert hy.domain == surrogate_data.hyperconfig.domain
+    candidates = hy.domain.inputs.sample(n_candidates)
+    results = hy.f(candidates=candidates)
+    assert len(results) == len(candidates)
+    assert f"valid_{hy.target_metric.name}" in results.columns
+    for e in RegressionMetricsEnum:
+        assert e.name in results.columns
+    assert len(results.columns) == 8
+
+
+def test_hyperoptimize_warning():
+    surrogate_data = SingleTaskGPSurrogate(
+        inputs=benchmark.domain.inputs,
+        outputs=benchmark.domain.outputs,
+        hyperconfig=None,
+    )
+    with pytest.warns(
+        match="No hyperopt is possible as no hyperopt config is available. Returning initial config."
+    ):
+        opt_data, metrics = hyperoptimize(
+            surrogate_data=surrogate_data, training_data=experiments, folds=3
+        )
+    assert opt_data == surrogate_data
+    assert len(metrics) == 0
+    assert set(metrics.columns) == {e.name for e in RegressionMetricsEnum}
+
+
+@pytest.mark.parametrize("strategy", ["FactorialStrategy", "RandomStrategy"])
+def test_hyperoptimize(strategy: str):
+    surrogate_data = SingleTaskGPSurrogate(
+        inputs=benchmark.domain.inputs,
+        outputs=benchmark.domain.outputs,
+    )
+    if strategy == "RandomStrategy":
+        surrogate_data.hyperconfig.hyperstrategy = strategy
+        surrogate_data.hyperconfig.n_iterations = 5
+
+    opt_data, metrics = hyperoptimize(
+        surrogate_data=surrogate_data, training_data=experiments, folds=3
+    )
+    if strategy == "RandomStrategy":
+        assert len(metrics) == 5
+    else:
+        assert len(metrics) == 12
+
+    assert set(metrics.columns) == set(
+        [e.name for e in RegressionMetricsEnum]
+        + surrogate_data.hyperconfig.domain.inputs.get_keys()
+    )
+    assert opt_data.kernel.base_kernel.ard == (metrics.iloc[0]["ard"] == "True")
+    if metrics.iloc[0].kernel == "matern_1.5":
+        assert isinstance(opt_data.kernel.base_kernel, MaternKernel)
+        assert opt_data.kernel.base_kernel.nu == 1.5
+    elif metrics.iloc[0].kernel == "matern_2.5":
+        assert isinstance(opt_data.kernel.base_kernel, MaternKernel)
+        assert opt_data.kernel.base_kernel.nu == 2.5
+    else:
+        assert isinstance(opt_data.kernel.base_kernel, RBFKernel)

--- a/tests/bofire/data_models/specs/kernels.py
+++ b/tests/bofire/data_models/specs/kernels.py
@@ -14,7 +14,7 @@ specs.add_valid(
 )
 specs.add_valid(
     kernels.LinearKernel,
-    lambda: {},
+    lambda: {"variance_prior": priors.valid().obj()},
 )
 specs.add_valid(
     kernels.MaternKernel,

--- a/tests/bofire/data_models/specs/strategies.py
+++ b/tests/bofire/data_models/specs/strategies.py
@@ -3,7 +3,11 @@ from bofire.benchmarks.single import Himmelblau
 from bofire.data_models.acquisition_functions.api import qPI
 from bofire.data_models.domain.api import Domain, Inputs
 from bofire.data_models.enum import CategoricalMethodEnum, SamplingMethodEnum
-from bofire.data_models.features.api import ContinuousInput
+from bofire.data_models.features.api import (
+    CategoricalInput,
+    ContinuousInput,
+    DiscreteInput,
+)
 from tests.bofire.data_models.specs.api import domain
 from tests.bofire.data_models.specs.specs import Specs
 
@@ -143,6 +147,22 @@ specs.add_valid(
                 max_parallelism=2,
             ).dict(),
         ],
+        "seed": 42,
+    },
+)
+
+
+specs.add_valid(
+    strategies.FactorialStrategy,
+    lambda: {
+        "domain": Domain(
+            inputs=Inputs(
+                features=[
+                    CategoricalInput(key="alpha", categories=["a", "b", "c"]),
+                    DiscreteInput(key="beta", values=[1.0, 2, 3.0, 4.0]),
+                ]
+            )
+        ),
         "seed": 42,
     },
 )

--- a/tests/bofire/data_models/specs/strategies.py
+++ b/tests/bofire/data_models/specs/strategies.py
@@ -142,7 +142,9 @@ specs.add_valid(
                 max_parallelism=2,
             ).dict(),
             strategies.Step(
-                strategy_data=strategies.QehviStrategy(domain=tempdomain),
+                strategy_data=strategies.QehviStrategy(
+                    domain=tempdomain,
+                ),
                 condition=strategies.NumberOfExperimentsCondition(n_experiments=30),
                 max_parallelism=2,
             ).dict(),

--- a/tests/bofire/data_models/specs/surrogates.py
+++ b/tests/bofire/data_models/specs/surrogates.py
@@ -19,6 +19,7 @@ from bofire.data_models.priors.api import (
     BOTORCH_SCALE_PRIOR,
 )
 from bofire.data_models.surrogates.api import ScalerEnum
+from bofire.data_models.surrogates.single_task_gp import SingleTaskGPHyperconfig
 from tests.bofire.data_models.specs.features import specs as features
 from tests.bofire.data_models.specs.specs import Specs
 
@@ -91,6 +92,7 @@ specs.add_valid(
         "noise_prior": BOTORCH_NOISE_PRIOR(),
         "input_preprocessing_specs": {},
         "dump": None,
+        "hyperconfig": SingleTaskGPHyperconfig(),
     },
 )
 specs.add_valid(

--- a/tests/bofire/data_models/specs/surrogates.py
+++ b/tests/bofire/data_models/specs/surrogates.py
@@ -45,6 +45,7 @@ specs.add_valid(
         "scaler": ScalerEnum.NORMALIZE,
         "input_preprocessing_specs": {"cat1": CategoricalEncodingEnum.ONE_HOT},
         "dump": None,
+        "hyperconfig": None,
     },
 )
 
@@ -67,6 +68,7 @@ specs.add_valid(
         "scaler": ScalerEnum.NORMALIZE,
         "input_preprocessing_specs": {"cat1": CategoricalEncodingEnum.ONE_HOT},
         "dump": None,
+        "hyperconfig": None,
     },
 )
 specs.add_valid(
@@ -124,6 +126,7 @@ specs.add_valid(
         "ccp_alpha": 0.0,
         "max_samples": None,
         "dump": None,
+        "hyperconfig": None,
     },
 )
 specs.add_valid(
@@ -152,5 +155,47 @@ specs.add_valid(
         "scaler": ScalerEnum.NORMALIZE,
         "input_preprocessing_specs": {},
         "dump": None,
+        "hyperconfig": None,
+    },
+)
+
+specs.add_valid(
+    models.XGBoostSurrogate,
+    lambda: {
+        "inputs": Inputs(
+            features=[
+                features.valid(ContinuousInput).obj(),
+            ]
+        ),
+        "outputs": Outputs(
+            features=[
+                features.valid(ContinuousOutput).obj(),
+            ]
+        ),
+        "n_estimators": 10,
+        "max_depth": 6,
+        "max_leaves": 0,
+        "max_bin": 256,
+        "grow_policy": "depthwise",
+        "learning_rate": 0.3,
+        "objective": "reg:squarederror",
+        "booster": "gbtree",
+        "n_jobs": 1,
+        "gamma": 0.0,
+        "min_child_weight": 1.0,
+        "max_delta_step": 0.0,
+        "subsample": 1.0,
+        "sampling_method": "uniform",
+        "colsample_bytree": 1.0,
+        "colsample_bylevel": 1.0,
+        "colsample_bynode": 1.0,
+        "reg_alpha": 0.0,
+        "reg_lambda": 1.0,
+        "scale_pos_weight": 1,
+        "random_state": None,
+        "num_parallel_tree": 1,
+        "input_preprocessing_specs": {},
+        "dump": None,
+        "hyperconfig": None,
     },
 )

--- a/tests/bofire/data_models/test_domain_validators.py
+++ b/tests/bofire/data_models/test_domain_validators.py
@@ -204,11 +204,8 @@ def test_domain_validate_experiments_valid(
 @pytest.mark.parametrize(
     "domain, experiments, strict",
     [
-        (d1, generate_experiments(d2), strict)
-        for strict in [True, False]
-        for d1 in domains
-        for d2 in domains
-        if d1 != d2
+        (domains[0], generate_experiments(domains[1]), True),
+        (domains[0], generate_experiments(domains[1]), False),
     ],
 )
 def test_domain_validate_experiments_invalid(

--- a/tests/bofire/strategies/test_factorial.py
+++ b/tests/bofire/strategies/test_factorial.py
@@ -1,0 +1,43 @@
+import pytest
+
+import bofire.strategies.api as strategies
+from bofire.data_models.domain.api import Domain, Inputs
+from bofire.data_models.features.api import CategoricalInput, DiscreteInput
+from bofire.data_models.strategies.api import FactorialStrategy
+
+
+def test_FactorialStrategy_ask():
+    strategy_data = FactorialStrategy(
+        domain=Domain(
+            inputs=Inputs(
+                features=[
+                    CategoricalInput(key="alpha", categories=["a", "b", "c"]),
+                    DiscreteInput(key="beta", values=[1.0, 2, 3.0, 4.0]),
+                ]
+            )
+        )
+    )
+    strategy = strategies.map(strategy_data)
+    candidates = strategy.ask(None)
+    assert len(candidates) == 12
+
+
+def test_FactorialStrategy_ask_invalid():
+    strategy_data = FactorialStrategy(
+        domain=Domain(
+            inputs=Inputs(
+                features=[
+                    CategoricalInput(key="alpha", categories=["a", "b", "c"]),
+                    DiscreteInput(key="beta", values=[1.0, 2, 3.0, 4.0]),
+                ]
+            )
+        )
+    )
+    strategy = strategies.map(strategy_data)
+    with pytest.raises(
+        ValueError,
+        match="FactorialStrategy will ignore the specified value of candidate_count. "
+        "The strategy automatically determines how many candidates to "
+        "propose.",
+    ):
+        strategy.ask(5)

--- a/tests/bofire/surrogates/test_gps.py
+++ b/tests/bofire/surrogates/test_gps.py
@@ -12,20 +12,36 @@ from pandas.testing import assert_frame_equal
 from pydantic import ValidationError
 
 import bofire.surrogates.api as surrogates
+from bofire.benchmarks.api import Himmelblau
 from bofire.data_models.domain.api import Inputs, Outputs
-from bofire.data_models.enum import CategoricalEncodingEnum
+from bofire.data_models.enum import CategoricalEncodingEnum, RegressionMetricsEnum
 from bofire.data_models.features.api import (
     CategoricalDescriptorInput,
     CategoricalInput,
     ContinuousInput,
     ContinuousOutput,
 )
-from bofire.data_models.kernels.api import HammondDistanceKernel, RBFKernel, ScaleKernel
+from bofire.data_models.kernels.api import (
+    HammondDistanceKernel,
+    MaternKernel,
+    RBFKernel,
+    ScaleKernel,
+)
+from bofire.data_models.priors.api import (
+    BOTORCH_LENGTHCALE_PRIOR,
+    BOTORCH_NOISE_PRIOR,
+    BOTORCH_SCALE_PRIOR,
+    MBO_LENGTHCALE_PRIOR,
+    MBO_NOISE_PRIOR,
+    MBO_OUTPUTSCALE_PRIOR,
+)
 from bofire.data_models.surrogates.api import (
     MixedSingleTaskGPSurrogate,
     ScalerEnum,
+    SingleTaskGPHyperconfig,
     SingleTaskGPSurrogate,
 )
+from bofire.data_models.surrogates.trainable import metrics2objectives
 from bofire.surrogates.single_task_gp import get_scaler
 from bofire.utils.torch_tools import tkwargs
 
@@ -214,6 +230,74 @@ def test_SingleTaskGPModel(kernel, scaler):
     model2.loads(dump)
     preds2 = model2.predict(samples)
     assert_frame_equal(preds, preds2)
+
+
+@pytest.mark.parametrize("target_metric", list(RegressionMetricsEnum))
+def test_hyperconfig_domain(target_metric: RegressionMetricsEnum):
+    # we test here also the abstract methods from the corresponding base class
+    # should be move somewhere else when tidying up all tests
+    hy = SingleTaskGPHyperconfig(target_metric=target_metric)
+    assert hy.domain.inputs == hy.inputs
+    assert hy.domain.outputs.get_keys() == [target_metric.name]
+    assert hy.domain.outputs[0].objective == metrics2objectives[target_metric]()
+
+
+def test_hyperconfig_invalid():
+    with pytest.raises(
+        ValueError,
+        match="It is not allowed to scpecify the number of its for FactorialStrategy",
+    ):
+        SingleTaskGPHyperconfig(n_iterations=5)
+    with pytest.raises(
+        ValueError,
+        match="At least number of hyperparams plus 2 iterations has to be specified",
+    ):
+        SingleTaskGPHyperconfig(n_iterations=3, hyperstrategy="RandomStrategy")
+    hy = SingleTaskGPHyperconfig(n_iterations=None, hyperstrategy="RandomStrategy")
+    assert hy.n_iterations == 13
+
+
+def test_SingleTaskGPHyperconfig():
+    # we test here also the basic trainable
+    benchmark = Himmelblau()
+    surrogate_data_no_hy = SingleTaskGPSurrogate(
+        inputs=benchmark.domain.inputs,
+        outputs=benchmark.domain.outputs,
+        hyperconfig=None,
+    )
+    with pytest.raises(ValueError, match="No hyperconfig available."):
+        surrogate_data_no_hy.update_hyperparameters(
+            benchmark.domain.inputs.sample(1).loc[0]
+        )
+    # test that correct stuff is written
+    surrogate_data = SingleTaskGPSurrogate(
+        inputs=benchmark.domain.inputs, outputs=benchmark.domain.outputs
+    )
+    candidate = surrogate_data.hyperconfig.inputs.sample(1).loc[0]
+    surrogate_data.update_hyperparameters(candidate)
+    assert surrogate_data.kernel.base_kernel.ard == (candidate["ard"] == "True")
+    if candidate.kernel == "matern_1.5":
+        assert isinstance(surrogate_data.kernel.base_kernel, MaternKernel)
+        assert surrogate_data.kernel.base_kernel.nu == 1.5
+    elif candidate.kernel == "matern_2.5":
+        assert isinstance(surrogate_data.kernel.base_kernel, MaternKernel)
+        assert surrogate_data.kernel.base_kernel.nu == 2.5
+    else:
+        assert isinstance(surrogate_data.kernel.base_kernel, RBFKernel)
+    if candidate.prior == "mbo":
+        assert surrogate_data.noise_prior == MBO_NOISE_PRIOR()
+        assert surrogate_data.kernel.outputscale_prior == MBO_OUTPUTSCALE_PRIOR()
+        assert (
+            surrogate_data.kernel.base_kernel.lengthscale_prior
+            == MBO_LENGTHCALE_PRIOR()
+        )
+    else:
+        assert surrogate_data.noise_prior == BOTORCH_NOISE_PRIOR()
+        assert surrogate_data.kernel.outputscale_prior == BOTORCH_SCALE_PRIOR()
+        assert (
+            surrogate_data.kernel.base_kernel.lengthscale_prior
+            == BOTORCH_LENGTHCALE_PRIOR()
+        )
 
 
 def test_MixedGPModel_invalid_preprocessing():

--- a/tests/bofire/surrogates/test_linear.py
+++ b/tests/bofire/surrogates/test_linear.py
@@ -1,0 +1,34 @@
+import numpy as np
+
+import bofire.surrogates.api as surrogates
+from bofire.data_models.domain.api import Inputs, Outputs
+from bofire.data_models.features.api import ContinuousInput, ContinuousOutput
+from bofire.data_models.kernels.api import LinearKernel
+from bofire.data_models.surrogates.api import LinearSurrogate
+
+
+def test_LinearSurrogate():
+    N_EXPERIMENTS = 10
+
+    inputs = Inputs(
+        features=[
+            ContinuousInput(key="a", bounds=(0, 40)),
+            ContinuousInput(key="b", bounds=(20, 60)),
+        ]
+    )
+    outputs = Outputs(features=[ContinuousOutput(key="c")])
+
+    experiments = inputs.sample(N_EXPERIMENTS)
+    experiments["c"] = (
+        experiments["a"] * 2.2
+        + experiments["b"] * -0.05
+        + experiments["b"]
+        + np.random.normal(loc=0, scale=5, size=N_EXPERIMENTS)
+    )
+    experiments["valid_c"] = 1
+
+    surrogate_data = LinearSurrogate(inputs=inputs, outputs=outputs)
+    surrogate = surrogates.map(surrogate_data)
+
+    assert isinstance(surrogate, surrogates.SingleTaskGPSurrogate)
+    assert isinstance(surrogate.kernel, LinearKernel)


### PR DESCRIPTION
This PR adds the possibility to optimize hyperparameters of bofire surrogates in an easy manner with bofire. For this purpose, trainable surrogates can have a configuration object attached in which the hyperparameters and its ranges etc. are defined, together with a method how to update them. 

Changing this configuration object which is part of the surrogate's data model allows to tweak the applied hyperparameter optimization. 

Furthermore, this PR adds:
- `FactorialStrategy` for purely discrete/categorical domains
- LinearSurrogate to easily setup linear models

In a next step, one could enable automatic hyperparameter optimization also in strategies.