### PR TITLE
Fragment filter

### DIFF
--- a/bofire/data_models/molfeatures/molfeatures.py
+++ b/bofire/data_models/molfeatures/molfeatures.py
@@ -1,6 +1,7 @@
 from abc import abstractmethod
 from typing import List, Literal, Optional
 
+import numpy as np
 import pandas as pd
 from pydantic import Field, validator
 from typing_extensions import Annotated
@@ -86,6 +87,22 @@ class Fragments(MolFeatures):
             columns=self.get_descriptor_names(),
             index=values.index,
         )
+
+    def get_contained_fragments(self, values: pd.Series) -> List[str]:
+        """Returns the list of fragments that containied in the provided list of smiles.
+
+        Args:
+            values (pd.Series): Series of smiles.
+
+        Returns:
+            List[str]: List of the contained fragments.
+        """
+        fragments = self.fragments or names.fragments
+        descriptor_values = smiles2fragments(
+            smiles=values.tolist(), fragments_list=fragments
+        )
+        nonzero_cols = np.any(descriptor_values, axis=0).nonzero()[0].tolist()
+        return [fragments[i] for i in nonzero_cols]
 
 
 class FingerprintsFragments(Fingerprints, Fragments):

--- a/tests/bofire/data_models/test_molfeatures.py
+++ b/tests/bofire/data_models/test_molfeatures.py
@@ -1,8 +1,10 @@
 import importlib
 
+import pandas as pd
 import pytest
 
 import bofire.data_models.molfeatures.names as names
+from bofire.data_models.molfeatures.api import Fragments
 
 RDKIT_AVAILABLE = importlib.util.find_spec("rdkit") is not None
 
@@ -23,3 +25,18 @@ def test_mordred():
 
     calc = Calculator(mordred_descriptors, ignore_3D=False)
     assert names.mordred == [str(d) for d in calc.descriptors]
+
+
+@pytest.mark.skipif(not RDKIT_AVAILABLE, reason="requires rdkit")
+@pytest.mark.parametrize("fragments", [None, ["fr_Al_COO", "fr_Al_OH"]])
+def test_fragments_get_contained_fragments(fragments):
+    mf = Fragments(fragments=fragments)
+    smiles = pd.Series(
+        [
+            "CC(=O)Oc1ccccc1C(=O)O",
+            "c1ccccc1",
+            "[CH3][CH2][OH]",
+            "N[C@](C)(F)C(=O)O",
+        ]
+    )
+    mf.get_contained_fragments(smiles)


### PR DESCRIPTION
This PR adds a method that can be used to get only the contained fragments for a list of smiles. This can then be used to intitialize the `Fragments` object only with the needed fragments. One could also think about adding a method which returns only the fragments with variance in it.