### PR TITLE
Move variance of fixed features check to predictive strategy

### DIFF
--- a/bofire/strategies/predictives/predictive.py
+++ b/bofire/strategies/predictives/predictive.py
@@ -5,6 +5,7 @@ import numpy as np
 import pandas as pd
 from pydantic import PositiveInt
 
+from bofire.data_models.features.task import TaskInput
 from bofire.data_models.strategies.api import Strategy as DataModel
 from bofire.data_models.types import InputTransformSpecs
 from bofire.strategies.data_models.candidate import Candidate
@@ -89,8 +90,18 @@ class PredictiveStrategy(Strategy):
                 experiments=experiments
             )
         )
-        for feature in self.domain.inputs.get_fixed():
-            if (cleaned_experiments[feature.key] == feature.fixed_value()[0]).all():  # type: ignore
+
+        fixed_nontasks = (
+            feat
+            for feat in self.domain.inputs.get_fixed()
+            if not isinstance(feat, TaskInput)
+        )
+        for feature in fixed_nontasks:
+            fixed_value = feature.fixed_value()
+            assert fixed_value is not None
+            if (
+                cleaned_experiments[feature.key] == fixed_value[0]
+            ).all() and isinstance(feature, TaskInput):
                 raise ValueError(
                     f"No variance in experiments for fixed feature {feature.key}"
                 )

--- a/bofire/strategies/predictives/predictive.py
+++ b/bofire/strategies/predictives/predictive.py
@@ -99,9 +99,7 @@ class PredictiveStrategy(Strategy):
         for feature in fixed_nontasks:
             fixed_value = feature.fixed_value()
             assert fixed_value is not None
-            if (
-                cleaned_experiments[feature.key] == fixed_value[0]
-            ).all() and isinstance(feature, TaskInput):
+            if (cleaned_experiments[feature.key] == fixed_value[0]).all():
                 raise ValueError(
                     f"No variance in experiments for fixed feature {feature.key}"
                 )

--- a/bofire/strategies/predictives/predictive.py
+++ b/bofire/strategies/predictives/predictive.py
@@ -83,6 +83,17 @@ class PredictiveStrategy(Strategy):
             self.set_experiments(experiments)
         else:
             self.add_experiments(experiments)
+        # we check here that the experiments do not have completely fixed columns
+        cleaned_experiments = (
+            self.domain.outputs.preprocess_experiments_all_valid_outputs(
+                experiments=experiments
+            )
+        )
+        for feature in self.domain.inputs.get_fixed():
+            if (cleaned_experiments[feature.key] == feature.fixed_value()[0]).all():  # type: ignore
+                raise ValueError(
+                    f"No variance in experiments for fixed feature {feature.key}"
+                )
         if retrain and self.has_sufficient_experiments():
             self.fit()
             # we have a seperate _tell here for things that are relevant when setting up the strategy but unrelated

--- a/bofire/strategies/strategy.py
+++ b/bofire/strategies/strategy.py
@@ -75,17 +75,6 @@ class Strategy(ABC):
             self.set_experiments(experiments=experiments)
         else:
             self.add_experiments(experiments=experiments)
-        # we check here that the experiments do not have completely fixed columns
-        cleaned_experiments = (
-            self.domain.outputs.preprocess_experiments_all_valid_outputs(
-                experiments=experiments
-            )
-        )
-        for feature in self.domain.inputs.get_fixed():
-            if (cleaned_experiments[feature.key] == feature.fixed_value()[0]).all():  # type: ignore
-                raise ValueError(
-                    f"No variance in experiments for fixed feature {feature.key}"
-                )
         self._tell()
 
     def _tell(self) -> None:

