### PR TITLE
change seed behavior

### DIFF
--- a/bofire/data_models/strategies/strategy.py
+++ b/bofire/data_models/strategies/strategy.py
@@ -1,8 +1,7 @@
 from abc import abstractmethod
-from typing import Optional, Type
+from typing import Annotated, Optional, Type
 
-import numpy as np
-from pydantic import validator
+from pydantic import Field, validator
 
 from bofire.data_models.base import BaseModel
 from bofire.data_models.constraints.api import Constraint
@@ -13,16 +12,7 @@ from bofire.data_models.features.api import Feature
 class Strategy(BaseModel):
     type: str
     domain: Domain
-    seed: Optional[int] = None
-
-    @validator("seed", always=True)
-    def validate_seed(cls, v, values):
-        if v is None:
-            return int(np.random.default_rng().integers(1000))
-        else:
-            if v < 0:
-                raise ValueError("Seed has to be greater or equal than zero.")
-        return v
+    seed: Optional[Annotated[int, Field(ge=0)]] = None
 
     @validator("domain")
     def validate_constraints(cls, domain: Domain):

--- a/bofire/strategies/strategy.py
+++ b/bofire/strategies/strategy.py
@@ -21,7 +21,7 @@ class Strategy(ABC):
         data_model: DataModel,
     ):
         self.domain = data_model.domain
-        self.seed = data_model.seed
+        self.seed = data_model.seed or np.random.default_rng().integers(1000)
         self.rng = np.random.default_rng(self.seed)  # type: ignore
         self._experiments = None
         self._candidates = None


### PR DESCRIPTION
This PR changes the behavior of handling random seeds in bofire. Before, when no seed was provided, a seed was generated in the data model. This is problematic, as when the user does not want to use a seed and the data model is stored in some backend, always the same seed is used and the same candidates are generated. 

The new behavior allows now for `None` values and generates the seed just in the functional model when no seed is provided orginally.