### PR TITLE
Interpoint Constraints

### DIFF
--- a/bofire/data_models/constraints/api.py
+++ b/bofire/data_models/constraints/api.py
@@ -4,6 +4,11 @@ from bofire.data_models.constraints.constraint import (
     Constraint,
     ConstraintError,
     ConstraintNotFulfilledError,
+    IntrapointConstraint,
+)
+from bofire.data_models.constraints.interpoint import (
+    InterpointConstraint,
+    InterpointEqualityConstraint,
 )
 from bofire.data_models.constraints.linear import (
     LinearConstraint,
@@ -21,6 +26,8 @@ AbstractConstraint = Union[
     Constraint,
     LinearConstraint,
     NonlinearConstraint,
+    IntrapointConstraint,
+    InterpointConstraint,
 ]
 
 AnyConstraint = Union[
@@ -29,6 +36,7 @@ AnyConstraint = Union[
     NonlinearEqualityConstraint,
     NonlinearInequalityConstraint,
     NChooseKConstraint,
+    InterpointEqualityConstraint,
 ]
 
 AnyConstraintError = Union[ConstraintError, ConstraintNotFulfilledError]

--- a/bofire/data_models/constraints/constraint.py
+++ b/bofire/data_models/constraints/constraint.py
@@ -13,6 +13,10 @@ class Constraint(BaseModel):
 
     type: str
 
+
+class IntrapointConstraint(Constraint):
+    type: str
+
     @abstractmethod
     def is_fulfilled(
         self, experiments: pd.DataFrame, tol: Optional[float] = 1e-6

--- a/bofire/data_models/constraints/constraint.py
+++ b/bofire/data_models/constraints/constraint.py
@@ -13,10 +13,6 @@ class Constraint(BaseModel):
 
     type: str
 
-
-class IntrapointConstraint(Constraint):
-    type: str
-
     @abstractmethod
     def is_fulfilled(
         self, experiments: pd.DataFrame, tol: Optional[float] = 1e-6
@@ -54,6 +50,10 @@ class IntrapointConstraint(Constraint):
             pd.DataFrame: the i-th row contains the jacobian evaluated at the i-th experiment
         """
         pass
+
+
+class IntrapointConstraint(Constraint):
+    type: str
 
 
 class ConstraintError(Exception):

--- a/bofire/data_models/constraints/interpoint.py
+++ b/bofire/data_models/constraints/interpoint.py
@@ -34,18 +34,12 @@ class InterpointEqualityConstraint(InterpointConstraint):
         self, experiments: pd.DataFrame, tol: Optional[float] = 1e-6
     ) -> pd.Series:
         multiplicity = self.multiplicity or len(experiments)
-        for i in range(math.floor(len(experiments) / multiplicity)):
+        for i in range(math.ceil(len(experiments) / multiplicity)):
             batch = experiments[self.feature].values[
-                i * multiplicity : (i + 1) * multiplicity
+                i * multiplicity : min((i + 1) * multiplicity, len(experiments))
             ]
             if not np.allclose(batch, batch[0]):
                 return pd.Series([False])
-        if len(experiments) % multiplicity > 0:
-            batch = experiments[self.feature].values[
-                -(len(experiments) % multiplicity) :
-            ]
-            print(batch)
-            return pd.Series([np.allclose(batch, batch[0])])
         return pd.Series([True])
 
     def __call__(self, experiments: pd.DataFrame) -> pd.Series:

--- a/bofire/data_models/constraints/interpoint.py
+++ b/bofire/data_models/constraints/interpoint.py
@@ -1,0 +1,53 @@
+import math
+from abc import abstractmethod
+from typing import Annotated, Literal, Optional
+
+import numpy as np
+import pandas as pd
+from pydantic import Field
+
+from bofire.data_models.constraints.constraint import Constraint
+
+
+class InterpointConstraint(Constraint):
+    type: str
+
+    @abstractmethod
+    def is_fulfilled(
+        self, experiments: pd.DataFrame, tol: Optional[float] = 1e-6
+    ) -> bool:
+        """Abstract method to check if a constraint is fulfilled for the whole set of experiments.
+
+        Args:
+            experiments (pd.DataFrame): Dataframe to check constraint fulfillment.
+            tol (float, optional): tolerance parameter. A constraint is considered as not fulfilled if
+                the violation is larger than tol. Defaults to 1e-6.
+
+        Returns:
+            bool: True if fulfilled else False
+        """
+        pass
+
+
+class InterpointEqualityConstraint(InterpointConstraint):
+    type: Literal["InterpointEqualityConstraint"] = "InterpointEqualityConstraint"
+    feature: str
+    multiplicity: Optional[Annotated[int, Field(ge=2)]]
+
+    def is_fulfilled(
+        self, experiments: pd.DataFrame, tol: Optional[float] = 1e-6
+    ) -> bool:
+        multiplicity = self.multiplicity or len(experiments)
+        for i in range(math.floor(len(experiments) / multiplicity)):
+            batch = experiments[self.feature].values[
+                i * multiplicity : (i + 1) * multiplicity
+            ]
+            if not np.allclose(batch, batch[0]):
+                return False
+        if len(experiments) % multiplicity > 0:
+            batch = experiments[self.feature].values[
+                -(len(experiments) % multiplicity) :
+            ]
+            print(batch)
+            return np.allclose(batch, batch[0])
+        return True

--- a/bofire/data_models/constraints/linear.py
+++ b/bofire/data_models/constraints/linear.py
@@ -47,19 +47,6 @@ class LinearConstraint(Constraint):
             experiments[self.features] @ self.coefficients - self.rhs
         ) / np.linalg.norm(self.coefficients)
 
-    # def lhs(self, df_data: pd.DataFrame) -> float:
-    #     """Evaluate the left-hand side of the constraint on each row of a dataframe
-
-    #     Args:
-    #         df_data (pd.DataFrame): Dataframe on which the left-hand side should be evaluated.
-
-    #     Returns:
-    #         np.array: 1-dim array with left-hand side of each row of the provided dataframe.
-    #     """
-    #     cols = self.features
-    #     coefficients = self.coefficients
-    #     return np.sum(df_data[cols].values * np.array(coefficients), axis=1)
-
     def __str__(self) -> str:
         """Generate string representation of the constraint.
 

--- a/bofire/data_models/domain/constraints.py
+++ b/bofire/data_models/domain/constraints.py
@@ -67,9 +67,13 @@ class Constraints(BaseModel):
         """
         if len(self.constraints) == 0:
             return pd.Series([True] * len(experiments), index=experiments.index)
-        return pd.concat(
-            [c.is_fulfilled(experiments, tol) for c in self.constraints], axis=1
-        ).all(axis=1)
+        return (
+            pd.concat(
+                [c.is_fulfilled(experiments, tol) for c in self.constraints], axis=1
+            )
+            .fillna(True)
+            .all(axis=1)
+        )
 
     def get(
         self,

--- a/bofire/data_models/strategies/random.py
+++ b/bofire/data_models/strategies/random.py
@@ -2,8 +2,10 @@ from typing import Literal, Type
 
 from bofire.data_models.constraints.api import (
     Constraint,
+    InterpointEqualityConstraint,
+    LinearEqualityConstraint,
+    LinearInequalityConstraint,
     NChooseKConstraint,
-    NonlinearEqualityConstraint,
 )
 from bofire.data_models.features.api import Feature
 from bofire.data_models.objectives.api import Objective
@@ -15,9 +17,12 @@ class RandomStrategy(Strategy):
 
     @classmethod
     def is_constraint_implemented(cls, my_type: Type[Constraint]) -> bool:
-        if my_type in [NChooseKConstraint, NonlinearEqualityConstraint]:
-            return False
-        return True
+        return my_type in [
+            LinearInequalityConstraint,
+            LinearEqualityConstraint,
+            NChooseKConstraint,
+            InterpointEqualityConstraint,
+        ]
 
     @classmethod
     def is_feature_implemented(cls, my_type: Type[Feature]) -> bool:

--- a/bofire/data_models/strategies/samplers/polytope.py
+++ b/bofire/data_models/strategies/samplers/polytope.py
@@ -1,6 +1,9 @@
-from typing import Literal, Type
+from typing import Annotated, Literal, Type
+
+from pydantic import Field
 
 from bofire.data_models.constraints.api import (
+    InterpointEqualityConstraint,
     LinearEqualityConstraint,
     LinearInequalityConstraint,
     NChooseKConstraint,
@@ -29,6 +32,8 @@ class PolytopeSampler(SamplerStrategy):
 
     type: Literal["PolytopeSampler"] = "PolytopeSampler"
     fallback_sampling_method: SamplingMethodEnum = SamplingMethodEnum.UNIFORM
+    n_burnin: Annotated[int, Field(ge=1)] = 10_000
+    n_thinning: Annotated[int, Field(ge=1)] = 32
 
     @classmethod
     def is_constraint_implemented(cls, my_type: Type[Feature]) -> bool:
@@ -36,6 +41,7 @@ class PolytopeSampler(SamplerStrategy):
             LinearInequalityConstraint,
             LinearEqualityConstraint,
             NChooseKConstraint,
+            InterpointEqualityConstraint,
         ]
 
     @classmethod

--- a/tests/bofire/data_models/specs/constraints.py
+++ b/tests/bofire/data_models/specs/constraints.py
@@ -46,3 +46,11 @@ specs.add_valid(
         "none_also_valid": False,
     },
 )
+
+specs.add_valid(
+    constraints.InterpointEqualityConstraint,
+    lambda: {
+        "feature": "f1",
+        "multiplicity": 1,
+    },
+)

--- a/tests/bofire/data_models/test_constraint_fulfillment.py
+++ b/tests/bofire/data_models/test_constraint_fulfillment.py
@@ -215,15 +215,6 @@ def get_row(features, value: float = None, values: List[float] = None):
             ),
             True,
         ),
-    ],
-)
-def test_fulfillment(df, constraint, fulfilled):
-    assert constraint.is_fulfilled(df).all() == fulfilled
-
-
-@pytest.mark.parametrize(
-    "df, constraint, fulfilled",
-    [
         (
             pd.DataFrame({"a": [1.0, 1.0, 1.0], "b": [1.0, 2.0, 3.0]}),
             InterpointEqualityConstraint(feature="a"),
@@ -255,5 +246,5 @@ def test_fulfillment(df, constraint, fulfilled):
         ),
     ],
 )
