### PR TITLE
Remove prior and add test

### DIFF
--- a/bofire/data_models/surrogates/linear.py
+++ b/bofire/data_models/surrogates/linear.py
@@ -3,11 +3,7 @@ from typing import Literal
 from pydantic import Field
 
 from bofire.data_models.kernels.api import LinearKernel
-from bofire.data_models.priors.api import (
-    BOTORCH_NOISE_PRIOR,
-    BOTORCH_SCALE_PRIOR,
-    AnyPrior,
-)
+from bofire.data_models.priors.api import BOTORCH_NOISE_PRIOR, AnyPrior
 
 # from bofire.data_models.strategies.api import FactorialStrategy
 from bofire.data_models.surrogates.botorch import BotorchSurrogate
@@ -18,8 +14,6 @@ from bofire.data_models.surrogates.trainable import TrainableSurrogate
 class LinearSurrogate(BotorchSurrogate, TrainableSurrogate):
     type: Literal["LinearSurrogate"] = "LinearSurrogate"
 
-    kernel: LinearKernel = Field(
-        default_factory=lambda: LinearKernel(variance_prior=BOTORCH_SCALE_PRIOR())
-    )
+    kernel: LinearKernel = Field(default_factory=lambda: LinearKernel())
     noise_prior: AnyPrior = Field(default_factory=lambda: BOTORCH_NOISE_PRIOR())
     scaler: ScalerEnum = ScalerEnum.NORMALIZE

--- a/tests/bofire/surrogates/test_linear.py
+++ b/tests/bofire/surrogates/test_linear.py
@@ -1,4 +1,5 @@
 import numpy as np
+from pandas.testing import assert_frame_equal
 
 import bofire.surrogates.api as surrogates
 from bofire.data_models.domain.api import Inputs, Outputs
@@ -32,3 +33,11 @@ def test_LinearSurrogate():
 
     assert isinstance(surrogate, surrogates.SingleTaskGPSurrogate)
     assert isinstance(surrogate.kernel, LinearKernel)
+
+    # check dump
+    surrogate.fit(experiments=experiments)
+    preds = surrogate.predict(experiments)
+    dump = surrogate.dumps()
+    surrogate.loads(dump)
+    preds2 = surrogate.predict(experiments)
+    assert_frame_equal(preds, preds2)


### PR DESCRIPTION
Currently the linear surrogate is not dumpable due to a problem in gpytorch when a variance priors gets assigned. As a hotfix, we do not apply a variance prior to the linear kernel as default.