### PR TITLE
Fix for categorical features that are fixed in fully categorical BO

### DIFF
--- a/bofire/strategies/predictives/botorch.py
+++ b/bofire/strategies/predictives/botorch.py
@@ -296,6 +296,9 @@ class BotorchStrategy(PredictiveStrategy):
                     for combi in self.domain.inputs.get_categorical_combinations()
                 ]
             )
+            # adding categorical features that are fixed 
+            for feat in self.domain.inputs.get_fixed():
+                choices[feat.key] = feat.fixed_value()[0]  # type: ignore             
             # compare the choices with the training data and remove all that are also part
             # of the training data
             merged = choices.merge(

--- a/bofire/strategies/predictives/botorch.py
+++ b/bofire/strategies/predictives/botorch.py
@@ -296,9 +296,9 @@ class BotorchStrategy(PredictiveStrategy):
                     for combi in self.domain.inputs.get_categorical_combinations()
                 ]
             )
-            # adding categorical features that are fixed 
+            # adding categorical features that are fixed
             for feat in self.domain.inputs.get_fixed():
-                choices[feat.key] = feat.fixed_value()[0]  # type: ignore             
+                choices[feat.key] = feat.fixed_value()[0]  # type: ignore
             # compare the choices with the training data and remove all that are also part
             # of the training data
             merged = choices.merge(


### PR DESCRIPTION
When all input features in an optimization are categorical/discrete, if only one category is allowed for the categorical features, then it will break. This is because the fixed feature is not included when `self.domain.inputs.get_categorical_combinations()` is used to generate the `choices` DataFrame. This results in the subsequent `merged` DataFrame having a column of NaN's for the fixed feature

This PR will fix this issue by adding in the fixed feature into `choices` before generating `merged`.

I have not included a test yet for this because I am not sure on where to place it in the folder. @jduerholt Where is the best place for this?