### PR TITLE
Feature/bump botorch

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ '3.8', '3.9', '3.10' ]
+        python-version: ['3.9', '3.10', '3.11' ]
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
@@ -38,7 +38,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ '3.8', '3.10' ]
+        python-version: [ '3.9', '3.11' ]
     steps:
       - uses: actions/checkout@v3
       - uses: conda-incubator/setup-miniconda@v2

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ setup(
     ],
     long_description=long_description,
     long_description_content_type="text/markdown",
-    python_requires=">=3.8",
+    python_requires=">=3.9.0",
     packages=find_packages(),
     include_package_data=True,
     install_requires=[
@@ -42,8 +42,7 @@ setup(
     ],
     extras_require={
         "optimization": [
-            "torch>=1.12",
-            "botorch>=0.8.5",
+            "botorch>=0.9.1",
             "multiprocess",
             "plotly",
             "formulaic>=0.6.0",


### PR DESCRIPTION
This PR bumps the botorch version to 0.9.1 and the minimal required python version to 3.9.0.