### PR TITLE
add output_scaler to mlp

### DIFF
--- a/bofire/data_models/surrogates/mlp.py
+++ b/bofire/data_models/surrogates/mlp.py
@@ -1,6 +1,6 @@
 from typing import Annotated, Literal, Sequence
 
-from pydantic import Field
+from pydantic import Field, validator
 
 from bofire.data_models.surrogates.botorch import BotorchSurrogate
 from bofire.data_models.surrogates.scaler import ScalerEnum
@@ -21,3 +21,25 @@ class MLPEnsemble(BotorchSurrogate, TrainableSurrogate):
     shuffle: bool = True
     scaler: ScalerEnum = ScalerEnum.NORMALIZE
     output_scaler: ScalerEnum = ScalerEnum.STANDARDIZE
+
+    @validator("output_scaler")
+    def validate_output_scaler(cls, output_scaler):
+        """validates that output_scaler is a valid type
+
+        Args:
+            output_scaler (ScalerEnum): Scaler used to transform the output
+
+        Raises:
+            ValueError: when ScalerEnum.NORMALIZE is used
+
+        Returns:
+            ScalerEnum: Scaler used to transform the output
+        """
+        if output_scaler in (ScalerEnum.IDENTITY, ScalerEnum.STANDARDIZE):
+            pass
+        elif output_scaler == ScalerEnum.NORMALIZE:
+            raise ValueError("Normalize is not supported as an output transform.")
+        else:
+            raise ValueError("Scaler enum not known.")
+
+        return output_scaler

--- a/bofire/data_models/surrogates/mlp.py
+++ b/bofire/data_models/surrogates/mlp.py
@@ -20,3 +20,4 @@ class MLPEnsemble(BotorchSurrogate, TrainableSurrogate):
     subsample_fraction: Annotated[float, Field(gt=0.0)] = 1.0
     shuffle: bool = True
     scaler: ScalerEnum = ScalerEnum.NORMALIZE
+    output_scaler: ScalerEnum = ScalerEnum.STANDARDIZE

