### PR TITLE
Feature/experiment validation

### DIFF
--- a/bofire/data_models/features/categorical.py
+++ b/bofire/data_models/features/categorical.py
@@ -392,6 +392,14 @@ class CategoricalOutput(Output):
                 raise ValueError("Objective values has to be larger equal than zero")
         return objective
 
+    def validate_experimental(self, values: pd.Series) -> pd.Series:
+        values = values.map(str)
+        if sum(values.isin(self.categories)) != len(values):
+            raise ValueError(
+                f"invalid values for `{self.key}`, allowed are: `{self.categories}`"
+            )
+        return values
+
     def to_dict(self) -> Dict:
         """Returns the catergories and corresponding objective values as dictionary"""
         return dict(zip(self.categories, self.objective))

--- a/bofire/data_models/features/continuous.py
+++ b/bofire/data_models/features/continuous.py
@@ -163,5 +163,15 @@ class ContinuousOutput(Output):
             )
         return self.objective(values)  # type: ignore
 
+    def validate_experimental(self, values: pd.Series) -> pd.Series:
+        try:
+            values = pd.to_numeric(values, errors="raise")
+        except ValueError:
+            raise ValueError(
+                f"not all values of input feature `{self.key}` are numerical"
+            )
+        values = values.astype("float64")
+        return values
+
     def __str__(self) -> str:
         return "ContinuousOutputFeature"

--- a/bofire/data_models/features/feature.py
+++ b/bofire/data_models/features/feature.py
@@ -136,6 +136,18 @@ class Output(Feature):
     def __call__(self, values: pd.Series) -> pd.Series:
         pass
 
+    @abstractmethod
+    def validate_experimental(self, values: pd.Series) -> pd.Series:
+        """Abstract method to validate the experimental Series
+
+        Args:
+            values (pd.Series): A dataFrame with values for the outcome
+
+        Returns:
+            pd.Series: The passed dataFrame with experiments
+        """
+        pass
+
 
 def is_numeric(s: Union[pd.Series, pd.DataFrame]) -> bool:
     if isinstance(s, pd.Series):

--- a/bofire/data_models/features/molecular.py
+++ b/bofire/data_models/features/molecular.py
@@ -29,6 +29,7 @@ class MolecularInput(Input):
     def validate_experimental(
         self, values: pd.Series, strict: bool = False
     ) -> pd.Series:
+        values = values.map(str)
         for smi in values:
             smiles2mol(smi)
 

--- a/bofire/data_models/features/numerical.py
+++ b/bofire/data_models/features/numerical.py
@@ -98,10 +98,13 @@ class NumericalInput(Input):
         Returns:
             pd.Series: A dataFrame with experiments
         """
-        if not is_numeric(values):
+        try:
+            values = pd.to_numeric(values, errors="raise")
+        except ValueError:
             raise ValueError(
                 f"not all values of input feature `{self.key}` are numerical"
             )
+        values = values.astype("float64")
         if strict:
             lower, upper = self.get_bounds(transform_type=None, values=values)
             if lower == upper:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,3 +29,7 @@ max-complexity = 18
 "bofire/data_models/api.py" = ["F401"]
 "bofire/data_models/surrogates/api.py" = ["F401"]
 "bofire/benchmarks/api.py" = ["F401"]
+
+[tool.pyright]
+include = ["bofire"]
+exclude = ["bofire/version.py"]

--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -1,5 +1,0 @@
-{
-    "include": [
-        "bofire"
-    ],
-}

--- a/tests/bofire/data_models/test_domain_validators.py
+++ b/tests/bofire/data_models/test_domain_validators.py
@@ -5,6 +5,7 @@ from typing import List
 import numpy as np
 import pandas as pd
 import pytest
+from pandas.testing import assert_frame_equal
 
 import tests.bofire.data_models.specs.api as specs
 from bofire.data_models.constraints.api import (
@@ -198,7 +199,14 @@ def test_domain_validate_experiments_valid(
     domain: Domain,
     experiments: pd.DataFrame,
 ):
-    domain.validate_experiments(experiments)
+    experiments1 = domain.validate_experiments(experiments.copy())
+    for col in experiments.columns:
+        experiments[col] = experiments[col].map(str)
+    experiments2 = domain.validate_experiments(experiments)
+    assert_frame_equal(
+        left=experiments1,
+        right=experiments2,
+    )
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
This PR adds the possibility to pass as `experiments` dataframe, a frame in which the `dtype`s are not yet correct (for example all floats as strings) and still to validate/convert it into the desired format depending on the used feature types.