### PR TITLE
name construction in a method

### DIFF
--- a/bofire/data_models/domain/features.py
+++ b/bofire/data_models/domain/features.py
@@ -27,7 +27,6 @@ from typing_extensions import Self
 from bofire.data_models.base import BaseModel
 from bofire.data_models.enum import CategoricalEncodingEnum, SamplingMethodEnum
 from bofire.data_models.features.api import (
-    _CAT_SEP,
     AnyFeature,
     AnyInput,
     AnyOutput,
@@ -44,6 +43,7 @@ from bofire.data_models.features.api import (
     Output,
     TaskInput,
 )
+from bofire.data_models.features.feature import get_encoded_name
 from bofire.data_models.filters import filter_by_attribute, filter_by_class
 from bofire.data_models.molfeatures.api import MolFeatures
 from bofire.data_models.objectives.api import (
@@ -414,7 +414,7 @@ class Inputs(_BaseFeatures[AnyInput]):
                     (np.array(range(len(feat.categories))) + counter).tolist()
                 )
                 features2names[feat.key] = tuple(
-                    [f"{feat.key}{_CAT_SEP}{c}" for c in feat.categories]
+                    [get_encoded_name(feat.key, c) for c in feat.categories]
                 )
                 counter += len(feat.categories)
             elif specs[feat.key] == CategoricalEncodingEnum.ORDINAL:
@@ -427,7 +427,7 @@ class Inputs(_BaseFeatures[AnyInput]):
                     (np.array(range(len(feat.categories) - 1)) + counter).tolist()
                 )
                 features2names[feat.key] = tuple(
-                    [f"{feat.key}{_CAT_SEP}{c}" for c in feat.categories[1:]]
+                    [get_encoded_name(feat.key, c) for c in feat.categories[1:]]
                 )
                 counter += len(feat.categories) - 1
             elif specs[feat.key] == CategoricalEncodingEnum.DESCRIPTOR:
@@ -436,7 +436,7 @@ class Inputs(_BaseFeatures[AnyInput]):
                     (np.array(range(len(feat.descriptors))) + counter).tolist()
                 )
                 features2names[feat.key] = tuple(
-                    [f"{feat.key}{_CAT_SEP}{d}" for d in feat.descriptors]
+                    [get_encoded_name(feat.key, d) for d in feat.descriptors]
                 )
                 counter += len(feat.descriptors)
             elif isinstance(specs[feat.key], MolFeatures):
@@ -446,7 +446,7 @@ class Inputs(_BaseFeatures[AnyInput]):
                     (np.array(range(len(descriptor_names))) + counter).tolist()
                 )
                 features2names[feat.key] = tuple(
-                    [f"{feat.key}{_CAT_SEP}{d}" for d in descriptor_names]
+                    [get_encoded_name(feat.key, d) for d in descriptor_names]
                 )
                 counter += len(descriptor_names)
         return features2idx, features2names

--- a/bofire/data_models/features/api.py
+++ b/bofire/data_models/features/api.py
@@ -7,7 +7,7 @@ from bofire.data_models.features.descriptor import (
     ContinuousDescriptorInput,
 )
 from bofire.data_models.features.discrete import DiscreteInput
-from bofire.data_models.features.feature import _CAT_SEP, Feature, Input, Output
+from bofire.data_models.features.feature import Feature, Input, Output
 from bofire.data_models.features.molecular import (
     CategoricalMolecularInput,
     MolecularInput,

--- a/bofire/data_models/features/descriptor.py
+++ b/bofire/data_models/features/descriptor.py
@@ -7,7 +7,7 @@ from pydantic import Field, field_validator, model_validator
 from bofire.data_models.enum import CategoricalEncodingEnum
 from bofire.data_models.features.categorical import CategoricalInput
 from bofire.data_models.features.continuous import ContinuousInput
-from bofire.data_models.features.feature import _CAT_SEP, TTransform
+from bofire.data_models.features.feature import TTransform, get_encoded_name
 from bofire.data_models.types import Descriptors, DiscreteVals
 
 
@@ -215,7 +215,7 @@ class CategoricalDescriptorInput(CategoricalInput):
         """
         return pd.DataFrame(
             data=values.map(dict(zip(self.categories, self.values))).values.tolist(),  # type: ignore
-            columns=[f"{self.key}{_CAT_SEP}{d}" for d in self.descriptors],
+            columns=[get_encoded_name(self.key, d) for d in self.descriptors],
             index=values.index,
         )
 
@@ -231,7 +231,7 @@ class CategoricalDescriptorInput(CategoricalInput):
         Returns:
             pd.Series: Series with categorical values.
         """
-        cat_cols = [f"{self.key}{_CAT_SEP}{d}" for d in self.descriptors]
+        cat_cols = [get_encoded_name(self.key, d) for d in self.descriptors]
         # we allow here explicitly that the dataframe can have more columns than needed to have it
         # easier in the backtransform.
         if np.any([c not in values.columns for c in cat_cols]):

--- a/bofire/data_models/features/feature.py
+++ b/bofire/data_models/features/feature.py
@@ -158,3 +158,8 @@ def is_numeric(s: Union[pd.Series, pd.DataFrame]) -> bool:
 
 def is_categorical(s: pd.Series, categories: List[str]):
     return sum(s.isin(categories)) == len(s)
+
+
+def get_encoded_name(feature_key: str, option_name: str) -> str:
+    """Get the name of the encoded column. Option could be the category or the descriptor name."""
+    return f"{feature_key}_{option_name}"

--- a/bofire/data_models/features/feature.py
+++ b/bofire/data_models/features/feature.py
@@ -158,6 +158,3 @@ def is_numeric(s: Union[pd.Series, pd.DataFrame]) -> bool:
 
 def is_categorical(s: pd.Series, categories: List[str]):
     return sum(s.isin(categories)) == len(s)
-
-
-_CAT_SEP = "_"

--- a/bofire/data_models/features/molecular.py
+++ b/bofire/data_models/features/molecular.py
@@ -6,8 +6,8 @@ import pandas as pd
 from pydantic import field_validator
 
 from bofire.data_models.enum import CategoricalEncodingEnum
-from bofire.data_models.features.categorical import _CAT_SEP, CategoricalInput
-from bofire.data_models.features.feature import Input
+from bofire.data_models.features.categorical import CategoricalInput
+from bofire.data_models.features.feature import Input, get_encoded_name
 from bofire.data_models.molfeatures.api import (
     AnyMolFeatures,
     Fingerprints,
@@ -98,7 +98,7 @@ class MolecularInput(Input):
         descriptor_values = transform_type.get_descriptor_values(values)
 
         descriptor_values.columns = [
-            f"{self.key}{_CAT_SEP}{d}" for d in transform_type.get_descriptor_names()
+            get_encoded_name(self.key, d) for d in transform_type.get_descriptor_names()
         ]
         descriptor_values.index = values.index
 
@@ -191,7 +191,7 @@ class CategoricalMolecularInput(CategoricalInput, MolecularInput):
         # This method is modified based on the categorical descriptor feature
         # TODO: move it to more central place
         cat_cols = [
-            f"{self.key}{_CAT_SEP}{d}" for d in transform_type.get_descriptor_names()
+            get_encoded_name(self.key, d) for d in transform_type.get_descriptor_names()
         ]
         # we allow here explicitly that the dataframe can have more columns than needed to have it
         # easier in the backtransform.


### PR DESCRIPTION
Make column names of categorical features and descriptors after encoding to, e.g., one-hot accessible from the outside and re-use the same code at all places inside BoFire.