### PR TITLE
Refactor get acquisition

### DIFF
--- a/bofire/data_models/strategies/predictives/sobo.py
+++ b/bofire/data_models/strategies/predictives/sobo.py
@@ -59,9 +59,25 @@ class AdditiveSoboStrategy(SoboBaseStrategy):
     type: Literal["AdditiveSoboStrategy"] = "AdditiveSoboStrategy"
     use_output_constraints: bool = True
 
+    @validator("domain")
+    def validate_is_multiobjective(cls, v, values):
+        if (len(v.outputs.get_by_objective(Objective))) < 2:
+            raise ValueError(
+                "Additive SOBO strategy requires at least 2 outputs with objectives. Consider SOBO strategy instead."
+            )
+        return v
+
 
 class MultiplicativeSoboStrategy(SoboBaseStrategy):
     type: Literal["MultiplicativeSoboStrategy"] = "MultiplicativeSoboStrategy"
+
+    @validator("domain")
+    def validate_is_multiobjective(cls, v, values):
+        if (len(v.outputs.get_by_objective(Objective))) < 2:
+            raise ValueError(
+                "Multiplicative SOBO strategy requires at least 2 outputs with objectives. Consider SOBO strategy instead."
+            )
+        return v
 
 
 class CustomSoboStrategy(SoboBaseStrategy):

--- a/bofire/strategies/predictives/qparego.py
+++ b/bofire/strategies/predictives/qparego.py
@@ -1,4 +1,4 @@
-from typing import List, Tuple, Union
+from typing import Callable, List, Tuple, Union
 
 import torch
 from botorch.acquisition import get_acquisition_function
