### PR TITLE
RDKit Logger

### DIFF
--- a/bofire/utils/cheminformatics.py
+++ b/bofire/utils/cheminformatics.py
@@ -5,7 +5,11 @@ import numpy as np
 import pandas as pd
 
 try:
+    from rdkit import RDLogger
     from rdkit.Chem import AllChem, Descriptors, MolFromSmiles  # type: ignore
+
+    lg = RDLogger.logger()
+    lg.setLevel(RDLogger.CRITICAL)
 
     # from sklearn.feature_extraction.text import CountVectorizer
 except ImportError:


### PR DESCRIPTION
As described here: https://github.com/experimental-design/bofire/pull/375#issuecomment-1999889317 the RDkit logger creates misleading error messages when desrializing features. This PR mutes this messages. Proper logging in BoFire will be part of a future PR. 