### PR TITLE
Qparege with constraints and batch proposals crashes

### DIFF
--- a/bofire/benchmarks/detergent.py
+++ b/bofire/benchmarks/detergent.py
@@ -1,0 +1,86 @@
+import numpy as np
+import pandas as pd
+
+from bofire.benchmarks.benchmark import Benchmark
+from bofire.data_models.constraints.linear import LinearInequalityConstraint
+from bofire.data_models.domain.domain import Domain
+from bofire.data_models.features.continuous import ContinuousInput, ContinuousOutput
+
+
+def _poly2(x: np.ndarray) -> np.ndarray:
+    """Quadratic feature expansion including bias term."""
+    return np.concatenate([[1], x, np.outer(x, x)[np.triu_indices(5)]])
+
+
+class Detergent(Benchmark):
+    """Detergent formulation problem.
+
+    There are 5 outputs representing the washing performance on different stain types.
+    Each output is modeled as a second degree polynomial.
+    The formulation consists of 5 components.
+    The sixth input is a filler (water) and is factored out and it's parameter bounds
+    0.6 < water < 0.8 result in 2 linear inequality constraints for the other parameters.
+    """
+
+    def __init__(self):
+        super().__init__()
+        # coefficients for the 2-order polynomial; generated with
+        # base = 3 * np.ones((1, 5))
+        # scale = PolynomialFeatures(degree=2).fit_transform(base).T
+        # coef = np.random.RandomState(42).normal(scale=scale, size=(len(scale), 5))
+        # coef = np.clip(coef, 0, None)
+        self.coef = np.array(
+            [
+                [0.4967, 0.0, 0.6477, 1.523, 0.0],
+                [0.0, 4.7376, 2.3023, 0.0, 1.6277],
+                [0.0, 0.0, 0.7259, 0.0, 0.0],
+                [0.0, 0.0, 0.9427, 0.0, 0.0],
+                [4.3969, 0.0, 0.2026, 0.0, 0.0],
+                [0.3328, 0.0, 1.1271, 0.0, 0.0],
+                [0.0, 16.6705, 0.0, 0.0, 7.4029],
+                [0.0, 1.8798, 0.0, 0.0, 1.7718],
+                [6.6462, 1.5423, 0.0, 0.0, 0.0],
+                [0.0, 0.0, 9.5141, 3.0926, 0.0],
+                [2.9168, 0.0, 0.0, 5.5051, 9.279],
+                [8.3815, 0.0, 0.0, 2.9814, 8.7799],
+                [0.0, 0.0, 0.0, 0.0, 7.3127],
+                [12.2062, 0.0, 9.0318, 3.2547, 0.0],
+                [3.2526, 13.8423, 0.0, 14.0818, 0.0],
+                [7.3971, 0.7834, 0.0, 0.8258, 0.0],
+                [0.0, 3.214, 13.301, 0.0, 0.0],
+                [0.0, 8.2386, 2.9588, 0.0, 4.6194],
+                [0.8737, 8.7178, 0.0, 0.0, 0.0],
+                [0.0, 2.6651, 2.3495, 0.046, 0.0],
+                [0.0, 0.0, 0.0, 0.0, 0.0],
+            ]
+        )
+
+        self._domain = Domain.from_lists(
+            inputs=[
+                ContinuousInput(key="x1", bounds=(0.0, 0.2)),
+                ContinuousInput(key="x2", bounds=(0.0, 0.3)),
+                ContinuousInput(key="x3", bounds=(0.02, 0.2)),
+                ContinuousInput(key="x4", bounds=(0.0, 0.06)),
+                ContinuousInput(key="x5", bounds=(0.0, 0.04)),
+            ],
+            outputs=[ContinuousOutput(key=f"y{i+1}") for i in range(5)],
+            constraints=[
+                LinearInequalityConstraint(
+                    features=["x1", "x2", "x3", "x4", "x5"],
+                    coefficients=[-1] * 5,
+                    rhs=-0.2,
+                ),
+                LinearInequalityConstraint(
+                    features=["x1", "x2", "x3", "x4", "x5"],
+                    coefficients=[1] * 5,
+                    rhs=0.4,
+                ),
+            ],
+        )
+
+    def _f(self, X: pd.DataFrame) -> pd.DataFrame:
+        x = np.atleast_2d(X[self.domain.inputs.get_keys()])
+        xp = np.stack([_poly2(xi) for xi in x], axis=0)
+        return pd.DataFrame(
+            xp @ self.coef, columns=self.domain.outputs.get_keys(), index=X.index
+        )

