### PR TITLE
Active Learning Strategy in BoFire

### DIFF
--- a/bofire/data_models/acquisition_functions/acquisition_function.py
+++ b/bofire/data_models/acquisition_functions/acquisition_function.py
@@ -69,3 +69,8 @@ class qLogNEHVI(MultiObjectiveAcquisitionFunction):
     type: Literal["qLogNEHVI"] = "qLogNEHVI"
     alpha: Annotated[float, Field(ge=0)] = 0.0
     prune_baseline: bool = True
+
+
+class qNegIntPosVar(SingleObjectiveAcquisitionFunction):
+    type: Literal["qNegIntPosVar"] = "qNegIntPosVar"
+    n_points: Annotated[int, Field(ge=1)] = 1024

--- a/bofire/data_models/acquisition_functions/api.py
+++ b/bofire/data_models/acquisition_functions/api.py
@@ -25,7 +25,18 @@ AbstractAcquisitionFunction = [
 ]
 
 AnyAcquisitionFunction = Union[
-    qNEI, qEI, qSR, qUCB, qPI, qLogEI, qLogNEI, qEHVI, qLogEHVI, qNEHVI, qLogNEHVI
+    qNEI,
+    qEI,
+    qSR,
+    qUCB,
+    qPI,
+    qLogEI,
+    qLogNEI,
+    qEHVI,
+    qLogEHVI,
+    qNEHVI,
+    qLogNEHVI,
+    qNegIntPosVar,
 ]
 
 AnySingleObjectiveAcquisitionFunction = Union[

--- a/bofire/data_models/acquisition_functions/api.py
+++ b/bofire/data_models/acquisition_functions/api.py
@@ -10,6 +10,7 @@ from bofire.data_models.acquisition_functions.acquisition_function import (
     qLogEI,
     qLogNEHVI,
     qLogNEI,
+    qNegIntPosVar,
     qNEHVI,
     qNEI,
     qPI,
@@ -32,3 +33,5 @@ AnySingleObjectiveAcquisitionFunction = Union[
 ]
 
 AnyMultiObjectiveAcquisitionFunction = Union[qEHVI, qLogEHVI, qNEHVI, qLogNEHVI]
+
+AnyActiveLearningAcquisitionFunction = qNegIntPosVar

--- a/bofire/data_models/strategies/api.py
+++ b/bofire/data_models/strategies/api.py
@@ -2,6 +2,9 @@ from typing import Union
 
 from bofire.data_models.strategies.doe import DoEStrategy
 from bofire.data_models.strategies.factorial import FactorialStrategy
+from bofire.data_models.strategies.predictives.active_learning import (
+    ActiveLearningStrategy,
+)
 from bofire.data_models.strategies.predictives.botorch import LSRBO, BotorchStrategy
 from bofire.data_models.strategies.predictives.mobo import MoboStrategy
 from bofire.data_models.strategies.predictives.multiobjective import (
@@ -53,6 +56,7 @@ AnyStrategy = Union[
     FactorialStrategy,
     MoboStrategy,
     ShortestPathStrategy,
+    ActiveLearningStrategy,
 ]
 
 AnyPredictive = Union[
@@ -64,6 +68,7 @@ AnyPredictive = Union[
     QnehviStrategy,
     QparegoStrategy,
     MoboStrategy,
+    ActiveLearningStrategy,
 ]
 
 

--- a/bofire/data_models/strategies/predictives/active_learning.py
+++ b/bofire/data_models/strategies/predictives/active_learning.py
@@ -1,0 +1,16 @@
+from typing import Literal
+
+from pydantic import Field
+
+from bofire.data_models.acquisition_functions.api import (
+    AnyActiveLearningAcquisitionFunction,
+    qNegIntPosVar,
+)
+from bofire.data_models.strategies.predictives.botorch import BotorchStrategy
+
+
+class ActiveLearningStrategy(BotorchStrategy):
+    type: Literal["ActiveLearningStrategy"] = "ActiveLearningStrategy"
+    acquisition_function: AnyActiveLearningAcquisitionFunction = Field(
+        default_factory=lambda: qNegIntPosVar()
+    )

--- a/bofire/data_models/strategies/predictives/active_learning.py
+++ b/bofire/data_models/strategies/predictives/active_learning.py
@@ -1,11 +1,14 @@
-from typing import Literal
+from typing import Literal, Type
 
-from pydantic import Field
+from pydantic import Field, field_validator
 
 from bofire.data_models.acquisition_functions.api import (
     AnyActiveLearningAcquisitionFunction,
     qNegIntPosVar,
 )
+from bofire.data_models.domain.api import Domain
+from bofire.data_models.features.api import CategoricalOutput, Feature
+from bofire.data_models.objectives.api import Objective
 from bofire.data_models.strategies.predictives.botorch import BotorchStrategy
 
 
@@ -14,3 +17,39 @@ class ActiveLearningStrategy(BotorchStrategy):
     acquisition_function: AnyActiveLearningAcquisitionFunction = Field(
         default_factory=lambda: qNegIntPosVar()
     )
+
+    @field_validator("domain")
+    @classmethod
+    def validate_domain_is_multiobjective(cls, domain: Domain):
+        """Validate that the domain contains only one output feature."""
+        if len(domain.outputs) != 1:
+            raise ValueError(
+                f"Only one output feature allowed for `ActiveLearningStrategy`, got {len(domain.outputs)}."
+            )
+        return domain
+
+    @classmethod
+    def is_feature_implemented(cls, my_type: Type[Feature]) -> bool:
+        """Method to check if a specific feature type is implemented for the strategy
+
+        Args:
+            my_type (Type[Feature]): Feature class
+
+        Returns:
+            bool: True if the feature type is valid for the strategy chosen, False otherwise
+        """
+        if my_type not in [CategoricalOutput]:
+            return True
+        return False
+
+    @classmethod
+    def is_objective_implemented(cls, my_type: Type[Objective]) -> bool:
+        """Method to check if a objective type is implemented for the strategy
+
+        Args:
+            my_type (Type[Objective]): Objective class
+
+        Returns:
+            bool: True if the objective type is valid for the strategy chosen, False otherwise
+        """
+        return True

--- a/bofire/strategies/api.py
+++ b/bofire/strategies/api.py
@@ -1,5 +1,6 @@
 from bofire.strategies.doe_strategy import DoEStrategy
 from bofire.strategies.mapper import map
+from bofire.strategies.predictives.active_learning import ActiveLearningStrategy
 from bofire.strategies.predictives.botorch import BotorchStrategy
 from bofire.strategies.predictives.predictive import PredictiveStrategy
 from bofire.strategies.predictives.qehvi import QehviStrategy

--- a/bofire/strategies/mapper.py
+++ b/bofire/strategies/mapper.py
@@ -3,6 +3,7 @@ from typing import Dict, Type
 import bofire.data_models.strategies.api as data_models
 from bofire.strategies.doe_strategy import DoEStrategy
 from bofire.strategies.factorial import FactorialStrategy
+from bofire.strategies.predictives.active_learning import ActiveLearningStrategy
 from bofire.strategies.predictives.botorch import BotorchStrategy
 from bofire.strategies.predictives.mobo import MoboStrategy
 from bofire.strategies.predictives.predictive import PredictiveStrategy
@@ -36,6 +37,7 @@ STRATEGY_MAP: Dict[Type[data_models.Strategy], Type[Strategy]] = {
     data_models.FactorialStrategy: FactorialStrategy,
     data_models.MoboStrategy: MoboStrategy,
     data_models.ShortestPathStrategy: ShortestPathStrategy,
+    data_models.ActiveLearningStrategy: ActiveLearningStrategy,
 }
 
 

--- a/bofire/strategies/predictives/active_learning.py
+++ b/bofire/strategies/predictives/active_learning.py
@@ -1,0 +1,22 @@
+from typing import List
+
+from botorch.acquisition.acquisition import AcquisitionFunction
+
+from bofire.data_models.strategies.predictives.active_learning import (
+    ActiveLearningStrategy as DataModel,
+)
+from bofire.strategies.predictives.botorch import BotorchStrategy
+
+
+class ActiveLearningStrategy(BotorchStrategy):
+    def __init__(
+        self,
+        data_model: DataModel,
+        **kwargs,
+    ):
+        super().__init__(data_model=data_model, **kwargs)
+        self.acquisition_function = data_model.acquisition_function
+
+    def _get_acqfs(self, n: int) -> List[AcquisitionFunction]:
+        # TODO: Init of the ACQF goes here
+        raise NotImplementedError

--- a/bofire/strategies/predictives/mobo.py
+++ b/bofire/strategies/predictives/mobo.py
@@ -84,56 +84,6 @@ class MoboStrategy(BotorchStrategy):
         )
         return [acqf]
 
-    # def _get_acqfs(
-    #     self, n
-    # ) -> List[
-    #     Union[
-    #         qExpectedHypervolumeImprovement,
-    #         qNoisyExpectedHypervolumeImprovement,
-    #         qLogNoisyExpectedHypervolumeImprovement,
-    #         qLogExpectedHypervolumeImprovement,
-    #     ]
-    # ]:
-    #     df = self.domain.outputs.preprocess_experiments_all_valid_outputs(
-    #         self.experiments
-    #     )
-
-    #     train_obj = (
-    #         df[self.domain.outputs.get_keys_by_objective(excludes=None)].values
-    #         * self.ref_point_mask
-    #     )
-    #     ref_point = self.get_adjusted_refpoint()
-    #     weights = np.array(
-    #         [
-    #             feat.objective.w  # type: ignore
-    #             for feat in self.domain.outputs.get_by_objective(excludes=None)
-    #         ]
-    #     )
-    #     # compute points that are better than the known reference point
-    #     better_than_ref = (train_obj > ref_point).all(axis=-1)
-    #     # partition non-dominated space into disjoint rectangles
-    #     partitioning = NondominatedPartitioning(
-    #         ref_point=torch.from_numpy(ref_point * weights),
-    #         # use observations that are better than the specified reference point and feasible
-    #         Y=torch.from_numpy(train_obj[better_than_ref]),
-    #     )
-
-    #     _, X_pending = self.get_acqf_input_tensors()
-
-    #     assert self.model is not None
-    #     # setup the acqf
-    #     acqf = qExpectedHypervolumeImprovement(
-    #         model=self.model,
-    #         ref_point=ref_point,  # use known reference point
-    #         partitioning=partitioning,
-    #         # sampler=self.sampler,
-    #         # define an objective that specifies which outcomes are the objectives
-    #         objective=self._get_objective(),
-    #         X_pending=X_pending,
-    #     )
-    #     acqf._default_sample_shape = torch.Size([self.num_sobol_samples])
-    #     return [acqf]
-
     def _get_objective(self) -> GenericMCMultiOutputObjective:
         objective = get_multiobjective_objective(outputs=self.domain.outputs)
         return GenericMCMultiOutputObjective(objective=objective)

--- a/tests/bofire/data_models/specs/acquisition_functions.py
+++ b/tests/bofire/data_models/specs/acquisition_functions.py
@@ -68,3 +68,8 @@ specs.add_valid(
     acquisition_functions.qLogNEHVI,
     lambda: {"alpha": random.random(), "prune_baseline": random.choice([True, False])},
 )
+
+specs.add_valid(
+    acquisition_functions.qNegIntPosVar,
+    lambda: {"n_points": random.randint(1, 1024)},
+)

--- a/tests/bofire/data_models/specs/strategies.py
+++ b/tests/bofire/data_models/specs/strategies.py
@@ -1,5 +1,10 @@
 import bofire.data_models.strategies.api as strategies
-from bofire.data_models.acquisition_functions.api import qEI, qLogNEHVI, qPI
+from bofire.data_models.acquisition_functions.api import (
+    qEI,
+    qLogNEHVI,
+    qNegIntPosVar,
+    qPI,
+)
 from bofire.data_models.constraints.api import (
     LinearEqualityConstraint,
     LinearInequalityConstraint,
@@ -106,6 +111,57 @@ specs.add_valid(
     },
 )
 specs.add_valid(
+    strategies.ActiveLearningStrategy,
+    lambda: {
+        "domain": Domain(
+            inputs=Inputs(
+                features=[
+                    ContinuousInput(
+                        key="a",
+                        bounds=(0, 1),
+                    ),
+                    ContinuousInput(
+                        key="b",
+                        bounds=(0, 1),
+                    ),
+                ]
+            ),
+            outputs=Outputs(features=[ContinuousOutput(key="alpha")]),
+        ).model_dump(),
+        "acquisition_function": qNegIntPosVar(n_points=2048).model_dump(),
+        **strategy_commons,
+    },
+)
+
+specs.add_invalid(
+    strategies.ActiveLearningStrategy,
+    lambda: {
+        "domain": Domain(
+            inputs=Inputs(
+                features=[
+                    ContinuousInput(
+                        key="a",
+                        bounds=(0, 1),
+                    ),
+                    ContinuousInput(
+                        key="b",
+                        bounds=(0, 1),
+                    ),
+                ]
+            ),
+            outputs=Outputs(
+                features=[ContinuousOutput(key="alpha"), ContinuousOutput(key="beta")]
+            ),
+        ).model_dump(),
+        "acquisition_function": qNegIntPosVar(n_points=2048).model_dump(),
+        **strategy_commons,
+    },
+    error=ValueError,
+    message="Only one output feature allowed for `ActiveLearningStrategy`, got 2.",
+)
+
+
+specs.add_valid(
     strategies.RandomStrategy,
     lambda: {
         "domain": domain.valid().obj().model_dump(),
@@ -138,6 +194,7 @@ specs.add_valid(
         "seed": 42,
     },
 )
+
 
 tempdomain = domain.valid().obj()
 


### PR DESCRIPTION
This PR is still work in progress and implements an `ActiveLearningStrategy` in `BoFire` as discussed in issue https://github.com/experimental-design/bofire/issues/331.

@jdridder: this is my current status:
- the overall framework is set up, the `ActiveLearningStrategy` inherits from the `BotorchStrategy` and can be used in combination with `AnyActiveLearningAcquisitionFunction`, which is currently only `qNegIntPosVar` and can be only used with one output feature.
- to make it actually working you have to implement the `_get_acqfs` method within the functional model of the `ActiveLearningStrategy`.
- feel free to add more acqfs, if you want to use the ones from @hvarfner PR https://github.com/pytorch/botorch/pull/2163, you have to add a validator that they can be used only in combination with a `SaasSingleTaskGPSurrogate` surrogate.

I would recomment that you just create a branch based on this branch and then create a new PR. Thank you very much for your support.