### PR TITLE
Remove `math.inf` from ContinuousInput data model

### DIFF
--- a/bofire/benchmarks/single.py
+++ b/bofire/benchmarks/single.py
@@ -234,7 +234,7 @@ class Branin(Benchmark):
                                 0.5 * locality_factor,
                             )
                             if locality_factor is not None
-                            else (math.inf, math.inf)
+                            else None
                         ),
                     ),
                     ContinuousInput(
@@ -246,7 +246,7 @@ class Branin(Benchmark):
                                 1.5 * locality_factor,
                             )
                             if locality_factor is not None
-                            else (math.inf, math.inf)
+                            else None
                         ),
                     ),
                 ]

--- a/bofire/data_models/features/continuous.py
+++ b/bofire/data_models/features/continuous.py
@@ -17,16 +17,16 @@ class ContinuousInput(NumericalInput):
         bounds (Tuple[float, float]): A tuple that stores the lower and upper bound of the feature.
         stepsize (float, optional): Float indicating the allowed stepsize between lower and upper. Defaults to None.
         local_relative_bounds (Tuple[float, float], optional): A tuple that stores the lower and upper bounds relative to a reference value.
-            Defaults to (math.inf, math.inf).
+            Defaults to None.
     """
 
     type: Literal["ContinuousInput"] = "ContinuousInput"
     order_id: ClassVar[int] = 1
 
     bounds: Tuple[float, float]
-    local_relative_bounds: Tuple[
-        Annotated[float, Field(gt=0)], Annotated[float, Field(gt=0)]
-    ] = (math.inf, math.inf)
+    local_relative_bounds: Optional[
+        Tuple[Annotated[float, Field(gt=0)], Annotated[float, Field(gt=0)]]
+    ] = None
     stepsize: Optional[float] = None
 
     @property
@@ -154,14 +154,18 @@ class ContinuousInput(NumericalInput):
             if reference_value is None or self.is_fixed():
                 return [self.lower_bound], [self.upper_bound]
             else:
+                local_relative_bounds = self.local_relative_bounds or (
+                    math.inf,
+                    math.inf,
+                )
                 return [
                     max(
-                        reference_value - self.local_relative_bounds[0],
+                        reference_value - local_relative_bounds[0],
                         self.lower_bound,
                     )
                 ], [
                     min(
-                        reference_value + self.local_relative_bounds[1],
+                        reference_value + local_relative_bounds[1],
                         self.upper_bound,
                     )
                 ]

--- a/bofire/data_models/strategies/shortest_path.py
+++ b/bofire/data_models/strategies/shortest_path.py
@@ -1,4 +1,3 @@
-import math
 from typing import Annotated, Dict, Literal, Type, Union
 
 import pandas as pd
@@ -30,7 +29,7 @@ def has_local_search_region(domain: Domain) -> bool:
     is_lsr = False
     for feat in domain.inputs.get(ContinuousInput):
         assert isinstance(feat, ContinuousInput)
-        if feat.local_relative_bounds != (math.inf, math.inf):
+        if feat.local_relative_bounds is not None:
             is_lsr = True
     return is_lsr
 


### PR DESCRIPTION
This PR removes the default `(math.inf, math.inf)` from the `ContiuousInput`, as this creates with `FastAPI` as @jkeupp find out in his PR on the data models from the hackathon.