### PR TITLE
Moving Output Objective

### DIFF
--- a/bofire/data_models/domain/features.py
+++ b/bofire/data_models/domain/features.py
@@ -739,7 +739,10 @@ class Outputs(_BaseFeatures[AnyOutput]):
         """
         desis = pd.concat(
             [
-                feat(experiments[f"{feat.key}_pred" if predictions else feat.key])  # type: ignore
+                feat(
+                    experiments[f"{feat.key}_pred" if predictions else feat.key],
+                    experiments[f"{feat.key}_pred" if predictions else feat.key],
+                )  # type: ignore
                 for feat in self.features
                 if feat.objective is not None
                 and not isinstance(feat, CategoricalOutput)
@@ -747,7 +750,10 @@ class Outputs(_BaseFeatures[AnyOutput]):
             + [
                 (
                     pd.Series(
-                        data=feat(experiments.filter(regex=f"{feat.key}(.*)_prob")),
+                        data=feat(
+                            experiments.filter(regex=f"{feat.key}(.*)_prob"),  # type: ignore
+                            experiments.filter(regex=f"{feat.key}(.*)_prob"),  # type: ignore
+                        ),
                         name=f"{feat.key}_pred",
                     )  # type: ignore
                     if predictions

--- a/bofire/data_models/features/categorical.py
+++ b/bofire/data_models/features/categorical.py
@@ -356,14 +356,14 @@ class CategoricalOutput(Output):
             raise ValueError("categories must match to objective categories")
         return self
 
-    def __call__(self, values: pd.Series) -> pd.Series:
+    def __call__(self, values: pd.Series, values_adapt: pd.Series) -> pd.Series:
         if self.objective is None:
             return pd.Series(
                 data=[np.nan for _ in range(len(values))],
                 index=values.index,
                 name=values.name,
             )
-        return self.objective(values)  # type: ignore
+        return self.objective(values, values_adapt)  # type: ignore
 
     def validate_experimental(self, values: pd.Series) -> pd.Series:
         values = values.map(str)

--- a/bofire/data_models/features/continuous.py
+++ b/bofire/data_models/features/continuous.py
@@ -178,14 +178,14 @@ class ContinuousOutput(Output):
         default_factory=lambda: MaximizeObjective(w=1.0)
     )
 
-    def __call__(self, values: pd.Series) -> pd.Series:
+    def __call__(self, values: pd.Series, values_adapt: pd.Series) -> pd.Series:
         if self.objective is None:
             return pd.Series(
                 data=[np.nan for _ in range(len(values))],
                 index=values.index,
                 name=values.name,
             )
-        return self.objective(values)  # type: ignore
+        return self.objective(values, values_adapt)  # type: ignore
 
     def validate_experimental(self, values: pd.Series) -> pd.Series:
         try:

--- a/bofire/data_models/objectives/api.py
+++ b/bofire/data_models/objectives/api.py
@@ -1,8 +1,6 @@
 from typing import Union
 
-from bofire.data_models.objectives.categorical import (
-    ConstrainedCategoricalObjective,
-)
+from bofire.data_models.objectives.categorical import ConstrainedCategoricalObjective
 from bofire.data_models.objectives.identity import (
     IdentityObjective,
     MaximizeObjective,
@@ -12,6 +10,7 @@ from bofire.data_models.objectives.objective import Objective
 from bofire.data_models.objectives.sigmoid import (
     MaximizeSigmoidObjective,
     MinimizeSigmoidObjective,
+    MovingMaximizeSigmoidObjective,
     SigmoidObjective,
 )
 from bofire.data_models.objectives.target import (
@@ -31,6 +30,7 @@ AnyCategoricalObjective = ConstrainedCategoricalObjective
 
 AnyConstraintObjective = Union[
     MaximizeSigmoidObjective,
+    MovingMaximizeSigmoidObjective,
     MinimizeSigmoidObjective,
     TargetObjective,
 ]
@@ -45,4 +45,5 @@ AnyObjective = Union[
     TargetObjective,
     CloseToTargetObjective,
     ConstrainedCategoricalObjective,
+    MovingMaximizeSigmoidObjective,
 ]

--- a/bofire/data_models/objectives/categorical.py
+++ b/bofire/data_models/objectives/categorical.py
@@ -1,4 +1,4 @@
-from typing import Dict, List, Literal, Union
+from typing import Dict, List, Literal, Optional, Union
 
 import numpy as np
 import pandas as pd
@@ -61,12 +61,16 @@ class ConstrainedCategoricalObjective(ConstrainedObjective, Objective):
         return dict(zip(d.values(), d.keys()))
 
     def __call__(
-        self, x: Union[pd.Series, np.ndarray]
+        self,
+        x: Union[pd.Series, np.ndarray],
+        x_adapt: Optional[Union[pd.Series, np.ndarray]] = None,
     ) -> Union[pd.Series, np.ndarray, float]:
         """The call function returning a probabilistic reward for x.
 
         Args:
             x (np.ndarray): A matrix of x values
