### PR TITLE
allow for max_active=#(variables in constraint) in n_choose_k_constraints_as_bounds()

### DIFF
--- a/bofire/strategies/doe/utils.py
+++ b/bofire/strategies/doe/utils.py
@@ -465,22 +465,22 @@ def nchoosek_constraints_as_bounds(
         for constraint in domain.constraints:
             if isinstance(constraint, NChooseKConstraint):
                 n_inactive = len(constraint.features) - constraint.max_count
-
-                # find indices of constraint.names in names
-                ind = [
-                    i
-                    for i, p in enumerate(domain.inputs.get_keys())
-                    if p in constraint.features
-                ]
-
-                # find and shuffle all combinations of elements of ind of length max_active
-                ind = np.array(list(combinations(ind, r=n_inactive)))
-                np.random.shuffle(ind)
-
-                # set bounds to zero in each experiments for the variables that should be inactive
-                for i in range(n_experiments):
-                    ind_vanish = ind[i % len(ind)]
-                    bounds[ind_vanish + i * len(domain.inputs), :] = [0, 0]
+                if (n_inactive > 0):
+                    # find indices of constraint.names in names
+                    ind = [
+                        i
+                        for i, p in enumerate(domain.inputs.get_keys())
+                        if p in constraint.features
+                    ]
+    
+                    # find and shuffle all combinations of elements of ind of length max_active
+                    ind = np.array(list(combinations(ind, r=n_inactive)))
+                    np.random.shuffle(ind)
+    
+                    # set bounds to zero in each experiments for the variables that should be inactive
+                    for i in range(n_experiments):
+                        ind_vanish = ind[i % len(ind)]
+                        bounds[ind_vanish + i * len(domain.inputs), :] = [0, 0]
     else:
         pass
 

--- a/bofire/strategies/doe/utils.py
+++ b/bofire/strategies/doe/utils.py
@@ -465,18 +465,18 @@ def nchoosek_constraints_as_bounds(
         for constraint in domain.constraints:
             if isinstance(constraint, NChooseKConstraint):
                 n_inactive = len(constraint.features) - constraint.max_count
-                if (n_inactive > 0):
+                if n_inactive > 0:
                     # find indices of constraint.names in names
                     ind = [
                         i
                         for i, p in enumerate(domain.inputs.get_keys())
                         if p in constraint.features
                     ]
-    
+
                     # find and shuffle all combinations of elements of ind of length max_active
                     ind = np.array(list(combinations(ind, r=n_inactive)))
                     np.random.shuffle(ind)
-    
+
                     # set bounds to zero in each experiments for the variables that should be inactive
                     for i in range(n_experiments):
                         ind_vanish = ind[i % len(ind)]


### PR DESCRIPTION
This PR fixed an error occuring in the edge case of an NChooseKConstraint w/ max_active=#(variables in NChooseKConstraint). In this case no additional restrictions to the bounds have to be made.