### PR TITLE
Fix for to and from categorical variable encoding

### DIFF
--- a/bofire/data_models/features/categorical.py
+++ b/bofire/data_models/features/categorical.py
@@ -226,7 +226,7 @@ class CategoricalInput(Input):
             raise ValueError(
                 f"{self.key}: Column names don't match categorical levels: {values.columns}, {cat_cols}."
             )
-        s = values[cat_cols].idxmax(1).str[(len(self.key) + 1):]
+        s = values[cat_cols].idxmax(1).str[(len(self.key) + 1) :]
         s.name = self.key
         return s
 
@@ -266,7 +266,7 @@ class CategoricalInput(Input):
             )
         values = values.copy()
         values[cat_cols[0]] = 1 - values[cat_cols[1:]].sum(axis=1)
-        s = values[cat_cols].idxmax(1).str[(len(self.key) + 1):]
+        s = values[cat_cols].idxmax(1).str[(len(self.key) + 1) :]
         s.name = self.key
         return s
 

--- a/bofire/data_models/features/categorical.py
+++ b/bofire/data_models/features/categorical.py
@@ -218,7 +218,7 @@ class CategoricalInput(Input):
             raise ValueError(
                 f"{self.key}: Column names don't match categorical levels: {values.columns}, {cat_cols}."
             )
-        s = values[cat_cols].idxmax(1).str.split(_CAT_SEP, expand=True).iloc[:, -1]
+        s = values[cat_cols].idxmax(1).str[(len(self.key) + 1):]
         s.name = self.key
         return s
 
@@ -258,7 +258,7 @@ class CategoricalInput(Input):
             )
         values = values.copy()
         values[cat_cols[0]] = 1 - values[cat_cols[1:]].sum(axis=1)
-        s = values[cat_cols].idxmax(1).str.split(_CAT_SEP, expand=True).iloc[:, -1]
+        s = values[cat_cols].idxmax(1).str[(len(self.key) + 1):]
         s.name = self.key
         return s
 

--- a/tests/bofire/data_models/test_features.py
+++ b/tests/bofire/data_models/test_features.py
@@ -576,7 +576,12 @@ def test_categorical_input_feature_validate_candidental_invalid(input_feature, v
         (
             "__c_alpha_c_",
             ["__c_alpha_c__B_b", "__c_alpha_c___A_a", "__c_alpha_c__C_c_"],
-            ["__c_alpha_c___A_a", "__c_alpha_c___A_a", "__c_alpha_c__C_c_", "__c_alpha_c__B_b"],
+            [
+                "__c_alpha_c___A_a",
+                "__c_alpha_c___A_a",
+                "__c_alpha_c__C_c_",
+                "__c_alpha_c__B_b",
+            ],
         ),
     ],
 )
@@ -600,7 +605,10 @@ def test_categorical_to_one_hot_encoding(key, categories, samples):
     [
         ("c", ["B", "A", "C"]),
         ("c_alpha", ["B_b", "_A_a", "C_c_"]),
-        ("__c_alpha_c_", ["__c_alpha_c__B_b", "__c_alpha_c___A_a", "__c_alpha_c__C_c_"]),
+        (
+            "__c_alpha_c_",
+            ["__c_alpha_c__B_b", "__c_alpha_c___A_a", "__c_alpha_c__C_c_"],
+        ),
     ],
 )
 def test_categorical_from_one_hot_encoding(key, categories):
@@ -638,7 +646,12 @@ def test_categorical_from_one_hot_encoding_invalid():
         (
             "__c_alpha_c_",
             ["__c_alpha_c__B_b", "__c_alpha_c___A_a", "__c_alpha_c__C_c_"],
-            ["__c_alpha_c___A_a", "__c_alpha_c___A_a", "__c_alpha_c__C_c_", "__c_alpha_c__B_b"],
+            [
+                "__c_alpha_c___A_a",
+                "__c_alpha_c___A_a",
+                "__c_alpha_c__C_c_",
+                "__c_alpha_c__B_b",
+            ],
         ),
     ],
 )
