### PR TITLE
Implement generic typing in Features

### DIFF
--- a/bofire/data_models/domain/features.py
+++ b/bofire/data_models/domain/features.py
@@ -189,6 +189,7 @@ class _BaseFeatures(BaseModel, Generic[F]):
 class Features(_BaseFeatures[AnyFeature]):
     pass
 
+
 class Inputs(_BaseFeatures[AnyInput]):
     """Container of input features, only input features are allowed.
 

--- a/bofire/data_models/domain/features.py
+++ b/bofire/data_models/domain/features.py
@@ -3,13 +3,25 @@ from __future__ import annotations
 import itertools
 import warnings
 from enum import Enum
-from typing import Dict, List, Literal, Optional, Sequence, Tuple, Type, Union, cast, Generic, TypeVar
+from typing import (
+    Dict,
+    Generic,
+    List,
+    Literal,
+    Optional,
+    Sequence,
+    Tuple,
+    Type,
+    TypeVar,
+    Union,
+    cast,
+)
 
-from typing_extensions import Self
 import numpy as np
 import pandas as pd
 from pydantic import Field, field_validator, validate_call
 from scipy.stats.qmc import LatinHypercube, Sobol
+from typing_extensions import Self
 
 from bofire.data_models.base import BaseModel
 from bofire.data_models.enum import CategoricalEncodingEnum, SamplingMethodEnum

--- a/bofire/data_models/domain/features.py
+++ b/bofire/data_models/domain/features.py
@@ -6,6 +6,7 @@ from enum import Enum
 from typing import (
     Dict,
     Generic,
+    Iterator,
     List,
     Literal,
     Optional,
@@ -75,7 +76,7 @@ class _BaseFeatures(BaseModel, Generic[F]):
             raise ValueError("Feature keys are not unique.")
         return features
 
-    def __iter__(self):
+    def __iter__(self) -> Iterator[F]:
         return iter(self.features)
 
     def __len__(self):

--- a/bofire/data_models/strategies/predictives/predictive.py
+++ b/bofire/data_models/strategies/predictives/predictive.py
@@ -26,7 +26,6 @@ class PredictiveStrategy(Strategy):
         """
         for feature in domain.outputs.get_by_objective(Objective):
             assert isinstance(feature, Output)
-            assert feature.objective is not None
             if not cls.is_objective_implemented(type(feature.objective)):  # type: ignore
                 raise ValueError(
                     f"Objective `{type(feature.objective)}` is not implemented for strategy `{cls.__name__}`"  # type: ignore


### PR DESCRIPTION
Implements generic typing for Features.

Currently, the dynamic typing for `Features`, `Inputs`, and `Outputs` doesn't work well with pyright. There are many `# type: ignore`s in the codebase, such as shown below, to address this. However, a solution that does work with pyright is generic typing. With this PR, you can remove these comments and the type checker is still happy. The API for interacting with `Features`, `Inputs`, and `Outputs` remains unchanged,

https://github.com/experimental-design/bofire/blob/0efb4685ce72c163a44e0f1fdc325ce191dda31d/bofire/data_models/strategies/predictives/botorch.py#L198