+            x_adapt (Optional[np.ndarray], optional): An array of x values which are used to
+                update the objective parameters on the fly. Defaults to None.
 
         Returns:
             np.ndarray: A reward calculated as inner product of probabilities and feasible objectives.

--- a/bofire/data_models/objectives/identity.py
+++ b/bofire/data_models/objectives/identity.py
@@ -1,4 +1,4 @@
-from typing import Literal, Tuple, Union
+from typing import Literal, Optional, Tuple, Union
 
 import numpy as np
 import pandas as pd
@@ -48,11 +48,17 @@ class IdentityObjective(Objective):
             )
         return bounds
 
-    def __call__(self, x: Union[pd.Series, np.ndarray]) -> Union[pd.Series, np.ndarray]:
+    def __call__(
+        self,
+        x: Union[pd.Series, np.ndarray],
+        x_adapt: Optional[Union[pd.Series, np.ndarray]] = None,
+    ) -> Union[pd.Series, np.ndarray]:
         """The call function returning a reward for passed x values
 
         Args:
             x (np.ndarray): An array of x values
+            x_adapt (Optional[np.ndarray], optional): An array of x values which are used to
+                update the objective parameters on the fly. Defaults to None.
 
         Returns:
             np.ndarray: The identity as reward, might be normalized to the passed lower and upper bounds
@@ -81,11 +87,17 @@ class MinimizeObjective(IdentityObjective):
 
     type: Literal["MinimizeObjective"] = "MinimizeObjective"
 
-    def __call__(self, x: Union[pd.Series, np.ndarray]) -> Union[pd.Series, np.ndarray]:
+    def __call__(
+        self,
+        x: Union[pd.Series, np.ndarray],
+        x_adapt: Optional[Union[pd.Series, np.ndarray]] = None,
+    ) -> Union[pd.Series, np.ndarray]:
         """The call function returning a reward for passed x values
 
         Args:
             x (np.ndarray): An array of x values
+            x_adapt (Optional[np.ndarray], optional): An array of x values which are used to
+                update the objective parameters on the fly. Defaults to None.
 
         Returns:
             np.ndarray: The negative identity as reward, might be normalized to the passed lower and upper bounds

--- a/bofire/data_models/objectives/objective.py
+++ b/bofire/data_models/objectives/objective.py
@@ -1,5 +1,5 @@
 from abc import abstractmethod
-from typing import Union
+from typing import Optional, Union
 
 import numpy as np
 import pandas as pd
@@ -15,11 +15,17 @@ class Objective(BaseModel):
     type: str
 
     @abstractmethod