@@ -662,7 +675,10 @@ def test_categorical_to_dummy_encoding(key, categories, samples):
     [
         ("c", ["B", "A", "C"]),
         ("c_alpha", ["B_b", "_A_a", "C_c_"]),
-        ("__c_alpha_c_", ["__c_alpha_c__B_b", "__c_alpha_c___A_a", "__c_alpha_c__C_c_"]),
+        (
+            "__c_alpha_c_",
+            ["__c_alpha_c__B_b", "__c_alpha_c___A_a", "__c_alpha_c__C_c_"],
+        ),
     ],
 )
 def test_categorical_from_dummy_encoding(key, categories):
@@ -739,19 +755,33 @@ def test_categorical_get_bounds(feature, transform_type, values, expected):
     assert np.allclose(lower, expected[0])
     assert np.allclose(upper, expected[1])
 
+
 @pytest.mark.parametrize(
     "key, categories, samples_in, descriptors",
     [
         ("c", ["B", "A", "C"], ["A", "A", "C", "B"], ["d1", "d2"]),
-        ("c_alpha", ["B_b", "_A_a", "C_c_"], ["_A_a", "_A_a", "C_c_", "B_b"], ["_d1_d", "d2_d_2_"]),
+        (
+            "c_alpha",
+            ["B_b", "_A_a", "C_c_"],
+            ["_A_a", "_A_a", "C_c_", "B_b"],
+            ["_d1_d", "d2_d_2_"],
+        ),
         (
             "__c_alpha_c_",
             ["__c_alpha_c__B_b", "__c_alpha_c___A_a", "__c_alpha_c__C_c_"],
-            ["__c_alpha_c___A_a", "__c_alpha_c___A_a", "__c_alpha_c__C_c_", "__c_alpha_c__B_b"], ["__c_alpha_c__d1_d", "__c_alpha_c_d2_d_2_"]
+            [
+                "__c_alpha_c___A_a",
+                "__c_alpha_c___A_a",
+                "__c_alpha_c__C_c_",
+                "__c_alpha_c__B_b",
+            ],
+            ["__c_alpha_c__d1_d", "__c_alpha_c_d2_d_2_"],
         ),
     ],
 )
