### PR TITLE
Infinite Width BNN Kernel and Surrogate

### DIFF
--- a/bofire/data_models/kernels/api.py
+++ b/bofire/data_models/kernels/api.py
@@ -11,6 +11,7 @@ from bofire.data_models.kernels.categorical import (
 )
 from bofire.data_models.kernels.continuous import (
     ContinuousKernel,
+    InfiniteWidthBNNKernel,
     LinearKernel,
     MaternKernel,
     PolynomialKernel,
@@ -22,10 +23,7 @@ from bofire.data_models.kernels.molecular import MolecularKernel, TanimotoKernel
 AbstractKernel = Union[Kernel, CategoricalKernel, ContinuousKernel, MolecularKernel]
 
 AnyContinuousKernel = Union[
-    MaternKernel,
-    LinearKernel,
-    PolynomialKernel,
-    RBFKernel,
+    MaternKernel, LinearKernel, PolynomialKernel, RBFKernel, InfiniteWidthBNNKernel
 ]
 
 AnyCategoricalKernel = HammingDistanceKernel
@@ -42,4 +40,5 @@ AnyKernel = Union[
     MaternKernel,
     RBFKernel,
     TanimotoKernel,
+    InfiniteWidthBNNKernel,
 ]

--- a/bofire/data_models/kernels/continuous.py
+++ b/bofire/data_models/kernels/continuous.py
@@ -1,6 +1,6 @@
 from typing import Literal, Optional
 
-from pydantic import field_validator
+from pydantic import PositiveInt, field_validator
 
 from bofire.data_models.kernels.kernel import Kernel
 from bofire.data_models.priors.api import AnyGeneralPrior, AnyPrior
@@ -38,3 +38,8 @@ class PolynomialKernel(ContinuousKernel):
     type: Literal["PolynomialKernel"] = "PolynomialKernel"
     offset_prior: Optional[AnyGeneralPrior] = None
     power: int = 2
+
+
+class InfiniteWidthBNNKernel(Kernel):
+    type: Literal["InfiniteWidthBNNKernel"] = "InfiniteWidthBNNKernel"
+    depth: PositiveInt = 3

--- a/bofire/data_models/surrogates/api.py
+++ b/bofire/data_models/surrogates/api.py
@@ -1,5 +1,6 @@
 from typing import Union
 
+from bofire.data_models.surrogates.bnn import SingleTaskIBNNSurrogate
 from bofire.data_models.surrogates.botorch import BotorchSurrogate
 from bofire.data_models.surrogates.botorch_surrogates import (
     AnyBotorchSurrogate,
@@ -53,6 +54,7 @@ AnySurrogate = Union[
     TanimotoGPSurrogate,
     LinearDeterministicSurrogate,
     MultiTaskGPSurrogate,
+    SingleTaskIBNNSurrogate,
 ]
 
 AnyTrainableSurrogate = Union[
@@ -66,6 +68,7 @@ AnyTrainableSurrogate = Union[
     XGBoostSurrogate,
     LinearSurrogate,
     PolynomialSurrogate,
+    SingleTaskIBNNSurrogate,
     TanimotoGPSurrogate,
 ]
 
@@ -83,6 +86,7 @@ AnyRegressionSurrogate = Union[
     TanimotoGPSurrogate,
     LinearDeterministicSurrogate,
     MultiTaskGPSurrogate,
+    SingleTaskIBNNSurrogate,
 ]
 
 AnyClassificationSurrogate = ClassificationMLPEnsemble

--- a/bofire/kernels/mapper.py
+++ b/bofire/kernels/mapper.py
@@ -1,7 +1,13 @@
+import warnings
 from typing import List
 
 import gpytorch
 import torch
+
+try:
+    from botorch.models.kernels import InfiniteWidthBNNKernel
+except ImportError:
+    warnings.warn("Please update to botorch development version to use this feature.")
 from botorch.models.kernels.categorical import CategoricalKernel
 from gpytorch.kernels import Kernel as GpytorchKernel
 
@@ -44,6 +50,19 @@ def map_MaternKernel(
             if data_model.lengthscale_prior is not None
             else None
         ),
+    )
+
+
+def map_InfiniteWidthBNNKernel(
+    data_model: data_models.InfiniteWidthBNNKernel,
+    batch_shape: torch.Size,
+    ard_num_dims: int,
+    active_dims: List[int],
+) -> "InfiniteWidthBNNKernel":
+    return InfiniteWidthBNNKernel(
+        batch_shape=batch_shape,
+        active_dims=tuple(active_dims),
+        depth=data_model.depth,
     )
 
 
@@ -177,6 +196,7 @@ KERNEL_MAP = {
     data_models.ScaleKernel: map_ScaleKernel,
     data_models.TanimotoKernel: map_TanimotoKernel,
     data_models.HammingDistanceKernel: map_HammingDistanceKernel,
+    data_models.InfiniteWidthBNNKernel: map_InfiniteWidthBNNKernel,
 }
 
 

--- a/bofire/surrogates/mapper.py
+++ b/bofire/surrogates/mapper.py
@@ -28,6 +28,7 @@ SURROGATE_MAP: Dict[Type[data_models.Surrogate], Type[Surrogate]] = {
     data_models.TanimotoGPSurrogate: SingleTaskGPSurrogate,
     data_models.LinearDeterministicSurrogate: LinearDeterministicSurrogate,
     data_models.MultiTaskGPSurrogate: MultiTaskGPSurrogate,
+    data_models.SingleTaskIBNNSurrogate: SingleTaskGPSurrogate,
 }
 
 

--- a/tests/bofire/data_models/specs/kernels.py
+++ b/tests/bofire/data_models/specs/kernels.py
@@ -33,6 +33,12 @@ specs.add_invalid(
     error=ValueError,
     message="nu expected to be 0.5, 1.5, or 2.5",
 )
+specs.add_valid(
+    kernels.InfiniteWidthBNNKernel,
+    lambda: {
+        "depth": 3,
+    },
+)
 
 specs.add_valid(
     kernels.RBFKernel,

--- a/tests/bofire/data_models/specs/surrogates.py
+++ b/tests/bofire/data_models/specs/surrogates.py
@@ -73,6 +73,23 @@ specs.add_valid(
 )
 
 specs.add_valid(
+    models.SingleTaskIBNNSurrogate,
+    lambda: {
+        "inputs": Inputs(
+            features=[
+                ContinuousInput(key="a", bounds=(0, 1)),
+                ContinuousInput(key="b", bounds=(0, 1)),
+            ]
+        ).model_dump(),
+        "outputs": Outputs(
+            features=[
+                features.valid(ContinuousOutput).obj(),
+            ]
+        ).model_dump(),
+    },
+)
+
+specs.add_valid(
     models.MixedSingleTaskGPSurrogate,
     lambda: {
         "inputs": Inputs(

--- a/tests/bofire/kernels/test_mapper.py
+++ b/tests/bofire/kernels/test_mapper.py
@@ -9,6 +9,7 @@ import bofire.kernels.api as kernels
 from bofire.data_models.kernels.api import (
     AdditiveKernel,
     HammingDistanceKernel,
+    InfiniteWidthBNNKernel,
     LinearKernel,
     MaternKernel,
     MultiplicativeKernel,
@@ -19,6 +20,14 @@ from bofire.data_models.kernels.api import (
 )
 from bofire.data_models.priors.api import BOTORCH_SCALE_PRIOR, GammaPrior
 from tests.bofire.data_models.specs.api import Spec
+
+try:
+    from botorch.models.kernels import InfiniteWidthBNNKernel as BNNKernel
+except ImportError:
+    BNN_AVAILABLE = False
+else:
+    BNN_AVAILABLE = True
+
 
 EQUIVALENTS = {
     RBFKernel: gpytorch.kernels.RBFKernel,
@@ -34,10 +43,19 @@ EQUIVALENTS = {
 
 def test_map(kernel_spec: Spec):
     kernel = kernel_spec.cls(**kernel_spec.typed_spec())
+    if isinstance(kernel, InfiniteWidthBNNKernel):
+        return
     gkernel = kernels.map(
         kernel, batch_shape=torch.Size(), ard_num_dims=10, active_dims=list(range(5))
     )
     assert isinstance(gkernel, EQUIVALENTS[kernel.__class__])
+
+
+@pytest.mark.skipif(BNN_AVAILABLE, reason="requires cyipopt")
+def test_map_infinite_width_bnn_kernel():
+    kernel = InfiniteWidthBNNKernel(depth=3)
+    gkernel = kernels.map(kernel, batch_shape=torch.Size(), active_dims=list(range(5)))
+    assert isinstance(gkernel, BNNKernel)
 
 
 def test_map_scale_kernel():


### PR DESCRIPTION
This PR adds the infinite width bayesian neural network kernel/surrogate from this recent paper from Andrew Gordon Wilson: https://arxiv.org/abs/2305.20028 which was recently added to `botorch`. Currently it is only in botorch devel, for this reason, I need to implement some workarounds for the testing.