### PR TITLE
Add aggregation modes to trainable surrogate data models

### DIFF
--- a/bofire/data_models/surrogates/api.py
+++ b/bofire/data_models/surrogates/api.py
@@ -22,6 +22,7 @@ try:
     )
     from bofire.data_models.surrogates.surrogate import Surrogate
     from bofire.data_models.surrogates.tanimoto_gp import TanimotoGPSurrogate
+    from bofire.data_models.surrogates.trainable import MeanAggregation, SumAggregation
     from bofire.data_models.surrogates.xgb import XGBoostSurrogate
 
     AbstractSurrogate = Union[Surrogate, BotorchSurrogate, EmpiricalSurrogate]

--- a/bofire/data_models/surrogates/mlp.py
+++ b/bofire/data_models/surrogates/mlp.py
@@ -1,4 +1,6 @@
-from typing import Literal, Sequence
+from typing import Annotated, Literal, Sequence
+
+from pydantic import Field
 
 from bofire.data_models.surrogates.botorch import BotorchSurrogate
 from bofire.data_models.surrogates.scaler import ScalerEnum
@@ -7,14 +9,14 @@ from bofire.data_models.surrogates.trainable import TrainableSurrogate
 
 class MLPEnsemble(BotorchSurrogate, TrainableSurrogate):
     type: Literal["MLPEnsemble"] = "MLPEnsemble"
-    n_estimators: int
+    n_estimators: Annotated[int, Field(ge=1)] = 5
     hidden_layer_sizes: Sequence = (100,)
     activation: Literal["relu", "logistic", "tanh"] = "relu"
-    dropout: float = 0.0
-    batch_size: int = 10
-    n_epochs: int = 200
-    lr: float = 1e-4
-    weight_decay: float = 0.0
-    subsample_fraction: float = 1.0
+    dropout: Annotated[float, Field(ge=0.0)] = 0.0
+    batch_size: Annotated[int, Field(ge=1)] = 10
+    n_epochs: Annotated[int, Field(ge=1)] = 200
+    lr: Annotated[float, Field(gt=0.0)] = 1e-4
+    weight_decay: Annotated[float, Field(ge=0.0)] = 0.0
+    subsample_fraction: Annotated[float, Field(gt=0.0)] = 1.0
     shuffle: bool = True
     scaler: ScalerEnum = ScalerEnum.NORMALIZE

--- a/bofire/data_models/surrogates/xgb.py
+++ b/bofire/data_models/surrogates/xgb.py
@@ -15,7 +15,7 @@ from bofire.data_models.surrogates.trainable import TrainableSurrogate
 
 class XGBoostSurrogate(Surrogate, TrainableSurrogate):
     type: Literal["XGBoostSurrogate"] = "XGBoostSurrogate"
-    n_estimators: int
+    n_estimators: Annotated[int, Field(ge=1)] = 100
     max_depth: Annotated[int, Field(ge=0)] = 6
     max_leaves: Annotated[int, Field(ge=0)] = 0
     max_bin: Annotated[int, Field(ge=0)] = 256

--- a/tests/bofire/data_models/specs/surrogates.py
+++ b/tests/bofire/data_models/specs/surrogates.py
@@ -42,6 +42,7 @@ specs.add_valid(
                 features.valid(ContinuousOutput).obj(),
             ]
         ),
+        "aggregations": None,
         "warmup_steps": 16,
         "num_samples": 4,
         "thinning": 2,
@@ -66,6 +67,7 @@ specs.add_valid(
                 features.valid(ContinuousOutput).obj(),
             ]
         ),
+        "aggregations": None,
         "continuous_kernel": MaternKernel(ard=True, nu=random.random()),
         "categorical_kernel": HammondDistanceKernel(ard=True),
         "scaler": ScalerEnum.NORMALIZE,
@@ -93,6 +95,7 @@ specs.add_valid(
             ),
             outputscale_prior=BOTORCH_SCALE_PRIOR(),
         ),
+        "aggregations": None,
         "scaler": ScalerEnum.NORMALIZE,
         "noise_prior": BOTORCH_NOISE_PRIOR(),
         "input_preprocessing_specs": {},
@@ -113,6 +116,7 @@ specs.add_valid(
                 features.valid(ContinuousOutput).obj(),
             ]
         ),
+        "aggregations": None,
         "input_preprocessing_specs": {},
         "n_estimators": 100,
         "criterion": "squared_error",
@@ -145,6 +149,7 @@ specs.add_valid(
                 features.valid(ContinuousOutput).obj(),
             ]
         ),
+        "aggregations": None,
         "n_estimators": 2,
         "hidden_layer_sizes": (100,),
         "activation": "relu",
@@ -175,6 +180,7 @@ specs.add_valid(
                 features.valid(ContinuousOutput).obj(),
             ]
         ),
+        "aggregations": None,
         "n_estimators": 10,
         "max_depth": 6,
         "max_leaves": 0,
@@ -221,6 +227,7 @@ specs.add_valid(
             ),
             outputscale_prior=BOTORCH_SCALE_PRIOR(),
         ),
+        "aggregations": None,
         "scaler": ScalerEnum.NORMALIZE,
         "noise_prior": BOTORCH_NOISE_PRIOR(),
         "input_preprocessing_specs": {"mol1": Fingerprints(n_bits=32, bond_radius=3)},


### PR DESCRIPTION
This PR adds the API for defining aggregated features in the future. Note that it is currently only supported in the data models but will not be used in the functional surrogates.

They can be specified like this for all trainable surrogates:

```
'aggregations': [{'type': 'SumAggregation',
   'features': ['x_1', 'x_2'],
   'keep_features': False},
  {'type': 'MeanAggregation',
   'features': ['x_1', 'x_2'],
   'keep_features': False}],
```