--- a/bofire/data_models/surrogates/mlp.py
+++ b/bofire/data_models/surrogates/mlp.py
@@ -35,11 +35,7 @@ class MLPEnsemble(BotorchSurrogate, TrainableSurrogate):
         Returns:
             ScalerEnum: Scaler used to transform the output
         """
-        if output_scaler in (ScalerEnum.IDENTITY, ScalerEnum.STANDARDIZE):
-            pass
-        elif output_scaler == ScalerEnum.NORMALIZE:
+        if output_scaler == ScalerEnum.NORMALIZE:
             raise ValueError("Normalize is not supported as an output transform.")
-        else:
-            raise ValueError("Scaler enum not known.")
 
         return output_scaler

--- a/bofire/surrogates/mlp.py
+++ b/bofire/surrogates/mlp.py
@@ -186,14 +186,10 @@ class MLPEnsemble(BotorchSurrogate, TrainableSurrogate):
         scaler = get_scaler(self.inputs, self.input_preprocessing_specs, self.scaler, X)
         transformed_X = self.inputs.transform(X, self.input_preprocessing_specs)
 
-        if self.output_scaler == ScalerEnum.IDENTITY:
-            output_scaler = None
-        elif self.output_scaler == ScalerEnum.STANDARDIZE:
+        if self.output_scaler == ScalerEnum.STANDARDIZE:
             output_scaler = Standardize(m=Y.shape[-1])
-        elif self.output_scaler == ScalerEnum.NORMALIZE:
-            raise ValueError("Normalize is not supported as an outcome transform.")
         else:
-            raise ValueError("Scaler enum not known.")
+            output_scaler = None
 
         mlps = []
         subsample_size = round(self.subsample_fraction * X.shape[0])

--- a/tests/bofire/data_models/specs/surrogates.py
+++ b/tests/bofire/data_models/specs/surrogates.py
@@ -176,6 +176,7 @@ specs.add_valid(
         "subsample_fraction": 1.0,
         "shuffle": True,
         "scaler": ScalerEnum.NORMALIZE,
+        "output_scaler": ScalerEnum.STANDARDIZE,
         "input_preprocessing_specs": {},
         "dump": None,
         "hyperconfig": None,

--- a/tests/bofire/surrogates/test_mlp.py
+++ b/tests/bofire/surrogates/test_mlp.py
@@ -208,27 +208,6 @@ def test_mlp_ensemble_fit(scaler, output_scaler):
     assert_frame_equal(preds, preds2)
 
 
-def test_mlp_ensemble_fit_invalid_output_scaler():
-    bench = Himmelblau()
-    samples = bench.domain.inputs.sample(10)
-    experiments = bench.f(samples, return_complete=True)
-    ens = MLPEnsemble(
-        inputs=bench.domain.inputs,
-        outputs=bench.domain.outputs,
-        n_estimators=2,
-        n_epochs=5,
-        scaler=ScalerEnum.NORMALIZE,
-        output_scaler=ScalerEnum.NORMALIZE,
-    )
-    surrogate = surrogates.map(ens)
-
-    with pytest.raises(
-        ValueError,
-        match="Normalize is not supported as an outcome transform.",
-    ):
-        surrogate.fit(experiments=experiments)
-
-
 @pytest.mark.parametrize(
     "scaler", [ScalerEnum.NORMALIZE, ScalerEnum.STANDARDIZE, ScalerEnum.IDENTITY]
 )

--- a/tests/bofire/surrogates/test_mlp.py
+++ b/tests/bofire/surrogates/test_mlp.py
@@ -2,6 +2,7 @@ import pytest
 import torch
 import torch.nn as nn
 from botorch.models.transforms.input import InputStandardize, Normalize
+from botorch.models.transforms.outcome import Standardize
 from pandas.testing import assert_frame_equal
 
 import bofire.surrogates.api as surrogates
@@ -163,9 +164,14 @@ def test_mlp_ensemble_forward():
 
 
 @pytest.mark.parametrize(
-    "scaler", [ScalerEnum.NORMALIZE, ScalerEnum.STANDARDIZE, ScalerEnum.IDENTITY]
+    "scaler, output_scaler",
+    [
+        [ScalerEnum.NORMALIZE, ScalerEnum.IDENTITY],
+        [ScalerEnum.STANDARDIZE, ScalerEnum.STANDARDIZE],
+        [ScalerEnum.IDENTITY, ScalerEnum.STANDARDIZE],
+    ],
 )
-def test_mlp_ensemble_fit(scaler):
+def test_mlp_ensemble_fit(scaler, output_scaler):
     bench = Himmelblau()
     samples = bench.domain.inputs.sample(10)
     experiments = bench.f(samples, return_complete=True)
@@ -175,10 +181,12 @@ def test_mlp_ensemble_fit(scaler):
         n_estimators=2,
         n_epochs=5,
         scaler=scaler,
+        output_scaler=output_scaler,
     )
     surrogate = surrogates.map(ens)
 
     surrogate.fit(experiments=experiments)
+
     if scaler == ScalerEnum.NORMALIZE:
         assert isinstance(surrogate.model.input_transform, Normalize)
     elif scaler == ScalerEnum.STANDARDIZE:
@@ -186,12 +194,39 @@ def test_mlp_ensemble_fit(scaler):
     else:
         with pytest.raises(AttributeError):
             assert surrogate.model.input_transform is None
+
+    if output_scaler == ScalerEnum.STANDARDIZE:
+        assert isinstance(surrogate.model.outcome_transform, Standardize)
+    elif output_scaler == ScalerEnum.IDENTITY:
+        assert not hasattr(surrogate.model, "outcome_transform")
+
     preds = surrogate.predict(experiments)
     dump = surrogate.dumps()
     surrogate2 = surrogates.map(ens)
     surrogate2.loads(dump)
     preds2 = surrogate2.predict(experiments)
     assert_frame_equal(preds, preds2)
+
+
+def test_mlp_ensemble_fit_invalid_output_scaler():
+    bench = Himmelblau()
+    samples = bench.domain.inputs.sample(10)
+    experiments = bench.f(samples, return_complete=True)
+    ens = MLPEnsemble(
+        inputs=bench.domain.inputs,
+        outputs=bench.domain.outputs,
+        n_estimators=2,
+        n_epochs=5,
+        scaler=ScalerEnum.NORMALIZE,
+        output_scaler=ScalerEnum.NORMALIZE,
+    )
+    surrogate = surrogates.map(ens)
+
+    with pytest.raises(
+        ValueError,
+        match="Normalize is not supported as an outcome transform.",
+    ):
+        surrogate.fit(experiments=experiments)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Added an output_scaler option for the MLP Ensemble surrogate. This is to give extra flexibility where standardizing data often improves fitting. I have set `ScalerEnum.STANDARDIZE` as the default output_scaler because this is common practice for regression problems. Currently only standardization and identity scalers are usable. Normalization is not implemented since there is no output transform for this natively on BoTorch. If needed one day, maybe we could implement it (but i believe standardization should be sufficient for us).