### PR TITLE
Compatibility fix for latest scipy

### DIFF
--- a/bofire/surrogates/diagnostics.py
+++ b/bofire/surrogates/diagnostics.py
@@ -4,7 +4,13 @@ from typing import Dict, List, Optional, Sequence, Tuple, Union
 import numpy as np
 import pandas as pd
 from pydantic import Field, field_validator, model_validator, validator
-from scipy.integrate import simps
+
+# this try except accounts for the renaming from simps to simpson in scipy 1.14.0
+try:
+    from scipy.integrate import simps as simpson
+except ImportError:
+    from scipy.integrate import simpson
+
 from scipy.stats import fisher_exact, kendalltau, norm, pearsonr, spearmanr
 from sklearn.metrics import (
     accuracy_score,
@@ -419,7 +425,7 @@ def _MiscalibrationArea(
             standard_deviation=standard_deviation,
             num_bins=num_bins,
         )
-        res = simps(Cqs - qs, qs)  # type: ignore
+        res = simpson(Cqs - qs, qs)  # type: ignore
 
         return float(res)
     except ValueError:
@@ -455,7 +461,7 @@ def _AbsoluteMiscalibrationArea(
             standard_deviation=standard_deviation,
             num_bins=num_bins,
         )
-        res = simps(np.abs(Cqs - qs), qs)  # type: ignore
+        res = simpson(np.abs(Cqs - qs), qs)  # type: ignore
 
         return float(res)
     except ValueError:

--- a/bofire/surrogates/diagnostics.py
+++ b/bofire/surrogates/diagnostics.py
@@ -425,7 +425,7 @@ def _MiscalibrationArea(
             standard_deviation=standard_deviation,
             num_bins=num_bins,
         )
-        res = simpson(Cqs - qs, qs)  # type: ignore
+        res = simpson(Cqs - qs, x=qs)  # type: ignore
 
         return float(res)
     except ValueError:
@@ -461,7 +461,7 @@ def _AbsoluteMiscalibrationArea(
             standard_deviation=standard_deviation,
             num_bins=num_bins,
         )
-        res = simpson(np.abs(Cqs - qs), qs)  # type: ignore
+        res = simpson(np.abs(Cqs - qs), x=qs)  # type: ignore
 
         return float(res)
     except ValueError:


### PR DESCRIPTION
This PR fixes a renaming issue in the latest scipy release. `scipy.integrate.simps` was renamed to `scipy.integrate.simpson`.

cc: @bertiqwerty @TobyBoyne 