-    def __call__(self, x: Union[pd.Series, np.ndarray]) -> Union[pd.Series, np.ndarray]:
+    def __call__(
+        self,
+        x: Union[pd.Series, np.ndarray],
+        x_adapt: Optional[Union[pd.Series, np.ndarray]] = None,
+    ) -> Union[pd.Series, np.ndarray]:
         """Abstract method to define the call function for the class Objective
 
         Args:
-            x (np.ndarray): An array of x values
+            x (np.ndarray): An array of x values for which the objective should be evaluated.
+            x_adapt (Optional[np.ndarray], optional): An array of x values which are used to
+                update the objective parameters on the fly. Defaults to None.
 
         Returns:
             np.ndarray: The desirability of the passed x values

--- a/bofire/data_models/objectives/sigmoid.py
+++ b/bofire/data_models/objectives/sigmoid.py
@@ -55,6 +55,15 @@ class MaximizeSigmoidObjective(SigmoidObjective):
 
 
 class MovingMaximizeSigmoidObjective(SigmoidObjective):
+    """Class for a maximizing sigmoid objective with a moving turning point that depends on so far observed x values.
+
+    Attributes:
+        w (float): float between zero and one for weighting the objective when used in a weighting based strategy.
+        steepness (float): Steepness of the sigmoid function. Has to be greater than zero.
+        tp (float): Relative turning point of the sigmoid function. The actual turning point is calculated by adding
+            the maximum of the observed x values to the relative turning point.
+    """
+
     type: Literal["MovingMaximizeSigmoidObjective"] = "MovingMaximizeSigmoidObjective"
 
     def get_adjusted_tp(self, x: Union[pd.Series, np.ndarray]) -> float:

--- a/bofire/data_models/objectives/sigmoid.py
+++ b/bofire/data_models/objectives/sigmoid.py
@@ -1,4 +1,4 @@
-from typing import Literal, Union
+from typing import Literal, Optional, Union
 
 import numpy as np
 import pandas as pd
@@ -37,16 +37,52 @@ class MaximizeSigmoidObjective(SigmoidObjective):
 
     type: Literal["MaximizeSigmoidObjective"] = "MaximizeSigmoidObjective"
 
-    def __call__(self, x: Union[pd.Series, np.ndarray]) -> Union[pd.Series, np.ndarray]:
+    def __call__(
+        self,
+        x: Union[pd.Series, np.ndarray],
+        x_adapt: Optional[Union[pd.Series, np.ndarray]] = None,
+    ) -> Union[pd.Series, np.ndarray]:
         """The call function returning a sigmoid shaped reward for passed x values.
 
         Args:
             x (np.ndarray): An array of x values
+            x_adapt (np.ndarray): An array of x values which are used to update the objective parameters on the fly.
 
         Returns:
             np.ndarray: A reward calculated with a sigmoid function. The stepness and the tipping point can be modified via passed arguments.
         """
         return 1 / (1 + np.exp(-1 * self.steepness * (x - self.tp)))
+
+
+class MovingMaximizeSigmoidObjective(SigmoidObjective):
+    type: Literal["MovingMaximizeSigmoidObjective"] = "MovingMaximizeSigmoidObjective"
+
+    def get_adjusted_tp(self, x: Union[pd.Series, np.ndarray]) -> float:
+        """Get the adjusted turning point for the sigmoid function.
+
+        Args:
+            x (np.ndarray): An array of x values
+
+        Returns:
+            float: The adjusted turning point for the sigmoid function.
+        """
+        return x.max() + self.tp
+
+    def __call__(
+        self, x: Union[pd.Series, np.ndarray], x_adapt: Union[pd.Series, np.ndarray]
+    ) -> Union[pd.Series, np.ndarray]:
+        """The call function returning a sigmoid shaped reward for passed x values.
+
+        Args:
+            x (np.ndarray): An array of x values
+            x_adapt (np.ndarray): An array of x values which are used to update the objective parameters on the fly.
+
+        Returns:
+            np.ndarray: A reward calculated with a sigmoid function. The stepness and the tipping point can be modified via passed arguments.
+        """
+        return 1 / (
+            1 + np.exp(-1 * self.steepness * (x - self.get_adjusted_tp(x_adapt)))
+        )
 
 
 class MinimizeSigmoidObjective(SigmoidObjective):
@@ -60,11 +96,16 @@ class MinimizeSigmoidObjective(SigmoidObjective):
 
     type: Literal["MinimizeSigmoidObjective"] = "MinimizeSigmoidObjective"
 
-    def __call__(self, x: Union[pd.Series, np.ndarray]) -> Union[pd.Series, np.ndarray]:
+    def __call__(
+        self,
+        x: Union[pd.Series, np.ndarray],
+        x_adapt: Optional[Union[pd.Series, np.ndarray]] = None,
+    ) -> Union[pd.Series, np.ndarray]:
         """The call function returning a sigmoid shaped reward for passed x values.
 
         Args:
             x (np.ndarray): An array of x values