--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,6 @@ setup(
         "xgb": ["xgboost>=1.7.5"],
         "cheminfo": ["rdkit>=2023.3.2", sklearn_dependency, "mordred"],
         "tests": [
-            "mock",
             "mopti",
             "pyright==1.1.305",
             "pytest",

--- a/tests/bofire/strategies/dummy.py
+++ b/tests/bofire/strategies/dummy.py
@@ -3,6 +3,7 @@ from typing import Dict, List, Literal, Optional, Tuple, Type
 
 import numpy as np
 import pandas as pd
+from botorch.acquisition.acquisition import AcquisitionFunction
 from pydantic.types import NonNegativeInt
 
 import bofire.data_models.strategies.api as data_models
@@ -86,10 +87,10 @@ class DummyStrategy(Strategy):
         return len(self.experiments) >= 3
 
 
-class DummyPredictiveStrategyDataModel(data_models.Strategy):
-    type: Literal[
+class DummyPredictiveStrategyDataModel(data_models.PredictiveStrategy):
+    type: Literal["DummyPredictiveStrategyDataModel"] = (
         "DummyPredictiveStrategyDataModel"
-    ] = "DummyPredictiveStrategyDataModel"
+    )
 
     @classmethod
     def is_constraint_implemented(cls, my_type: Type[Constraint]) -> bool:
@@ -194,8 +195,8 @@ class DummyBotorchPredictiveStrategy(BotorchStrategy):
             f"{inspect.stack()[0][3]} not implemented for {self.__class__.__name__}"
         )
 
-    def _get_acqfs(self, n: int):
-        pass
+    def _get_acqfs(self, n: int) -> List[AcquisitionFunction]:
+        return []
 
     def _choose_from_pool(
         self,

--- a/tests/bofire/strategies/dummy.py
+++ b/tests/bofire/strategies/dummy.py
@@ -88,9 +88,9 @@ class DummyStrategy(Strategy):
 
 
 class DummyPredictiveStrategyDataModel(data_models.PredictiveStrategy):
-    type: Literal["DummyPredictiveStrategyDataModel"] = (
+    type: Literal[
         "DummyPredictiveStrategyDataModel"
-    )
+    ] = "DummyPredictiveStrategyDataModel"
 
     @classmethod
     def is_constraint_implemented(cls, my_type: Type[Constraint]) -> bool:

--- a/tests/bofire/strategies/test_multitask.py
+++ b/tests/bofire/strategies/test_multitask.py
@@ -89,8 +89,8 @@ def test_sobo_with_multitask(task_input):
     )
 
 
-def test_random_multitask():
-    def test(strat_data_model):
+def test_nosurrogate_multitask():
+    def test(strat_data_model, **kwargs):
         task_input = TaskInput(
             key="task", categories=["task_1", "task_2"], allowed=[False, True]
         )
@@ -104,7 +104,7 @@ def test_random_multitask():
             }
         )
         domain = _domain(task_input)
-        dm = strat_data_model(domain=domain)
+        dm = strat_data_model(domain=domain, **kwargs)
 
         strat = strategies.map(dm)
         strat.tell(experiments)
@@ -125,4 +125,5 @@ def test_random_multitask():
         assert len(candidate) == 1
 
     test(RandomStrategy)
-    test(DoEStrategy)
+    # test(DoEStrategy, formula="linear")
+

--- a/tests/bofire/strategies/test_multitask.py
+++ b/tests/bofire/strategies/test_multitask.py
@@ -8,7 +8,6 @@ from bofire.data_models.domain.api import Domain, Inputs, Outputs
 from bofire.data_models.features.api import ContinuousInput, ContinuousOutput, TaskInput
 from bofire.data_models.objectives.api import MaximizeObjective
 from bofire.data_models.strategies.api import (
-    DoEStrategy,
     RandomStrategy,
     SoboStrategy,
 )

--- a/tests/bofire/strategies/test_multitask.py
+++ b/tests/bofire/strategies/test_multitask.py
@@ -126,4 +126,3 @@ def test_nosurrogate_multitask():
 
     test(RandomStrategy)
     # test(DoEStrategy, formula="linear")
-

--- a/tests/bofire/strategies/test_multitask.py
+++ b/tests/bofire/strategies/test_multitask.py
@@ -7,42 +7,26 @@ from bofire.data_models.acquisition_functions.api import qLogEI
 from bofire.data_models.domain.api import Domain, Inputs, Outputs
 from bofire.data_models.features.api import ContinuousInput, ContinuousOutput, TaskInput
 from bofire.data_models.objectives.api import MaximizeObjective
-from bofire.data_models.strategies.api import SoboStrategy
+from bofire.data_models.strategies.api import (
+    DoEStrategy,
+    RandomStrategy,
+    SoboStrategy,
+)
 from bofire.data_models.surrogates.api import (
     BotorchSurrogates,
     MultiTaskGPSurrogate,
 )
 
 
-@pytest.mark.parametrize(
-    "task_input",
-    [
-        (TaskInput(key="task", categories=["task_1", "task_2"], allowed=[False, True])),
-        (TaskInput(key="task", categories=["task_1", "task_2"], allowed=[True, False])),
-    ],
-)
-def test_sobo_with_multitask(task_input):
-    # set the data
-    def task_1_f(x):
-        return np.sin(x * 2 * np.pi)
+def _task_1_f(x):
+    return np.sin(x * 2 * np.pi)
 
-    def task_2_f(x):
-        return 0.9 * np.sin(x * 2 * np.pi) - 0.2 + 0.2 * np.cos(x * 3 * np.pi)
 
-    task_1_x = np.linspace(0.6, 1, 4)
-    task_1_y = task_1_f(task_1_x)
+def _task_2_f(x):
+    return 0.9 * np.sin(x * 2 * np.pi) - 0.2 + 0.2 * np.cos(x * 3 * np.pi)
 
-    task_2_x = np.linspace(0, 1, 15)
-    task_2_y = task_2_f(task_2_x)
 