@@ -10,7 +10,6 @@ from botorch.utils.sampling import sample_simplex
 
 from bofire.data_models.objectives.api import (
     CloseToTargetObjective,
-    ConstrainedObjective,
     MaximizeObjective,
     MinimizeObjective,
     Objective,
@@ -41,7 +40,9 @@ class QparegoStrategy(BotorchStrategy):
     def _get_objective_and_constraints(
         self,
     ) -> Tuple[
-        GenericMCObjective, Union[ConstrainedObjective, None], Union[List, float]
+        GenericMCObjective,
+        Union[List[Callable[[torch.Tensor], torch.Tensor]], None],
+        Union[List, float],
     ]:
         """Returns the scalarized objective.
 

--- a/bofire/strategies/predictives/sobo.py
+++ b/bofire/strategies/predictives/sobo.py
@@ -155,6 +155,8 @@ class MultiplicativeSoboStrategy(SoboStrategy):
         super().__init__(data_model=data_model, **kwargs)
 
     def _get_objective(self) -> GenericMCObjective:
+        # we absorb all constraints into the objective
+        self.constraint_callables = None
         return GenericMCObjective(
             objective=get_multiplicative_botorch_objective(  # type: ignore
                 outputs=self.domain.outputs

--- a/bofire/strategies/predictives/sobo.py
+++ b/bofire/strategies/predictives/sobo.py
@@ -18,7 +18,7 @@ from botorch.acquisition.objective import (
 )
 from botorch.models.gpytorch import GPyTorchModel
 
-from bofire.data_models.acquisition_functions.api import qPI, qUCB, qSR
+from bofire.data_models.acquisition_functions.api import qPI, qSR, qUCB
 from bofire.data_models.objectives.api import ConstrainedObjective, Objective
 from bofire.data_models.strategies.api import AdditiveSoboStrategy as AdditiveDataModel
 from bofire.data_models.strategies.api import CustomSoboStrategy as CustomDataModel

--- a/bofire/strategies/predictives/sobo.py
+++ b/bofire/strategies/predictives/sobo.py
@@ -105,10 +105,9 @@ class SoboStrategy(BotorchStrategy):
             constraint_callables, etas = None, 1e-3
 
         # special cases of qUCB and qSR do not work with separate constraints
-        if (
-            isinstance(self.acquisition_function, qUCB)
-            or isinstance(self.acquisition_function, qSR)
-        ) and (constraint_callables is not None):
+        if (isinstance(self.acquisition_function, (qSR, qUCB))) and (
+            constraint_callables is not None
+        ):
             return (
                 ConstrainedMCObjective(
                     objective=objective_callable,  # type: ignore
@@ -164,9 +163,7 @@ class AdditiveSoboStrategy(SoboStrategy):
             )
 
             # special cases of qUCB and qSR do not work with separate constraints
-            if isinstance(self.acquisition_function, qUCB) or isinstance(
-                self.acquisition_function, qSR
-            ):
+            if isinstance(self.acquisition_function, (qSR, qUCB)):
                 return (
                     ConstrainedMCObjective(
                         objective=objective_callable,  # type: ignore
@@ -264,9 +261,7 @@ class CustomSoboStrategy(SoboStrategy):
                 outputs=self.domain.outputs, f=self.f, exclude_constraints=True
             )
             # special cases of qUCB and qSR do not work with separate constraints
-            if isinstance(self.acquisition_function, qUCB) or isinstance(
-                self.acquisition_function, qSR
-            ):
+            if isinstance(self.acquisition_function, (qSR, qUCB)):
                 return (
                     ConstrainedMCObjective(
                         objective=objective_callable,  # type: ignore

--- a/bofire/strategies/predictives/sobo.py
+++ b/bofire/strategies/predictives/sobo.py
@@ -1,6 +1,6 @@
 import base64
 import warnings
-from typing import List, Union, Tuple
+from typing import List, Union
 
 try:
     import cloudpickle

--- a/bofire/strategies/predictives/sobo.py
+++ b/bofire/strategies/predictives/sobo.py
@@ -1,6 +1,6 @@
 import base64
 import warnings
-from typing import List, Tuple, Union
+from typing import Callable, List, Tuple, Union
 
 try:
     import cloudpickle
@@ -80,7 +80,7 @@ class SoboStrategy(BotorchStrategy):
         self,
     ) -> Tuple[
         Union[GenericMCObjective, ConstrainedMCObjective],
-        Union[ConstrainedObjective, None],
+        Union[List[Callable[[torch.Tensor], torch.Tensor]], None],
         Union[List, float],
     ]:
         try:
@@ -143,7 +143,7 @@ class AdditiveSoboStrategy(SoboStrategy):
         self,
     ) -> Tuple[
         Union[GenericMCObjective, ConstrainedMCObjective],
-        Union[ConstrainedObjective, None],
+        Union[List[Callable[[torch.Tensor], torch.Tensor]], None],
         Union[List, float],
     ]:
         # get the constraints
@@ -209,7 +209,9 @@ class MultiplicativeSoboStrategy(SoboStrategy):
     def _get_objective_and_constraints(
         self,
     ) -> Tuple[
-        GenericMCObjective, Union[ConstrainedObjective, None], Union[List, float]
+        GenericMCObjective,
+        Union[List[Callable[[torch.Tensor], torch.Tensor]], None],
+        Union[List, float],
     ]:
         # we absorb all constraints into the objective
         return (
@@ -240,7 +242,7 @@ class CustomSoboStrategy(SoboStrategy):
         self,
     ) -> Tuple[
         Union[GenericMCObjective, ConstrainedMCObjective],
-        Union[ConstrainedObjective, None],
+        Union[List[Callable[[torch.Tensor], torch.Tensor]], None],
         Union[List, float],
     ]:
         if self.f is None:

--- a/tests/bofire/strategies/test_all.py
+++ b/tests/bofire/strategies/test_all.py
@@ -5,12 +5,15 @@ import bofire.data_models.strategies.api as data_models
 import bofire.strategies.api as strategies
 from tests.bofire.strategies.test_qehvi import BOTORCH_QEHVI_STRATEGY_SPECS
 from tests.bofire.strategies.test_qparego import BOTORCH_QPAREGO_STRATEGY_SPECS
-from tests.bofire.strategies.test_sobo import BOTORCH_SOBO_STRATEGY_SPECS
+from tests.bofire.strategies.test_sobo import (
+    BOTORCH_ADDITIVE_AND_MULTIPLICATIVE_SOBO_STRATEGY_SPECS,
+    BOTORCH_SOBO_STRATEGY_SPECS,
+)
 
 STRATEGY_SPECS = {
     data_models.SoboStrategy: BOTORCH_SOBO_STRATEGY_SPECS,
-    data_models.AdditiveSoboStrategy: BOTORCH_SOBO_STRATEGY_SPECS,
-    data_models.MultiplicativeSoboStrategy: BOTORCH_SOBO_STRATEGY_SPECS,
+    data_models.AdditiveSoboStrategy: BOTORCH_ADDITIVE_AND_MULTIPLICATIVE_SOBO_STRATEGY_SPECS,
+    data_models.MultiplicativeSoboStrategy: BOTORCH_ADDITIVE_AND_MULTIPLICATIVE_SOBO_STRATEGY_SPECS,
     data_models.QehviStrategy: BOTORCH_QEHVI_STRATEGY_SPECS,
     data_models.QnehviStrategy: BOTORCH_QEHVI_STRATEGY_SPECS,
     data_models.QparegoStrategy: BOTORCH_QPAREGO_STRATEGY_SPECS,

--- a/tests/bofire/strategies/test_qparego.py
+++ b/tests/bofire/strategies/test_qparego.py
@@ -136,7 +136,7 @@ def test_qparego(num_test_candidates):
     my_strategy = QparegoStrategy(data_model=data_model)
     my_strategy.tell(experiments)
     # test get objective
-    objective = my_strategy._get_objective()
+    objective, _, _ = my_strategy._get_objective_and_constraints()
     assert isinstance(objective, GenericMCObjective)
     acqfs = my_strategy._get_acqfs(2)
     assert len(acqfs) == 2
@@ -163,7 +163,7 @@ def test_qparego_constraints(num_test_candidates):
     my_strategy = QparegoStrategy(data_model=data_model)
     my_strategy.tell(experiments)
     # test get objective
-    objective = my_strategy._get_objective()
+    objective, _, _ = my_strategy._get_objective_and_constraints()
     assert isinstance(objective, GenericMCObjective)
     # ask
     candidates = my_strategy.ask(num_test_candidates)

--- a/tests/bofire/strategies/test_qparego.py
+++ b/tests/bofire/strategies/test_qparego.py
@@ -9,7 +9,7 @@ from botorch.acquisition import (
     qLogNoisyExpectedImprovement,
     qNoisyExpectedImprovement,
 )
-from botorch.acquisition.objective import ConstrainedMCObjective, GenericMCObjective
+from botorch.acquisition.objective import GenericMCObjective
 from pydantic import ValidationError
 
 import bofire.data_models.strategies.api as data_models
@@ -164,7 +164,7 @@ def test_qparego_constraints(num_test_candidates):
     my_strategy.tell(experiments)
     # test get objective
     objective = my_strategy._get_objective()
-    assert isinstance(objective, ConstrainedMCObjective)
+    assert isinstance(objective, GenericMCObjective)
     # ask
     candidates = my_strategy.ask(num_test_candidates)
     assert len(candidates) == num_test_candidates

--- a/tests/bofire/strategies/test_sobo.py
+++ b/tests/bofire/strategies/test_sobo.py
@@ -65,6 +65,35 @@ BOTORCH_SOBO_STRATEGY_SPECS = {
     ],
 }
 
+VALID_ADDITIVE_AND_MULTIPLICATIVE_BOTORCH_SOBO_STRATEGY_SPEC = {
+    "domain": domains[2],
+    "acquisition_function": specs.acquisition_functions.valid().obj(),
+    "descriptor_method": "EXHAUSTIVE",
+    "categorical_method": "EXHAUSTIVE",
+}
+
+BOTORCH_ADDITIVE_AND_MULTIPLICATIVE_SOBO_STRATEGY_SPECS = {
+    "valids": [
+        VALID_ADDITIVE_AND_MULTIPLICATIVE_BOTORCH_SOBO_STRATEGY_SPEC,
+        {**VALID_ADDITIVE_AND_MULTIPLICATIVE_BOTORCH_SOBO_STRATEGY_SPEC, "seed": 1},
+    ],
+    "invalids": [
+        {
+            **VALID_ADDITIVE_AND_MULTIPLICATIVE_BOTORCH_SOBO_STRATEGY_SPEC,
+            "acquisition_function": None,
+        },
+        {
+            **VALID_ADDITIVE_AND_MULTIPLICATIVE_BOTORCH_SOBO_STRATEGY_SPEC,
+            "descriptor_method": None,
+        },
+        {
+            **VALID_ADDITIVE_AND_MULTIPLICATIVE_BOTORCH_SOBO_STRATEGY_SPEC,
+            "categorical_method": None,
+        },
+        {**VALID_ADDITIVE_AND_MULTIPLICATIVE_BOTORCH_SOBO_STRATEGY_SPEC, "seed": -1},
+    ],
+}
+
 
 @pytest.mark.parametrize(
     "domain, acqf",

--- a/tests/bofire/strategies/test_sobo.py
+++ b/tests/bofire/strategies/test_sobo.py
@@ -215,7 +215,7 @@ def test_custom_get_objective():
     )
     strategy = CustomSoboStrategy(data_model=data_model)
     strategy.f = f
-    generic_objective = strategy._get_objective()
+    generic_objective, _, _ = strategy._get_objective_and_constraints()
     assert isinstance(generic_objective, GenericMCObjective)
 
 
@@ -227,7 +227,7 @@ def test_custom_get_objective_invalid():
     strategy = CustomSoboStrategy(data_model=data_model)
 
     with pytest.raises(ValueError):
-        strategy._get_objective()
+        strategy._get_objective_and_constraints()
 
 
 def test_custom_dumps_loads():
@@ -267,11 +267,11 @@ def test_custom_dumps_loads():
     assert isinstance(strategy3.f, type(f))
 
     samples = torch.rand(30, 2, requires_grad=True) * 5
-    objective1 = strategy1._get_objective()
+    objective1, _, _ = strategy1._get_objective_and_constraints()
     output1 = objective1.forward(samples)
-    objective2 = strategy2._get_objective()
+    objective2, _, _ = strategy2._get_objective_and_constraints()
     output2 = objective2.forward(samples)
-    objective3 = strategy3._get_objective()
+    objective3, _, _ = strategy3._get_objective_and_constraints()
     output3 = objective3.forward(samples)
 
     torch.testing.assert_close(output1, output2)
@@ -331,7 +331,7 @@ def test_sobo_get_obective(outputs, expected_objective):
         )
     )
     strategy = SoboStrategy(data_model=strategy_data)
-    obj = strategy._get_objective()
+    obj, _, _ = strategy._get_objective_and_constraints()
     assert isinstance(obj, expected_objective)
 
 
@@ -345,7 +345,7 @@ def test_sobo_get_constrained_objective():
     strategy_data = data_models.SoboStrategy(domain=domain, acquisition_function=qUCB())
     strategy = SoboStrategy(data_model=strategy_data)
     strategy.tell(experiments=experiments)
-    obj = strategy._get_objective()
+    obj, _, _ = strategy._get_objective_and_constraints()
     assert isinstance(obj, ConstrainedMCObjective)
 
 
@@ -359,5 +359,5 @@ def test_sobo_get_constrained_objective2():
     strategy_data = data_models.SoboStrategy(domain=domain, acquisition_function=qEI())
     strategy = SoboStrategy(data_model=strategy_data)
     strategy.tell(experiments=experiments)
-    obj = strategy._get_objective()
+    obj, _, _ = strategy._get_objective_and_constraints()
     assert isinstance(obj, GenericMCObjective)

--- a/tests/bofire/strategies/test_sobo.py
+++ b/tests/bofire/strategies/test_sobo.py
@@ -342,8 +342,22 @@ def test_sobo_get_constrained_objective():
     domain.outputs.get_by_key("f_1").objective = MaximizeSigmoidObjective(
         tp=1.5, steepness=2.0
     )
-    strategy_data = data_models.SoboStrategy(domain=domain)
+    strategy_data = data_models.SoboStrategy(domain=domain, acquisition_function=qUCB())
     strategy = SoboStrategy(data_model=strategy_data)
     strategy.tell(experiments=experiments)
     obj = strategy._get_objective()
     assert isinstance(obj, ConstrainedMCObjective)
+
+
+def test_sobo_get_constrained_objective2():
+    benchmark = DTLZ2(dim=6)
+    experiments = benchmark.f(benchmark.domain.inputs.sample(5), return_complete=True)
+    domain = benchmark.domain
+    domain.outputs.get_by_key("f_1").objective = MaximizeSigmoidObjective(
+        tp=1.5, steepness=2.0
+    )
+    strategy_data = data_models.SoboStrategy(domain=domain, acquisition_function=qEI())
+    strategy = SoboStrategy(data_model=strategy_data)
+    strategy.tell(experiments=experiments)
+    obj = strategy._get_objective()
+    assert isinstance(obj, GenericMCObjective)


### PR DESCRIPTION
# Major changes based on BoTorch commit 748b46a

**Constrained objective functionality:**

- Constrained objectives are handled differently using the [`SampleReducingMCAcquisitionFunction`](https://github.com/pytorch/botorch/blob/main/botorch/acquisition/monte_carlo.py) class as compared to the previous `ConstrainedMCObjective` class
- Updated scripts reference the new version of the [`get_acquisition_function`](https://github.com/pytorch/botorch/blob/main/botorch/acquisition/factory.py) function which is designed to work with the `SampleReducingMCAcquisitionFunction` class


### Class structure changes

The below changes all occur in 'bofire/strategies/predictives/sobo.py'

1. Modified the `_get_objective()` method to be the `_get_objective_and_constraints()` method which now returns a tuple of the form: (ObjectiveCallable, ConstraintCallable, Etas), where the ObjectiveCallable is only a `ConstrainedMCObjective` if the acquisition function is `qUCB()` or `qSR()` as these acquisition functions do not utilize the functionality of constraints in the new `get_acquisition_function` function from BoTorch
2. Modified the `get_acqfs()` method to utilize the new `get_acquisition_function` function from BoTorch

The below changes all occur in 'bofire/strategies/predictives/qparego.py'

1. Modified the `_get_objective()` method to be the `_get_objective_and_constraints()` method which now returns a tuple of the form: (ObjectiveCallable, ConstraintCallable, Etas)
2. Modified the `get_acqfs()` method to utilize the new `get_acquisition_function` function from BoTorch


### Validator changes

1. Updated the `AdditiveSoboStrategy` and `MultiplicativeSoboStrategy` to have domain validators which make sure that there are at least 2 objectives submitted for the strategy (since otherwise regular SOBO is sufficient) - changes are done in 'bofire/data_models/strategies/predictives/sobo.py'
2. Modified the associated tests in 'tests/bofire/strategies/test_all.py' and 'tests/bofire/strategies/test_sobo.py' to make sure that multiobjective problems are used for the tests


### Additional changes

1. Modified the acquisition function in `test_sobo_get_constrained_objective` to be `qUCB()` in 'tests/bofire/strategies/test_sobo.py' as `qUCB()` and `qSR()` are the only functions which are incompatible with the new `get_acquisition_function`
2. Added a test in 'tests/bofire/strategies/test_sobo.py' which repeats the test from above but with  `qEI()` as the acquisition function; the expected return is now a `GenericMCObjective`
3. Modified the `test_qparego_constraints` in 'tests/bofire/strategies/test_qparego.py' to only allow for `GenericMCObjective` instances
4. Updated all occurences of `strategy._get_objective()` to be `strategy._get_objective_and_constraints()` (with proper indexing for the return)