### PR TITLE
Botorch 0.9.5

### DIFF
--- a/bofire/data_models/features/continuous.py
+++ b/bofire/data_models/features/continuous.py
@@ -65,7 +65,9 @@ class ContinuousInput(NumericalInput):
         allowed_values = np.arange(
             self.lower_bound, self.upper_bound + self.stepsize, self.stepsize
         )
-        idx = abs(values.values.reshape([3, 1]) - allowed_values).argmin(axis=1)  # type: ignore
+        idx = abs(values.values.reshape([len(values), 1]) - allowed_values).argmin(
+            axis=1
+        )  # type: ignore
         return pd.Series(
             data=self.lower_bound + idx * self.stepsize, index=values.index
         )

--- a/bofire/strategies/samplers/polytope.py
+++ b/bofire/strategies/samplers/polytope.py
@@ -142,7 +142,7 @@ class PolytopeSampler(SamplerStrategy):
                 equality_constraints=combined_eqs if len(combined_eqs) > 0 else None,
                 n_burnin=self.n_burnin,
                 thinning=self.n_thinning,
-                seed=self.seed,
+                seed=self.rng.integers(1, 1000),
             ).squeeze(dim=0)
 
             # check that the random generated candidates are not always the same

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ setup(
     ],
     extras_require={
         "optimization": [
-            "botorch>=0.9.4",
+            "botorch>=0.9.5",
             "multiprocess",
             "plotly",
             "formulaic>=0.6.0",


### PR DESCRIPTION
BoTorch version 0.9.5 was released yesterday. It features the possibility to use q>1 for nonlinear constraints which is very helpful for us due to how NChooseK constraints are implemented in the BO part of BoFire. This PR sets the min required BoTorch version for BoFire to 0.9.5.

In addition, the following two bugs are fixed:
- Rounding of continuous inputs was only working for series of length 3.
- The random seed was not set correctly set in the polytope sampler.