-def test_categorical_descriptor_to_descriptor_encoding(key, categories, samples_in, descriptors):
+def test_categorical_descriptor_to_descriptor_encoding(
+    key, categories, samples_in, descriptors
+):
     c = CategoricalDescriptorInput(
         key=key,
         categories=categories,
@@ -770,6 +800,7 @@ def test_categorical_descriptor_to_descriptor_encoding(key, categories, samples_
     untransformed = c.from_descriptor_encoding(t_samples)
     assert np.all(samples == untransformed)
 
+
 @pytest.mark.parametrize(
     "key, categories, descriptors",
     [
@@ -777,7 +808,8 @@ def test_categorical_descriptor_to_descriptor_encoding(key, categories, samples_
         ("c_alpha", ["B_b", "_A_a", "C_c_"], ["_d1_d", "d2_d_2_"]),
         (
             "__c_alpha_c_",
-            ["__c_alpha_c__B_b", "__c_alpha_c___A_a", "__c_alpha_c__C_c_"], ["__c_alpha_c__d1_d", "__c_alpha_c_d2_d_2_"]
+            ["__c_alpha_c__B_b", "__c_alpha_c___A_a", "__c_alpha_c__C_c_"],
+            ["__c_alpha_c__d1_d", "__c_alpha_c_d2_d_2_"],
         ),
     ],
 )

--- a/tests/bofire/data_models/test_molecular.py
+++ b/tests/bofire/data_models/test_molecular.py
@@ -281,53 +281,56 @@ def test_molecular_descriptor_feature_get_bounds(expected, transform_type):
 
 @pytest.mark.skipif(not RDKIT_AVAILABLE, reason="requires rdkit")
 @pytest.mark.parametrize(
-    "transform_type, values",
+    "key, transform_type, values",
     [
         (
+            "molecule_2_two",
             Fingerprints(n_bits=32),
             {
-                "molecule_fingerprint_0": {0: 1.0, 1: 1.0, 2: 0.0, 3: 0.0},
-                "molecule_fingerprint_1": {0: 1.0, 1: 0.0, 2: 1.0, 3: 1.0},
-                "molecule_fingerprint_2": {0: 1.0, 1: 0.0, 2: 1.0, 3: 0.0},
-                "molecule_fingerprint_3": {0: 1.0, 1: 0.0, 2: 0.0, 3: 1.0},
-                "molecule_fingerprint_4": {0: 1.0, 1: 0.0, 2: 0.0, 3: 0.0},
-                "molecule_fingerprint_5": {0: 1.0, 1: 1.0, 2: 0.0, 3: 1.0},
-                "molecule_fingerprint_6": {0: 0.0, 1: 0.0, 2: 1.0, 3: 0.0},
-                "molecule_fingerprint_7": {0: 1.0, 1: 0.0, 2: 1.0, 3: 1.0},
-                "molecule_fingerprint_8": {0: 1.0, 1: 0.0, 2: 0.0, 3: 1.0},
-                "molecule_fingerprint_9": {0: 1.0, 1: 0.0, 2: 0.0, 3: 0.0},
-                "molecule_fingerprint_10": {0: 1.0, 1: 0.0, 2: 0.0, 3: 1.0},
-                "molecule_fingerprint_11": {0: 1.0, 1: 0.0, 2: 0.0, 3: 0.0},
-                "molecule_fingerprint_12": {0: 0.0, 1: 0.0, 2: 0.0, 3: 0.0},
-                "molecule_fingerprint_13": {0: 1.0, 1: 0.0, 2: 0.0, 3: 1.0},
-                "molecule_fingerprint_14": {0: 0.0, 1: 0.0, 2: 0.0, 3: 0.0},
-                "molecule_fingerprint_15": {0: 1.0, 1: 0.0, 2: 0.0, 3: 0.0},
-                "molecule_fingerprint_16": {0: 1.0, 1: 1.0, 2: 1.0, 3: 0.0},
-                "molecule_fingerprint_17": {0: 1.0, 1: 1.0, 2: 0.0, 3: 0.0},
-                "molecule_fingerprint_18": {0: 1.0, 1: 0.0, 2: 0.0, 3: 1.0},
-                "molecule_fingerprint_19": {0: 0.0, 1: 0.0, 2: 0.0, 3: 1.0},
-                "molecule_fingerprint_20": {0: 0.0, 1: 0.0, 2: 0.0, 3: 0.0},
-                "molecule_fingerprint_21": {0: 0.0, 1: 0.0, 2: 0.0, 3: 0.0},
-                "molecule_fingerprint_22": {0: 1.0, 1: 0.0, 2: 0.0, 3: 0.0},
-                "molecule_fingerprint_23": {0: 1.0, 1: 0.0, 2: 0.0, 3: 1.0},
-                "molecule_fingerprint_24": {0: 0.0, 1: 0.0, 2: 0.0, 3: 0.0},
-                "molecule_fingerprint_25": {0: 1.0, 1: 0.0, 2: 0.0, 3: 1.0},
-                "molecule_fingerprint_26": {0: 0.0, 1: 0.0, 2: 0.0, 3: 0.0},
-                "molecule_fingerprint_27": {0: 1.0, 1: 0.0, 2: 0.0, 3: 0.0},
-                "molecule_fingerprint_28": {0: 1.0, 1: 0.0, 2: 0.0, 3: 0.0},
-                "molecule_fingerprint_29": {0: 1.0, 1: 0.0, 2: 0.0, 3: 1.0},
-                "molecule_fingerprint_30": {0: 0.0, 1: 0.0, 2: 1.0, 3: 0.0},
-                "molecule_fingerprint_31": {0: 0.0, 1: 0.0, 2: 0.0, 3: 0.0},
+                "molecule_2_two_fingerprint_0": {0: 1.0, 1: 1.0, 2: 0.0, 3: 0.0},
+                "molecule_2_two_fingerprint_1": {0: 1.0, 1: 0.0, 2: 1.0, 3: 1.0},
+                "molecule_2_two_fingerprint_2": {0: 1.0, 1: 0.0, 2: 1.0, 3: 0.0},
+                "molecule_2_two_fingerprint_3": {0: 1.0, 1: 0.0, 2: 0.0, 3: 1.0},
+                "molecule_2_two_fingerprint_4": {0: 1.0, 1: 0.0, 2: 0.0, 3: 0.0},
+                "molecule_2_two_fingerprint_5": {0: 1.0, 1: 1.0, 2: 0.0, 3: 1.0},
+                "molecule_2_two_fingerprint_6": {0: 0.0, 1: 0.0, 2: 1.0, 3: 0.0},
+                "molecule_2_two_fingerprint_7": {0: 1.0, 1: 0.0, 2: 1.0, 3: 1.0},
+                "molecule_2_two_fingerprint_8": {0: 1.0, 1: 0.0, 2: 0.0, 3: 1.0},
+                "molecule_2_two_fingerprint_9": {0: 1.0, 1: 0.0, 2: 0.0, 3: 0.0},
+                "molecule_2_two_fingerprint_10": {0: 1.0, 1: 0.0, 2: 0.0, 3: 1.0},
+                "molecule_2_two_fingerprint_11": {0: 1.0, 1: 0.0, 2: 0.0, 3: 0.0},
+                "molecule_2_two_fingerprint_12": {0: 0.0, 1: 0.0, 2: 0.0, 3: 0.0},
+                "molecule_2_two_fingerprint_13": {0: 1.0, 1: 0.0, 2: 0.0, 3: 1.0},
+                "molecule_2_two_fingerprint_14": {0: 0.0, 1: 0.0, 2: 0.0, 3: 0.0},
+                "molecule_2_two_fingerprint_15": {0: 1.0, 1: 0.0, 2: 0.0, 3: 0.0},
+                "molecule_2_two_fingerprint_16": {0: 1.0, 1: 1.0, 2: 1.0, 3: 0.0},
+                "molecule_2_two_fingerprint_17": {0: 1.0, 1: 1.0, 2: 0.0, 3: 0.0},
+                "molecule_2_two_fingerprint_18": {0: 1.0, 1: 0.0, 2: 0.0, 3: 1.0},
+                "molecule_2_two_fingerprint_19": {0: 0.0, 1: 0.0, 2: 0.0, 3: 1.0},
+                "molecule_2_two_fingerprint_20": {0: 0.0, 1: 0.0, 2: 0.0, 3: 0.0},
+                "molecule_2_two_fingerprint_21": {0: 0.0, 1: 0.0, 2: 0.0, 3: 0.0},
+                "molecule_2_two_fingerprint_22": {0: 1.0, 1: 0.0, 2: 0.0, 3: 0.0},
+                "molecule_2_two_fingerprint_23": {0: 1.0, 1: 0.0, 2: 0.0, 3: 1.0},
+                "molecule_2_two_fingerprint_24": {0: 0.0, 1: 0.0, 2: 0.0, 3: 0.0},
+                "molecule_2_two_fingerprint_25": {0: 1.0, 1: 0.0, 2: 0.0, 3: 1.0},
+                "molecule_2_two_fingerprint_26": {0: 0.0, 1: 0.0, 2: 0.0, 3: 0.0},
+                "molecule_2_two_fingerprint_27": {0: 1.0, 1: 0.0, 2: 0.0, 3: 0.0},
+                "molecule_2_two_fingerprint_28": {0: 1.0, 1: 0.0, 2: 0.0, 3: 0.0},
+                "molecule_2_two_fingerprint_29": {0: 1.0, 1: 0.0, 2: 0.0, 3: 1.0},
+                "molecule_2_two_fingerprint_30": {0: 0.0, 1: 0.0, 2: 1.0, 3: 0.0},
+                "molecule_2_two_fingerprint_31": {0: 0.0, 1: 0.0, 2: 0.0, 3: 0.0},
             },
         ),
         (
+            "molecule_",
             Fragments(fragments=["fr_unbrch_alkane", "fr_thiocyan"]),
             {
-                "molecule_fr_unbrch_alkane": {0: 0.0, 1: 0.0, 2: 0.0, 3: 0.0},
-                "molecule_fr_thiocyan": {0: 0.0, 1: 0.0, 2: 0.0, 3: 0.0},
+                "molecule__fr_unbrch_alkane": {0: 0.0, 1: 0.0, 2: 0.0, 3: 0.0},
+                "molecule__fr_thiocyan": {0: 0.0, 1: 0.0, 2: 0.0, 3: 0.0},
             },
         ),
         (
+            "molecule",
             FingerprintsFragments(
                 n_bits=32, fragments=["fr_unbrch_alkane", "fr_thiocyan"]
             ),
@@ -369,21 +372,22 @@ def test_molecular_descriptor_feature_get_bounds(expected, transform_type):
             },
         ),
         (
+            "_mo_le_cule",
             MordredDescriptors(descriptors=["NssCH2", "ATSC2d"]),
             {
-                "molecule_NssCH2": {
+                "_mo_le_cule_NssCH2": {
                     0: 0.5963718820861676,
                     1: -1.5,
                     2: -0.28395061728395066,
                     3: -8.34319526627219,
                 },
-                "molecule_ATSC2d": {0: 0.0, 1: 0.0, 2: 1.0, 3: 0.0},
+                "_mo_le_cule_ATSC2d": {0: 0.0, 1: 0.0, 2: 1.0, 3: 0.0},
             },
         ),
     ],
 )
-def test_molecular_input_to_descriptor_encoding(transform_type, values):
-    input_feature = MolecularInput(key="molecule")
+def test_molecular_input_to_descriptor_encoding(key, transform_type, values):
+    input_feature = MolecularInput(key=key)
 
     encoded = input_feature.to_descriptor_encoding(transform_type, VALID_SMILES)
     assert len(encoded.columns) == len(transform_type.get_descriptor_names())
@@ -561,10 +565,19 @@ def test_categorical_molecular_input_valid_smiles():
     CategoricalMolecularInput(key="a", categories=VALID_SMILES.tolist())
 
 
+@pytest.mark.parametrize(
+    "key",
+    [
+        ("molecule_2_two"),
+        ("molecule_"),
+        ("molecule"),
+        ("_mo_le_cule"),
+    ],
+)
 @pytest.mark.skipif(not RDKIT_AVAILABLE, reason="requires rdkit")
-def test_categorical_molecular_input_from_descriptor_encoding():
-    feat = CategoricalMolecularInput(key="a", categories=VALID_SMILES.to_list())
-    values = pd.Series(data=["c1ccccc1", "[CH3][CH2][OH]"], name="a")
+def test_categorical_molecular_input_from_descriptor_encoding(key):
+    feat = CategoricalMolecularInput(key=key, categories=VALID_SMILES.to_list())
+    values = pd.Series(data=["c1ccccc1", "[CH3][CH2][OH]"], name=key)
     for transform_type in [
         Fingerprints(),
         FingerprintsFragments(),


### PR DESCRIPTION
A follow-up to PR#[200](https://github.com/experimental-design/bofire/pull/200)

The previous PR was still buggy when the categories had underscores in them.
This PR is a fix for this