+            x_adapt (np.ndarray): An array of x values which are used to update the objective parameters on the fly.
 
         Returns:
             np.ndarray: A reward calculated with a sigmoid function. The stepness and the tipping point can be modified via passed arguments.

--- a/bofire/data_models/objectives/target.py
+++ b/bofire/data_models/objectives/target.py
@@ -1,4 +1,4 @@
-from typing import Literal, Union
+from typing import Literal, Optional, Union
 
 import numpy as np
 import pandas as pd
@@ -27,7 +27,11 @@ class CloseToTargetObjective(Objective):
     target_value: float
     exponent: float
 
-    def __call__(self, x: Union[pd.Series, np.ndarray]) -> Union[pd.Series, np.ndarray]:
+    def __call__(
+        self,
+        x: Union[pd.Series, np.ndarray],
+        x_adapt: Optional[Union[pd.Series, np.ndarray]] = None,
+    ) -> Union[pd.Series, np.ndarray]:
         return -1 * (np.abs(x - self.target_value) ** self.exponent)
 
 
@@ -48,11 +52,17 @@ class TargetObjective(Objective, ConstrainedObjective):
     tolerance: TGe0
     steepness: TGt0
 
-    def __call__(self, x: Union[pd.Series, np.ndarray]) -> Union[pd.Series, np.ndarray]:
+    def __call__(
+        self,
+        x: Union[pd.Series, np.ndarray],
+        x_adapt: Optional[Union[pd.Series, np.ndarray]] = None,
+    ) -> Union[pd.Series, np.ndarray]:
         """The call function returning a reward for passed x values.
 
         Args:
             x (np.array): An array of x values
+            x_adapt (Optional[np.ndarray], optional): An array of x values which are used to
+                update the objective parameters on the fly. Defaults to None.
 
         Returns:
             np.array: An array of reward values calculated by the product of two sigmoidal shaped functions resulting in a maximum at the target value.

--- a/bofire/plot/objective.py
+++ b/bofire/plot/objective.py
@@ -13,6 +13,7 @@ def plot_objective_plotly(
     lower: float,
     upper: float,
     values: Optional[pd.Series] = None,
+    adapt_values: Optional[pd.Series] = None,
     layout_options: Optional[Dict] = None,
 ):
     """Plot the assigned objective.
