### PR TITLE
Sync the output of surrogate.predict and strategy.predict

### DIFF
--- a/bofire/strategies/predictives/botorch.py
+++ b/bofire/strategies/predictives/botorch.py
@@ -120,7 +120,7 @@ class BotorchStrategy(PredictiveStrategy):
         # input and further transform it to a torch tensor
         X = torch.from_numpy(transformed.values).to(**tkwargs)
         with torch.no_grad():
-            posterior = self.model.posterior(X=X)  # type: ignore
+            posterior = self.model.posterior(X=X, observation_noise=True)  # type: ignore
         if len(posterior.mean.shape) == 2:
             preds = posterior.mean.cpu().detach().numpy()
             stds = np.sqrt(posterior.variance.cpu().detach().numpy())

--- a/bofire/surrogates/fully_bayesian.py
+++ b/bofire/surrogates/fully_bayesian.py
@@ -57,7 +57,7 @@ class SaasSingleTaskGPSurrogate(BotorchSurrogate, TrainableSurrogate):
         # transform to tensor
         X = torch.from_numpy(transformed_X.values).to(**tkwargs)
         with torch.no_grad():
-            posterior = self.model.posterior(X=X)  # type: ignore
+            posterior = self.model.posterior(X=X, observation_noise=True)  # type: ignore
 
         preds = posterior.mixture_mean.detach().numpy()
         stds = np.sqrt(posterior.mixture_variance.detach().numpy())


### PR DESCRIPTION
This PR fixes the problem that when calling in a botorch based strategy the `predict` method the result deviates from calling predict on the underlying surrogate in the standard deviation. `observation_noise` has to be included in both cases. 