### PR TITLE
Add generic typing to Constraints

### DIFF
--- a/bofire/data_models/domain/constraints.py
+++ b/bofire/data_models/domain/constraints.py
@@ -1,31 +1,49 @@
 import collections.abc
 from itertools import chain
-from typing import List, Literal, Optional, Sequence, Type, Union
+from typing import (
+    Generic,
+    Iterator,
+    List,
+    Literal,
+    Optional,
+    Sequence,
+    Type,
+    TypeVar,
+    Union,
+    get_args,
+)
 
 import pandas as pd
 from pydantic import Field
 
 from bofire.data_models.base import BaseModel
-from bofire.data_models.constraints.api import AnyConstraint, Constraint
+from bofire.data_models.constraints.api import (
+    AnyConstraint,
+)
 from bofire.data_models.filters import filter_by_class
 
+C = TypeVar("C", bound=AnyConstraint)
+C_ = TypeVar("C_", bound=AnyConstraint)
+C__ = TypeVar("C__", bound=AnyConstraint)
+AnyConstraintTuple = get_args(AnyConstraint)
 
-class Constraints(BaseModel):
+
+class Constraints(BaseModel, Generic[C]):
     type: Literal["Constraints"] = "Constraints"
-    constraints: Sequence[AnyConstraint] = Field(default_factory=lambda: [])
+    constraints: Sequence[C] = Field(default_factory=lambda: [])
 
-    def __iter__(self):
+    def __iter__(self) -> Iterator[C]:
         return iter(self.constraints)
 
     def __len__(self):
         return len(self.constraints)
 
-    def __getitem__(self, i):
+    def __getitem__(self, i) -> C:
         return self.constraints[i]
 
     def __add__(
-        self, other: Union[Sequence[AnyConstraint], "Constraints"]
-    ) -> "Constraints":
+        self, other: Union[Sequence[C_], "Constraints[C_]"]
+    ) -> "Constraints[Union[C, C_]]":
         if isinstance(other, collections.abc.Sequence):
             other_constraints = other
         else:
