### PR TITLE
Fix bug in `aggregate_by_duplicates`

### DIFF
--- a/bofire/data_models/domain/domain.py
+++ b/bofire/data_models/domain/domain.py
@@ -426,10 +426,11 @@ class Domain(BaseModel):
                 for i in range(experiments.shape[0])
             ]
 
-        # round it
-        experiments[self.get_feature_keys(ContinuousInput)] = experiments[
-            self.get_feature_keys(ContinuousInput)
-        ].round(prec)
+        # round it if continuous inputs are present
+        if len(self.inputs.get(ContinuousInput)) > 0:
+            experiments[self.get_feature_keys(ContinuousInput)] = experiments[
+                self.get_feature_keys(ContinuousInput)
+            ].round(prec)
 
         # coerce invalid to nan
         experiments = self.coerce_invalids(experiments)


### PR DESCRIPTION
`aggregate_by_duplicates` was throwing an error when used for domains with no continuous features. This PR fixes it.