### PR TITLE
Hotfix/molecular input

### DIFF
--- a/bofire/data_models/features/molecular.py
+++ b/bofire/data_models/features/molecular.py
@@ -51,8 +51,26 @@ class MolecularInput(Input):
         raise ValueError("Sampling not supported for `MolecularInput`")
 
     def get_bounds(
-        self, transform_type: AnyMolFeatures, values: pd.Series
+        self,
+        transform_type: AnyMolFeatures,
+        values: pd.Series,
+        reference_value: Optional[str] = None,
     ) -> Tuple[List[float], List[float]]:
+        """
+        Calculates the lower and upper bounds for the feature based on the given transform type and values.
+
+        Args:
+            transform_type (AnyMolFeatures): The type of transformation to apply to the data.
+            values (pd.Series): The actual data over which the lower and upper bounds are calculated.
+            reference_value (Optional[str], optional): The reference value for the transformation. Not used here.
+                Defaults to None.
+
+        Returns:
+            Tuple[List[float], List[float]]: A tuple containing the lower and upper bounds of the transformed data.
+
+        Raises:
+            NotImplementedError: Raised when `values` is None, as it is currently required for `MolecularInput`.
+        """
         if values is None:
             raise NotImplementedError(
                 "`values` is currently required for `MolecularInput`"
@@ -133,7 +151,11 @@ class CategoricalMolecularInput(CategoricalInput, MolecularInput):
     ) -> Tuple[List[float], List[float]]:
         if isinstance(transform_type, CategoricalEncodingEnum):
             # we are just using the standard categorical transformations
-            return super().get_bounds(transform_type=transform_type, values=values)
+            return super().get_bounds(
+                transform_type=transform_type,
+                values=values,
+                reference_value=reference_value,
+            )
         else:
             # in case that values is None, we return the optimization bounds
             # else we return the complete bounds

--- a/tests/bofire/data_models/features/test_molecular.py
+++ b/tests/bofire/data_models/features/test_molecular.py
@@ -233,6 +233,7 @@ def test_molecular_feature_get_bounds(expected, transform_type):
     lower, upper = input_feature.get_bounds(
         transform_type=transform_type,
         values=VALID_SMILES,
+        reference_value=None,
     )
     assert np.allclose(lower, expected[0])
     assert np.allclose(upper, expected[1])
@@ -398,7 +399,9 @@ def test_categorical_molecular_input_get_bounds():
     feat = CategoricalMolecularInput(
         key="a", categories=VALID_SMILES.to_list(), allowed=[True, True, True, True]
     )
-    lower, upper = feat.get_bounds(transform_type=CategoricalEncodingEnum.ONE_HOT)
+    lower, upper = feat.get_bounds(
+        transform_type=CategoricalEncodingEnum.ONE_HOT, reference_value=None
+    )
     assert lower == [0 for _ in range(len(feat.categories))]
     assert upper == [1 for _ in range(len(feat.categories))]
     # now test it with descriptors,
@@ -411,7 +414,8 @@ def test_categorical_molecular_input_get_bounds():
                 "nAromAtom",
                 "nAromBond",
             ]
-        )
+        ),
+        reference_value=None,
     )
     assert lower == [6.0, 6.0]
     assert upper == [6.0, 6.0]
@@ -424,6 +428,7 @@ def test_categorical_molecular_input_get_bounds():
             ]
         ),
         values=VALID_SMILES,
+        reference_value=None,
     )
     assert lower == [0.0, 0.0]
     assert upper == [6.0, 6.0]


### PR DESCRIPTION
This PR fixes a bug in the `MolecularInput`. Currently the `reference_value` is ignored there, which creates an error when calling `Inputs.get_bounds`.