@@ -22,6 +23,8 @@ def plot_objective_plotly(
         lower (float): lower bound for the plot
         upper (float): upper bound for the plot
         values (Optional[pd.Series], optional): If provided, scatter also the historical data in the plot. Defaults to None.
+        adapt_values (Optional[pd.Series], optional): If provided, adapt the objective function to the passed values.
+            Defaults to None.
         layout_options: (Dict, optional): Options that are passed to plotlys `update_layout`.
     """
     if feature.objective is None:
@@ -30,14 +33,14 @@ def plot_objective_plotly(
         )
 
     x = pd.Series(np.linspace(lower, upper, 5000))
-    reward = feature.objective.__call__(x)
+    reward = feature.objective.__call__(x, x_adapt=adapt_values)  # type: ignore
 
     fig1 = px.line(x=x, y=reward, title=feature.key)
 
     if values is not None:
         fig2 = px.scatter(
             x=values,
-            y=feature.objective.__call__(values),
+            y=feature.objective.__call__(values, x_adapt=adapt_values),  # type: ignore
         )
         fig = go.Figure(data=fig1.data + fig2.data)  # type: ignore
     else:

--- a/bofire/strategies/predictives/qehvi.py
+++ b/bofire/strategies/predictives/qehvi.py
@@ -35,6 +35,7 @@ class QehviStrategy(BotorchStrategy):
     objective: Optional[MCMultiOutputObjective] = None
 
     def _get_acqfs(self, n) -> List[qExpectedHypervolumeImprovement]:
+        assert self.experiments is not None, "No experiments available."
         df = self.domain.outputs.preprocess_experiments_all_valid_outputs(
             self.experiments
         )
@@ -76,10 +77,14 @@ class QehviStrategy(BotorchStrategy):
         return [acqf]
 
     def _get_objective(self) -> GenericMCMultiOutputObjective:
-        objective = get_multiobjective_objective(outputs=self.domain.outputs)
+        assert self.experiments is not None, "No experiments available."
+        objective = get_multiobjective_objective(
+            outputs=self.domain.outputs, experiments=self.experiments
+        )
         return GenericMCMultiOutputObjective(objective=objective)
 
     def get_adjusted_refpoint(self) -> List[float]:
+        assert self.experiments is not None, "No experiments available."
         if self.ref_point is None:
             df = self.domain.outputs.preprocess_experiments_all_valid_outputs(
                 self.experiments

--- a/bofire/strategies/predictives/qnehvi.py
+++ b/bofire/strategies/predictives/qnehvi.py
@@ -21,10 +21,13 @@ class QnehviStrategy(QehviStrategy):
         self.alpha = data_model.alpha
 
     def _get_acqfs(self, n) -> List[qNoisyExpectedHypervolumeImprovement]:
+        assert self.experiments is not None, "No experiments available."
         X_train, X_pending = self.get_acqf_input_tensors()
 
         # get etas and constraints
-        constraints, etas = get_output_constraints(self.domain.outputs)
+        constraints, etas = get_output_constraints(
+            self.domain.outputs, experiments=self.experiments
+        )
         if len(constraints) == 0:
             constraints, etas = None, 1e-3
         else:

--- a/bofire/strategies/predictives/qparego.py
+++ b/bofire/strategies/predictives/qparego.py
@@ -51,6 +51,7 @@ class QparegoStrategy(BotorchStrategy):
             Union[ConstrainedObjective, None]: the botorch constraints.
             Union[List, float]: etas used in the botorch constraints.
         """
+        assert self.experiments is not None, "No experiments available."
         ref_point_mask = torch.from_numpy(get_ref_point_mask(domain=self.domain)).to(
             **tkwargs
         )
@@ -70,7 +71,9 @@ class QparegoStrategy(BotorchStrategy):
             * ref_point_mask
         )
 