--- a/bofire/strategies/predictives/botorch.py
+++ b/bofire/strategies/predictives/botorch.py
@@ -327,7 +327,7 @@ class BotorchStrategy(PredictiveStrategy):
                 ic_gen_kwargs=ic_gen_kwargs,
                 ic_generator=ic_generator,
                 options={
-                    "batch_limit": 5 if len(nonlinear_constraints) == 0 else 1,
+                    "batch_limit": 5 if len(nonlinear_constraints or []) == 0 else 1,
                     "maxiter": 200,
                 },
             )

--- a/tests/bofire/benchmarks/test_detergent.py
+++ b/tests/bofire/benchmarks/test_detergent.py
@@ -1,0 +1,18 @@
+from bofire.benchmarks.detergent import Detergent
+from bofire.data_models.strategies.random import (
+    RandomStrategy as RandomStrategyDataModel,
+)
+from bofire.strategies.api import RandomStrategy
+
+
+def test_detergent():
+    d = Detergent()
+    assert len(d.domain.inputs) == 5
+    assert len(d.domain.outputs) == 5
+    assert len(d.domain.constraints) == 2
+
+    # check that the domain has feasible points
+    random_search_dm = RandomStrategyDataModel(domain=d.domain)
+    random_search = RandomStrategy(random_search_dm)
+    candidates = random_search.ask(2)
+    assert d.domain.constraints.is_fulfilled(candidates).all()

--- a/tests/bofire/benchmarks/test_detergent.py
+++ b/tests/bofire/benchmarks/test_detergent.py
@@ -16,3 +16,7 @@ def test_detergent():
     random_search = RandomStrategy(random_search_dm)
     candidates = random_search.ask(2)
     assert d.domain.constraints.is_fulfilled(candidates).all()
+    y = d.f(candidates)
+    assert y.shape == (2, 5)
+    for o_key in d.domain.outputs.get_keys():
+        assert o_key in y.columns

--- a/tests/bofire/strategies/test_qparego.py
+++ b/tests/bofire/strategies/test_qparego.py
@@ -143,7 +143,7 @@ def test_qparego(num_test_candidates):
 
 @pytest.mark.parametrize(
     "num_test_candidates",
-    list(range(1, 2)),
+    [1, 2],
 )
 def test_qparego_constraints(num_test_candidates):
     # generate data
@@ -153,7 +153,9 @@ def test_qparego_constraints(num_test_candidates):
     )
     experiments = benchmark.f(random_strategy.ask(10), return_complete=True)
     # init strategy
-    data_model = data_models.QparegoStrategy(domain=benchmark.domain)
+    data_model = data_models.QparegoStrategy(
+        domain=benchmark.domain, num_sobol_samples=1024, num_restarts=1
+    )
     my_strategy = QparegoStrategy(data_model=data_model)
     my_strategy.tell(experiments)
     # test get objective
@@ -161,7 +163,7 @@ def test_qparego_constraints(num_test_candidates):
     assert isinstance(objective, GenericMCObjective)
     # ask
     candidates = my_strategy.ask(num_test_candidates)
-    assert benchmark.domain.constraints.is_fulfilled(candidates)
+    assert benchmark.domain.constraints.is_fulfilled(candidates).all()
     assert len(candidates) == num_test_candidates
 
 

--- a/tests/bofire/strategies/test_qparego.py
+++ b/tests/bofire/strategies/test_qparego.py
@@ -14,7 +14,8 @@ from pydantic import ValidationError
 
 import bofire.data_models.strategies.api as data_models
 import bofire.data_models.surrogates.api as surrogate_data_models
-from bofire.benchmarks.multi import C2DTLZ2, DTLZ2, CrossCoupling
+from bofire.benchmarks.detergent import Detergent
+from bofire.benchmarks.multi import DTLZ2, CrossCoupling
 from bofire.data_models.acquisition_functions.api import qEI, qLogEI, qLogNEI, qNEI
 from bofire.data_models.domain.api import Outputs
 from bofire.data_models.strategies.api import RandomStrategy as RandomStrategyDataModel
@@ -146,7 +147,7 @@ def test_qparego(num_test_candidates):
 )
 def test_qparego_constraints(num_test_candidates):
     # generate data
-    benchmark = C2DTLZ2(dim=4)
+    benchmark = Detergent()
     random_strategy = RandomStrategy(
         data_model=RandomStrategyDataModel(domain=benchmark.domain)
     )
@@ -160,6 +161,7 @@ def test_qparego_constraints(num_test_candidates):
     assert isinstance(objective, GenericMCObjective)
     # ask
     candidates = my_strategy.ask(num_test_candidates)
+    assert benchmark.domain.constraints.is_fulfilled(candidates)
     assert len(candidates) == num_test_candidates
 
 


### PR DESCRIPTION
The error was not detected because earlier
- ~~The previous constraint-test of Qparego didn't seem to have constraints.~~ _There are output constraints but no input constraints in the test._
- The previous constraint-test didn't test batch proposals even though it looked like it did at first glance.

This PR also adds the detergent benchmark problem.