@@ -78,10 +96,10 @@ class Constraints(BaseModel):
 
     def get(
         self,
-        includes: Union[Type, List[Type]] = Constraint,
-        excludes: Optional[Union[Type, List[Type]]] = None,
+        includes: Union[Type[C_], Sequence[Type[C_]]] = AnyConstraintTuple,
+        excludes: Optional[Union[Type[C__], List[Type[C__]]]] = None,
         exact: bool = False,
-    ) -> "Constraints":
+    ) -> "Constraints[C_]":
         """get constraints of the domain
 
         Args:

--- a/bofire/data_models/domain/constraints.py
+++ b/bofire/data_models/domain/constraints.py
@@ -10,22 +10,18 @@ from typing import (
     Type,
     TypeVar,
     Union,
-    get_args,
 )
 
 import pandas as pd
 from pydantic import Field
 
 from bofire.data_models.base import BaseModel
-from bofire.data_models.constraints.api import (
-    AnyConstraint,
-)
+from bofire.data_models.constraints.api import AnyConstraint, Constraint
 from bofire.data_models.filters import filter_by_class
 
-C = TypeVar("C", bound=AnyConstraint)
-C_ = TypeVar("C_", bound=AnyConstraint)
-C__ = TypeVar("C__", bound=AnyConstraint)
-AnyConstraintTuple = get_args(AnyConstraint)
+C = TypeVar("C", bound=Union[AnyConstraint, Constraint])
+C_ = TypeVar("C_", bound=Union[AnyConstraint, Constraint])
+C__ = TypeVar("C__", bound=Union[AnyConstraint, Constraint])
 
 
 class Constraints(BaseModel, Generic[C]):
@@ -96,7 +92,7 @@ class Constraints(BaseModel, Generic[C]):
 
     def get(
         self,
-        includes: Union[Type[C_], Sequence[Type[C_]]] = AnyConstraintTuple,
+        includes: Union[Type[C_], Sequence[Type[C_]]] = Constraint,
         excludes: Optional[Union[Type[C__], List[Type[C__]]]] = None,
         exact: bool = False,
     ) -> "Constraints[C_]":

--- a/bofire/data_models/domain/constraints.py
+++ b/bofire/data_models/domain/constraints.py
@@ -20,8 +20,8 @@ from bofire.data_models.constraints.api import AnyConstraint, Constraint
 from bofire.data_models.filters import filter_by_class
 
 C = TypeVar("C", bound=Union[AnyConstraint, Constraint])
-C_ = TypeVar("C_", bound=Union[AnyConstraint, Constraint])
-C__ = TypeVar("C__", bound=Union[AnyConstraint, Constraint])
+CIncludes = TypeVar("CIncludes", bound=Union[AnyConstraint, Constraint])
+CExcludes = TypeVar("CExcludes", bound=Union[AnyConstraint, Constraint])
 
 
 class Constraints(BaseModel, Generic[C]):
@@ -38,8 +38,8 @@ class Constraints(BaseModel, Generic[C]):
         return self.constraints[i]
 
     def __add__(
-        self, other: Union[Sequence[C_], "Constraints[C_]"]
-    ) -> "Constraints[Union[C, C_]]":
+        self, other: Union[Sequence[CIncludes], "Constraints[CIncludes]"]
+    ) -> "Constraints[Union[C, CIncludes]]":
         if isinstance(other, collections.abc.Sequence):
             other_constraints = other
         else:
@@ -92,19 +92,19 @@ class Constraints(BaseModel, Generic[C]):
 
     def get(
         self,
-        includes: Union[Type[C_], Sequence[Type[C_]]] = Constraint,
-        excludes: Optional[Union[Type[C__], List[Type[C__]]]] = None,
+        includes: Union[Type[CIncludes], Sequence[Type[CIncludes]]] = Constraint,
+        excludes: Optional[Union[Type[CExcludes], List[Type[CExcludes]]]] = None,
         exact: bool = False,
-    ) -> "Constraints[C_]":
-        """get constraints of the domain
+    ) -> "Constraints[CIncludes]":
+        """Get constraints of the domain
 
         Args:
-            includes (Union[Constraint, List[Constraint]], optional): Constraint class or list of specific constraint classes to be returned. Defaults to Constraint.
-            excludes (Union[Type, List[Type]], optional): Constraint class or list of specific constraint classes to be excluded from the return. Defaults to None.
+            includes (Union[Type[Constraint], List[Type[Constraint]]], optional): Constraint class or list of specific constraint classes to be returned. Defaults to Constraint.
+            excludes (Union[Type[Constraint], List[Type[Constraint]]], optional): Constraint class or list of specific constraint classes to be excluded from the return. Defaults to None.
             exact (bool, optional): Boolean to distinguish if only the exact class listed in includes and no subclasses inherenting from this class shall be returned. Defaults to False.
 
         Returns:
-            List[Constraint]: List of constraints in the domain fitting to the passed requirements.
+            Constraints: constraints in the domain fitting to the passed requirements.
         """
         return Constraints(
             constraints=filter_by_class(

--- a/bofire/data_models/domain/constraints.py
+++ b/bofire/data_models/domain/constraints.py
@@ -99,9 +99,9 @@ class Constraints(BaseModel, Generic[C]):
         """Get constraints of the domain
 
         Args:
-            includes (Union[Type[Constraint], List[Type[Constraint]]], optional): Constraint class or list of specific constraint classes to be returned. Defaults to Constraint.
-            excludes (Union[Type[Constraint], List[Type[Constraint]]], optional): Constraint class or list of specific constraint classes to be excluded from the return. Defaults to None.
-            exact (bool, optional): Boolean to distinguish if only the exact class listed in includes and no subclasses inherenting from this class shall be returned. Defaults to False.
+            includes: Constraint class or list of specific constraint classes to be returned. Defaults to Constraint.
+            excludes: Constraint class or list of specific constraint classes to be excluded from the return. Defaults to None.
+            exact: Boolean to distinguish if only the exact class listed in includes and no subclasses inherenting from this class shall be returned. Defaults to False.
 
         Returns:
             Constraints: constraints in the domain fitting to the passed requirements.

--- a/bofire/utils/torch_tools.py
+++ b/bofire/utils/torch_tools.py
@@ -1,5 +1,5 @@
 import math
-from typing import Callable, Dict, List, Optional, Tuple, Union
+from typing import Callable, Dict, List, Optional, Tuple, Type, Union
 
 import numpy as np
 import torch
@@ -34,7 +34,7 @@ tkwargs = {
 
 def get_linear_constraints(
     domain: Domain,
-    constraint: Union[LinearEqualityConstraint, LinearInequalityConstraint],
+    constraint: Union[Type[LinearEqualityConstraint], Type[LinearInequalityConstraint]],
     unit_scaled: bool = False,
 ) -> List[Tuple[Tensor, Tensor, float]]:
     """Converts linear constraints to the form required by BoTorch.

--- a/bofire/utils/torch_tools.py
+++ b/bofire/utils/torch_tools.py
@@ -41,7 +41,7 @@ def get_linear_constraints(
 
     Args:
         domain (Domain): Optimization problem definition.
-        constraint (Union[LinearEqualityConstraint, LinearInequalityConstraint]): Type of constraint that should be converted.
+        constraint (Union[Type[LinearEqualityConstraint], Type[LinearInequalityConstraint]]): Type of constraint that should be converted.
         unit_scaled (bool, optional): If True, transforms constraints by assuming that the bound for the continuous features are [0,1]. Defaults to False.
 
     Returns:

--- a/bofire/utils/torch_tools.py
+++ b/bofire/utils/torch_tools.py
@@ -40,9 +40,9 @@ def get_linear_constraints(
     """Converts linear constraints to the form required by BoTorch.
 
     Args:
-        domain (Domain): Optimization problem definition.
-        constraint (Union[Type[LinearEqualityConstraint], Type[LinearInequalityConstraint]]): Type of constraint that should be converted.
-        unit_scaled (bool, optional): If True, transforms constraints by assuming that the bound for the continuous features are [0,1]. Defaults to False.
+        domain: Optimization problem definition.
+        constraint: Type of constraint that should be converted.
+        unit_scaled: If True, transforms constraints by assuming that the bound for the continuous features are [0,1]. Defaults to False.
 
     Returns:
         List[Tuple[Tensor, Tensor, float]]: List of tuples, each tuple consists of a tensor with the feature indices, coefficients and a float for the rhs.


### PR DESCRIPTION
Following on from #383, here's generic typing in Constraints!

Pyright (and whatever type checker your IDE uses) will now infer the type of constraints contained in a `Constraints` object.

It isn't perfect - you can't type hint set subtraction [1], so the `excludes` keyword isn't typed properly. But it clears up more `# type: ignore`s than before!

```python
constraints = Constraints(constraints=[LinearEqualityConstraint(...), NChooseKConstraint(...)]))
# type of constraints.features is inferred as Sequence[LinearEqualityConstraint | NChooseKConstraint]
sub_constraints = constraints.get(includes=[NChooseKConstraint])
# type of sub_constraints.features is inferred as Sequence[NChooseKConstraint]
```

[1] https://discuss.python.org/t/type-intersection-and-negation-in-type-annotations/23879