### PR TITLE
Use weights_only for load

### DIFF
--- a/bofire/surrogates/botorch.py
+++ b/bofire/surrogates/botorch.py
@@ -64,4 +64,4 @@ class BotorchSurrogate(Surrogate):
     def loads(self, data: str):
         """Loads the actual model from a base64 encoded pickle bytes object and writes it to the `model` attribute."""
         buffer = io.BytesIO(base64.b64decode(data.encode()))
-        self.model = torch.load(buffer, weights_only=True)
+        self.model = torch.load(buffer, weights_only=False)

--- a/bofire/surrogates/botorch.py
+++ b/bofire/surrogates/botorch.py
@@ -64,4 +64,4 @@ class BotorchSurrogate(Surrogate):
     def loads(self, data: str):
         """Loads the actual model from a base64 encoded pickle bytes object and writes it to the `model` attribute."""
         buffer = io.BytesIO(base64.b64decode(data.encode()))
-        self.model = torch.load(buffer)
+        self.model = torch.load(buffer, weights_only=True)

--- a/bofire/surrogates/random_forest.py
+++ b/bofire/surrogates/random_forest.py
@@ -168,4 +168,4 @@ class RandomForestSurrogate(BotorchSurrogate, TrainableSurrogate):
     def loads(self, data: str):
         """Loads the actual random forest from a base64 encoded pickle bytes object and writes it to the `model` attribute."""
         buffer = io.BytesIO(base64.b64decode(data.encode()))
-        self.model = torch.load(buffer, weights_only=True)
+        self.model = torch.load(buffer, weights_only=False)

--- a/bofire/surrogates/random_forest.py
+++ b/bofire/surrogates/random_forest.py
@@ -168,4 +168,4 @@ class RandomForestSurrogate(BotorchSurrogate, TrainableSurrogate):
     def loads(self, data: str):
         """Loads the actual random forest from a base64 encoded pickle bytes object and writes it to the `model` attribute."""
         buffer = io.BytesIO(base64.b64decode(data.encode()))
-        self.model = torch.load(buffer)
+        self.model = torch.load(buffer, weights_only=True)


### PR DESCRIPTION
`torch.load` without `weights_only` parameter is unsafe. Explicitly set `weights_only` to False only if you trust the data you load and full pickle functionality is needed, otherwise set `weights_only=True`.

If `weights_only=True` doesn't work for some cases, then explicit `weights_only=False` should be used.

Found with https://github.com/pytorch-labs/torchfix/