-def test_fulfillment_intrapoint(df, constraint, fulfilled):
-    assert constraint.is_fulfilled(df) == fulfilled
+def test_fulfillment(df, constraint, fulfilled):
+    assert constraint.is_fulfilled(df).all() == fulfilled

--- a/tests/bofire/data_models/test_constraint_fulfillment.py
+++ b/tests/bofire/data_models/test_constraint_fulfillment.py
@@ -4,6 +4,7 @@ import pandas as pd
 import pytest
 
 from bofire.data_models.constraints.api import (
+    InterpointEqualityConstraint,
     LinearEqualityConstraint,
     LinearInequalityConstraint,
     NChooseKConstraint,
@@ -218,3 +219,41 @@ def get_row(features, value: float = None, values: List[float] = None):
 )
 def test_fulfillment(df, constraint, fulfilled):
     assert constraint.is_fulfilled(df).all() == fulfilled
+
+
+@pytest.mark.parametrize(
+    "df, constraint, fulfilled",
+    [
+        (
+            pd.DataFrame({"a": [1.0, 1.0, 1.0], "b": [1.0, 2.0, 3.0]}),
+            InterpointEqualityConstraint(feature="a"),
+            True,
+        ),
+        (
+            pd.DataFrame({"a": [1.0, 1.0, 2.0], "b": [1.0, 2.0, 3.0]}),
+            InterpointEqualityConstraint(feature="a"),
+            False,
+        ),
+        (
+            pd.DataFrame({"a": [1.0, 1.0, 2.0, 2.0], "b": [1.0, 2.0, 3.0, 4.0]}),
+            InterpointEqualityConstraint(feature="a", multiplicity=2),
+            True,
+        ),
+        (
+            pd.DataFrame(
+                {"a": [1.0, 1.0, 2.0, 2.0, 3.0], "b": [1.0, 2.0, 3.0, 4.0, 5.0]}
+            ),
+            InterpointEqualityConstraint(feature="a", multiplicity=2),
+            True,
+        ),
+        (
+            pd.DataFrame(
+                {"a": [1.0, 1.0, 2.0, 3.0, 3.0], "b": [1.0, 2.0, 3.0, 4.0, 5.0]}
+            ),
+            InterpointEqualityConstraint(feature="a", multiplicity=2),
+            False,
+        ),
+    ],
+)
+def test_fulfillment_intrapoint(df, constraint, fulfilled):
+    assert constraint.is_fulfilled(df) == fulfilled


### PR DESCRIPTION
As discussed here, this adds the first interpoint constraint data model to BoFire.

From my perspective, a call method on interpoint constraints is somehow ill defined and not needed. What do you think about the `jacobian` method?

The integration in the `Constraints` data model is not yet complete, as the return value of the is_fulfilled method is now a bool and not a series of bools as in the case of the intrapoints. Will fix this later.

@Osburg @dlinzner-bcs  @KappatC 