-        obj_callable = get_multiobjective_objective(outputs=self.domain.outputs)
+        obj_callable = get_multiobjective_objective(
+            outputs=self.domain.outputs, experiments=self.experiments
+        )
 
         df_preds = self.predict(
             self.domain.outputs.preprocess_experiments_any_valid_output(
@@ -90,7 +93,9 @@ class QparegoStrategy(BotorchStrategy):
             return scalarization(obj_callable(Z, None) * ref_point_mask, X)
 
         if len(weights) != len(self.domain.outputs.get_by_objective(Objective)):
-            constraint_callables, etas = get_output_constraints(self.domain.outputs)
+            constraint_callables, etas = get_output_constraints(
+                self.domain.outputs, experiments=self.experiments
+            )
         else:
             constraint_callables, etas = None, 1e-3
 

--- a/bofire/utils/multiobjective.py
+++ b/bofire/utils/multiobjective.py
@@ -85,7 +85,9 @@ def compute_hypervolume(
     outputs = domain.outputs.get_by_objective(
         includes=[MaximizeObjective, MinimizeObjective, CloseToTargetObjective]
     )
-    objective = get_multiobjective_objective(outputs=outputs)
+    objective = get_multiobjective_objective(
+        outputs=outputs, experiments=optimal_experiments
+    )  # type: ignore
     ref_point_mask = torch.from_numpy(get_ref_point_mask(domain)).to(**tkwargs)
     hv = Hypervolume(
         ref_point=torch.tensor(
@@ -127,7 +129,7 @@ def infer_ref_point(
         includes=[MaximizeObjective, MinimizeObjective, CloseToTargetObjective]
     )
     keys = [f.key for f in outputs]
-    objective = get_multiobjective_objective(outputs=outputs)
+    objective = get_multiobjective_objective(outputs=outputs, experiments=experiments)  # type: ignore
 
     df = domain.outputs.preprocess_experiments_all_valid_outputs(
         experiments, output_feature_keys=keys

--- a/bofire/utils/multiobjective.py
+++ b/bofire/utils/multiobjective.py
@@ -68,7 +68,7 @@ def get_pareto_front(
     df = domain.outputs.preprocess_experiments_all_valid_outputs(
         experiments, output_feature_keys
     )
-    objective = get_multiobjective_objective(outputs=outputs)  # type: ignore
+    objective = get_multiobjective_objective(outputs=outputs, experiments=experiments)  # type: ignore
     pareto_mask = np.array(
         is_non_dominated(
             objective(

--- a/bofire/utils/torch_tools.py
+++ b/bofire/utils/torch_tools.py
@@ -238,6 +238,10 @@ def constrained_objective2botorch(
     Args:
         idx (int): Index of the constraint objective in the list of outputs.
         objective (BotorchConstrainedObjective): The objective that should be transformed.
+        x_adapt (Optional[Tensor]): The tensor that should be used to adapt the objective,
+            for example in case of a moving turning point in the `MovingMaximizeSigmoidObjective`.
+        eps (float, optional): Small value to avoid numerical instabilities in case of the `ConstrainedCategoricalObjective`.
+            Defaults to 1e-8.
 
     Returns:
         Tuple[List[Callable[[Tensor], Tensor]], List[float], int]: List of callables that can be used by botorch for setting up the constrained objective,
@@ -312,6 +316,9 @@ def get_output_constraints(
     Args:
         outputs (Outputs): Output feature object that should
             be processed.
+        experiments (pd.DataFrame): DataFrame containing the experiments that are used for
+            adapting the objectives on the fly, for example in the case of the
+            `MovingMaximizeSigmoidObjective`.
 
     Returns:
         Tuple[List[Callable[[Tensor], Tensor]], List[float]]: List of constraint callables,
@@ -537,10 +544,13 @@ def get_additive_botorch_objective(
 def get_multiobjective_objective(
     outputs: Outputs, experiments: pd.DataFrame
 ) -> Callable[[Tensor, Optional[Tensor]], Tensor]:
-    """Returns
+    """Returns a callable that can be used by botorch for multiobjective optimization.
 
     Args:
-        outputs (Outputs): _description_
+        outputs (Outputs): Outputs object for which the callable should be generated.
+        experiments (pd.DataFrame): DataFrame containing the experiments that are used for
+            adapting the objectives on the fly, for example in the case of the
+            `MovingMaximizeSigmoidObjective`.
 
     Returns:
         Callable[[Tensor], Tensor]: _description_

--- a/tests/bofire/data_models/features/test_categorical.py
+++ b/tests/bofire/data_models/features/test_categorical.py
@@ -473,5 +473,5 @@ def test_categorical_output_call():
             categories=["c1", "c2"], desirability=[True, False]
         ),
     )
-    output = categorical_output(test_df)
+    output = categorical_output(test_df, test_df)
     assert output.tolist() == test_df["c1"].tolist()

--- a/tests/bofire/data_models/specs/objectives.py
+++ b/tests/bofire/data_models/specs/objectives.py
@@ -28,6 +28,10 @@ specs.add_valid(
     lambda: {"w": 1.0, "bounds": (0.1, 0.9)},
 )
 
+specs.add_valid(
+    objectives.MovingMaximizeSigmoidObjective,
+    lambda: {"w": 1.0, "tp": 0.3, "steepness": 0.2},
+)
 
 specs.add_valid(
     objectives.MinimizeSigmoidObjective,


### PR DESCRIPTION
This PR adds the possibility of smart objectives that change during the optimization campaign. So far only the `MovingMaximizeSigmoidObjective` is implemented (out of an actual need). It changes its turning point based on the best so far achieved value. 