### PR TITLE
FIx warning in Iterative Trimming Module

### DIFF
--- a/bofire/outlier_detection/outlier_detection.py
+++ b/bofire/outlier_detection/outlier_detection.py
@@ -76,8 +76,9 @@ class IterativeTrimming(OutlierDetection):
                 break  # converged
             ix_old = ix_sub
 
-            self.surrogate.fit(experiments[experiments.index.isin(indices[ix_sub])])  # type: ignore
-
+            self.surrogate.fit(  # type: ignore
+                experiments[experiments.index.isin(indices[ix_sub])].copy()
+            )
             # make prediction
             pred = self.surrogate.predict(experiments)
             d_sq = (


### PR DESCRIPTION
This PR fixes a warning in the iterative trimming outlier detection module which is due to pandas setting values on a copy of a dataframe.