### PR TITLE
Set default value for bounds in ContinuousInput Feature

### DIFF
--- a/bofire/data_models/features/continuous.py
+++ b/bofire/data_models/features/continuous.py
@@ -20,7 +20,7 @@ class ContinuousInput(NumericalInput):
     type: Literal["ContinuousInput"] = "ContinuousInput"
     order_id: ClassVar[int] = 1
 
-    bounds: Tuple[float, float]
+    bounds: Tuple[float, float] = Field(default_factory=lambda: (0.0, 1.0))
     stepsize: Optional[float] = None
 
     @property


### PR DESCRIPTION
This PR implement default bounds for the `ContinuousInput` feature of `(0,1)`, which allows the user to just type:
```
ContinuousInput(key="input_1")
```
instead of
```
ContinuousInput(key="input_1", bounds = (0,1))
```
which is especially useful in situations where using features of BoFire where bounds are not needed. Less typing is then needed ;)