### PR TITLE
add generic benchmarl module

### DIFF
--- a/bofire/benchmarks/api.py
+++ b/bofire/benchmarks/api.py
@@ -1,7 +1,7 @@
 from typing import Union
 
 from bofire.benchmarks.aspen_benchmark import Aspen_benchmark
-from bofire.benchmarks.benchmark import Benchmark
+from bofire.benchmarks.benchmark import Benchmark, GenericBenchmark, run
 from bofire.benchmarks.hyperopt import Hyperopt, hyperoptimize
 from bofire.benchmarks.multi import C2DTLZ2, DTLZ2, ZDT1, CrossCoupling, SnarBenchmark
 from bofire.benchmarks.single import Ackley, Branin, Branin30, Hartmann, Himmelblau

--- a/bofire/benchmarks/benchmark.py
+++ b/bofire/benchmarks/benchmark.py
@@ -86,6 +86,22 @@ class Benchmark:
         return self._domain  # type: ignore
 
 
+class GenericBenchmark(Benchmark):
+    def __init__(
+        self,
+        domain: Domain,
+        func: Callable[[pd.DataFrame], pd.DataFrame],
+        outlier_rate: Annotated[float, Field(ge=0, lt=1)] = 0,
+        outlier_prior: Optional[AnyOutlierPrior] = None,
+    ):
+        super().__init__(outlier_prior=outlier_prior, outlier_rate=outlier_rate)
+        self._domain = domain
+        self.func = func
+
+    def _f(self, candidates: pd.DataFrame) -> pd.DataFrame:
+        return self.func(candidates)
+
+
 class StrategyFactory(Protocol):
     def __call__(self, domain: Domain) -> AnyStrategy:
         ...

--- a/tests/bofire/benchmarks/test_benchmark.py
+++ b/tests/bofire/benchmarks/test_benchmark.py
@@ -1,8 +1,10 @@
 import numpy as np
 import pandas as pd
+from pandas.testing import assert_frame_equal
 
 import bofire.benchmarks.benchmark as benchmark
 import bofire.strategies.api as strategies
+from bofire.benchmarks.api import GenericBenchmark
 from bofire.benchmarks.multi import ZDT1
 from bofire.benchmarks.single import Himmelblau
 from bofire.data_models.domain.api import Domain
@@ -14,6 +16,15 @@ from bofire.data_models.strategies.api import (
     RejectionSampler as RejectionSamplerDataModel,
 )
 from bofire.utils.multiobjective import compute_hypervolume
+
+
+def test_generic_benchmark():
+    bench = ZDT1(n_inputs=5)
+    genbench = GenericBenchmark(domain=bench.domain, func=bench._f)
+    candidates = bench.domain.inputs.sample(5)
+    samples1 = bench.f(candidates=candidates)
+    samples2 = genbench.f(candidates=candidates)
+    assert_frame_equal(samples1, samples2)
 
 
 def test_benchmark():


### PR DESCRIPTION
This PR adds a generic benchmark class which takes a `Domain` and a `Callable` as input.