### PR TITLE
Add testing against Botorch devel

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -55,29 +55,29 @@ jobs:
       - name: Run pip freeze, Python ${{ matrix.python-version }}
         run: pip freeze
 
-    testing_against_latest_botorch:
-      runs-on: ubuntu-latest
-      steps:
-        - uses: actions/checkout@v2
-        - uses: actions/setup-python@v2
-          with:
-            python-version: 3.10
-        - name: Install latest botorch
-          run: |
-            pip install --upgrade git+https://github.com/cornellius-gp/linear_operator.git
-            pip install --upgrade git+https://github.com/cornellius-gp/gpytorch.git
-            export ALLOW_LATEST_GPYTORCH_LINOP=true
-            pip install --upgrade git+https://github.com/pytorch/botorch.git
-        - name: Install Bofire, Python ${{ matrix.python-version }}
-          run: pip install ".[optimization,tests,cheminfo,xgb]"
-        - name: Install ipopt, Python ${{ matrix.python-version }}
-          run: sudo apt install build-essential pkg-config coinor-libipopt1v5 coinor-libipopt-dev
-        - name: Install cyipopt, Python ${{ matrix.python-version }}
-          run: pip install cyipopt
-        - name: Run tests, Python ${{ matrix.python-version }}
-          run: pytest -ra --cov=bofire --cov-report term-missing tests
-        - name: Run pip freeze, Python ${{ matrix.python-version }}
-          run: pip freeze    
+  testing_against_latest_botorch:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+          python-version: 3.10
+      - name: Install latest botorch
+        run: |
+          pip install --upgrade git+https://github.com/cornellius-gp/linear_operator.git
+          pip install --upgrade git+https://github.com/cornellius-gp/gpytorch.git
+          export ALLOW_LATEST_GPYTORCH_LINOP=true
+          pip install --upgrade git+https://github.com/pytorch/botorch.git
+      - name: Install Bofire, Python ${{ matrix.python-version }}
+        run: pip install ".[optimization,tests,cheminfo,xgb]"
+      - name: Install ipopt, Python ${{ matrix.python-version }}
+        run: sudo apt install build-essential pkg-config coinor-libipopt1v5 coinor-libipopt-dev
+      - name: Install cyipopt, Python ${{ matrix.python-version }}
+        run: pip install cyipopt
+      - name: Run tests, Python ${{ matrix.python-version }}
+        run: pytest -ra --cov=bofire --cov-report term-missing tests
+      - name: Run pip freeze, Python ${{ matrix.python-version }}
+        run: pip freeze    
 
 
   testing_tutorials:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -61,7 +61,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
         with:
-          python-version: 3.10
+          python-version: '3.10'
       - name: Install latest botorch
         run: |
           pip install --upgrade git+https://github.com/cornellius-gp/linear_operator.git
@@ -86,7 +86,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
         with:
-          python-version: 3.10
+          python-version: '3.10'
       - name: Install Bofire
         run: pip install ".[optimization,tests,cheminfo,xgb]"
       - name: Install ipopt

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -55,6 +55,30 @@ jobs:
       - name: Run pip freeze, Python ${{ matrix.python-version }}
         run: pip freeze
 
+    testing_against_latest_botorch:
+      runs-on: ubuntu-latest
+      steps:
+        - uses: actions/checkout@v2
+        - uses: actions/setup-python@v2
+          with:
+            python-version: 3.10
+        - name: Install latest botorch
+          run: |
+            pip install --upgrade git+https://github.com/cornellius-gp/linear_operator.git
+            pip install --upgrade git+https://github.com/cornellius-gp/gpytorch.git
+            export ALLOW_LATEST_GPYTORCH_LINOP=true
+            pip install --upgrade git+https://github.com/pytorch/botorch.git
+        - name: Install Bofire, Python ${{ matrix.python-version }}
+          run: pip install ".[optimization,tests,cheminfo,xgb]"
+        - name: Install ipopt, Python ${{ matrix.python-version }}
+          run: sudo apt install build-essential pkg-config coinor-libipopt1v5 coinor-libipopt-dev
+        - name: Install cyipopt, Python ${{ matrix.python-version }}
+          run: pip install cyipopt
+        - name: Run tests, Python ${{ matrix.python-version }}
+          run: pytest -ra --cov=bofire --cov-report term-missing tests
+        - name: Run pip freeze, Python ${{ matrix.python-version }}
+          run: pip freeze    
+
 
   testing_tutorials:
     runs-on: ubuntu-latest
@@ -62,7 +86,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
         with:
-          python-version: 3.9
+          python-version: 3.10
       - name: Install Bofire
         run: pip install ".[optimization,tests,cheminfo,xgb]"
       - name: Install ipopt

--- a/scripts/run_tutorials.py
+++ b/scripts/run_tutorials.py
@@ -68,12 +68,16 @@ def run_tutorials(
         }
     ).set_index("name")
 
+    # ToDo: take care
+    # here are notebooks which are not tested due to random issues
+    blacklist = ["basic_examples.ipynb"]
+
     for tutorial in tutorials:
         print(42 * "#", tutorial)
         # # for now we skip all tutorials but the one for which we have implemented SMOKE_TEST. This will change soon!
-        # if str(tutorial).split("/")[-1] not in running_tutorials:
-        #     print("Skipping", str(tutorial))
-        #     continue
+        if str(tutorial).split("/")[-1] in blacklist:
+            print("Skipping", str(tutorial))
+            continue
         num_runs += 1
         t1 = time.time()
         run_out = run_script(tutorial, env=env, timeout_minutes=timeout_minutes)

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ setup(
     extras_require={
         "optimization": [
             "torch>=1.12",
-            "botorch>=0.8.4",
+            "botorch>=0.8.5",
             "multiprocess",
             "plotly",
             "formulaic>=0.6.0",


### PR DESCRIPTION
This PR adds a test in which bofire is tested against the latest development versions of `botorch`, `gpytorch` and `linear_operator`.

In addition, I took the `basic_examples.ipynb` tutorial for DoE out of the tests as it is failing too ofter. @Osburg will take care (https://github.com/experimental-design/bofire/issues/236).