### PR TITLE
Add arXiv reference to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,20 @@ print(mobo_strategy.experiments)
 
 Documentation including a section on how to get started can be found under https://experimental-design.github.io/bofire/.
 
+## Reference
+
+We would love for you to use BoFire in your work! If you do, please cite [our paper](https://arxiv.org/abs/2408.05040):
+
+    @misc{durholt2024bofire,
+      title={BoFire: Bayesian Optimization Framework Intended for Real Experiments}, 
+      author={Johannes P. D{\"{u}}rholt and Thomas S. Asche and Johanna Kleinekorte and Gabriel Mancino-Ball and Benjamin Schiller and Simon Sung and Julian Keupp and Aaron Osburg and Toby Boyne and Ruth Misener and Rosona Eldred and Wagner Steuer Costa and Chrysoula Kappatou and Robert M. Lee and Dominik Linzner and David Walz and Niklas Wulkow and Behrang Shafei},
+      year={2024},
+      eprint={2408.05040},
+      archivePrefix={arXiv},
+      primaryClass={cs.LG},
+      url={https://arxiv.org/abs/2408.05040}, 
+    }
+
 ## Contributing
 
 See our [Contributing](./CONTRIBUTING.md) guidelines. If you are not sure about something or find bugs, feel free to create an issue.

--- a/docs/index.md
+++ b/docs/index.md
@@ -77,3 +77,17 @@ By default IPOPT uses the freely available linear solver MUMPS. For large models
 ```
 find_local_max_ipopt(domain, "fully-quadratic", ipopt_options={"linear_solver":"ma57", "hsllib":"libcoinhsl.so"})
 ```
+
+## Reference
+
+We would love for you to use BoFire in your work! If you do, please cite [our paper](https://arxiv.org/abs/2408.05040):
+
+    @misc{durholt2024bofire,
+      title={BoFire: Bayesian Optimization Framework Intended for Real Experiments}, 
+      author={Johannes P. D{\"{u}}rholt and Thomas S. Asche and Johanna Kleinekorte and Gabriel Mancino-Ball and Benjamin Schiller and Simon Sung and Julian Keupp and Aaron Osburg and Toby Boyne and Ruth Misener and Rosona Eldred and Wagner Steuer Costa and Chrysoula Kappatou and Robert M. Lee and Dominik Linzner and David Walz and Niklas Wulkow and Behrang Shafei},
+      year={2024},
+      eprint={2408.05040},
+      archivePrefix={arXiv},
+      primaryClass={cs.LG},
+      url={https://arxiv.org/abs/2408.05040}, 
+    }


### PR DESCRIPTION
The BoFire paper has been published on arXiv (https://arxiv.org/abs/2408.05040). This pull request adds the bibtex reference to the README.

