### PR TITLE
Allow for LinearSurrogate in BotorchSurrogates

### DIFF
--- a/bofire/data_models/surrogates/botorch_surrogates.py
+++ b/bofire/data_models/surrogates/botorch_surrogates.py
@@ -8,6 +8,7 @@ from bofire.data_models.domain.api import Inputs, Outputs
 from bofire.data_models.features.api import TInputTransformSpecs
 from bofire.data_models.surrogates.empirical import EmpiricalSurrogate
 from bofire.data_models.surrogates.fully_bayesian import SaasSingleTaskGPSurrogate
+from bofire.data_models.surrogates.linear import LinearSurrogate
 from bofire.data_models.surrogates.mixed_single_task_gp import (
     MixedSingleTaskGPSurrogate,
 )
@@ -24,6 +25,7 @@ AnyBotorchSurrogate = Union[
     MLPEnsemble,
     SaasSingleTaskGPSurrogate,
     TanimotoGPSurrogate,
+    LinearSurrogate,
 ]
 
 


### PR DESCRIPTION
So far `LinearSurrogate`s were not allowed in `BotorchSurrogates` as mentioned in https://github.com/experimental-design/bofire/issues/286. 

This is a fix for it.