-    experiments = pd.DataFrame(
-        {
-            "x": np.concatenate([task_1_x, task_2_x]),
-            "y": np.concatenate([task_1_y, task_2_y]),
-            "task": ["task_1"] * len(task_1_x) + ["task_2"] * len(task_2_x),
-        }
-    )
-
+def _domain(task_input):
     input_features = [
         ContinuousInput(key="x", bounds=(0, 1)),
         task_input,
@@ -54,16 +38,42 @@ def test_sobo_with_multitask(task_input):
 
     output_features = [ContinuousOutput(key="y", objective=objective)]
     outputs = Outputs(features=output_features)
+    return Domain(inputs=inputs, outputs=outputs)
 
-    surrogate_data = [MultiTaskGPSurrogate(inputs=inputs, outputs=outputs)]
+
+@pytest.mark.parametrize(
+    "task_input",
+    [
+        (TaskInput(key="task", categories=["task_1", "task_2"], allowed=[False, True])),
+        (TaskInput(key="task", categories=["task_1", "task_2"], allowed=[True, False])),
+    ],
+)
+def test_sobo_with_multitask(task_input):
+    # set the data
+
+    task_1_x = np.linspace(0.6, 1, 4)
+    task_1_y = _task_1_f(task_1_x)
+
+    task_2_x = np.linspace(0, 1, 15)
+    task_2_y = _task_2_f(task_2_x)
+
+    experiments = pd.DataFrame(
+        {
+            "x": np.concatenate([task_1_x, task_2_x]),
+            "y": np.concatenate([task_1_y, task_2_y]),
+            "task": ["task_1"] * len(task_1_x) + ["task_2"] * len(task_2_x),
+        }
+    )
+
+    domain = _domain(task_input)
+    surrogate_data = [
+        MultiTaskGPSurrogate(inputs=domain.inputs, outputs=domain.outputs)
+    ]
 
     surrogate_specs = BotorchSurrogates(surrogates=surrogate_data)
 
     strategy_data_model = SoboStrategy(
-        domain=Domain(
-            inputs=inputs,
-            outputs=outputs,
-        ),
+        domain=domain,
         surrogate_specs=surrogate_specs,
         acquisition_function=qLogEI(),
     )
@@ -77,3 +87,42 @@ def test_sobo_with_multitask(task_input):
         candidate["task"].item()
         == task_input.categories[task_input.allowed.index(True)]
     )
+
+
+def test_random_multitask():
+    def test(strat_data_model):
+        task_input = TaskInput(
+            key="task", categories=["task_1", "task_2"], allowed=[False, True]
+        )
+        task_1_x = np.linspace(0.6, 1, 4)
+        task_1_y = _task_1_f(task_1_x)
+        experiments = pd.DataFrame(
+            {
+                "x": task_1_x,
+                "y": task_1_y,
+                "task": ["task_1"] * len(task_1_x),
+            }
+        )
+        domain = _domain(task_input)
+        dm = strat_data_model(domain=domain)
+
+        strat = strategies.map(dm)
+        strat.tell(experiments)
+        candidate = strat.ask(1)
+        assert len(candidate) == 1
+
+        task_2_x = np.linspace(0, 1, 15)
+        task_2_y = _task_2_f(task_2_x)
+        experiments = pd.DataFrame(
+            {
+                "x": np.concatenate([task_1_x, task_2_x]),
+                "y": np.concatenate([task_1_y, task_2_y]),
+                "task": ["task_1"] * len(task_1_x) + ["task_2"] * len(task_2_x),
+            }
+        )
+        strat.tell(experiments)
+        candidate = strat.ask(1)
+        assert len(candidate) == 1
+
+    test(RandomStrategy)
+    test(DoEStrategy)

--- a/tests/bofire/strategies/test_strategy.py
+++ b/tests/bofire/strategies/test_strategy.py
@@ -247,7 +247,9 @@ def test_strategy_no_variance():
         data_model=dummy.DummyStrategyDataModel(domain=domain)
     )
     strategy.tell(experiments)
-    strategy = dummy.DummyPredictiveStrategy(data_model=dummy.DummyPredictiveStrategyDataModel(domain=domain))
+    strategy = dummy.DummyPredictiveStrategy(
+        data_model=dummy.DummyPredictiveStrategyDataModel(domain=domain)
+    )
     with pytest.raises(ValueError):
         strategy.tell(experiments)
     # introduce variance but in an invalid experiment

--- a/tests/bofire/strategies/test_strategy.py
+++ b/tests/bofire/strategies/test_strategy.py
@@ -1,6 +1,6 @@
 from typing import List
+from unittest import mock
 
-import mock
 import numpy as np
 import pandas as pd
 import pytest
@@ -246,6 +246,8 @@ def test_strategy_no_variance():
     strategy = dummy.DummyStrategy(
         data_model=dummy.DummyStrategyDataModel(domain=domain)
     )
+    strategy.tell(experiments)
+    strategy = dummy.DummyPredictiveStrategy(data_model=dummy.DummyPredictiveStrategyDataModel(domain=domain))
     with pytest.raises(ValueError):
         strategy.tell(experiments)
     # introduce variance but in an invalid experiment


### PR DESCRIPTION
I think it is okay to check for variance in fixed features only in predictive strategies. This helps to add data from only one task to the random strategy (or any strategy without surrogate) in case you have a multi-task domain. This might be useful in case you have a stepwise strategy with a random step to get initial random data from one of the tasks where you might not have historical data of.