### PR TITLE
Fix linting in pipeline

### DIFF
--- a/bofire/data_models/surrogates/shape.py
+++ b/bofire/data_models/surrogates/shape.py
@@ -31,9 +31,9 @@ from bofire.data_models.types import Bounds, validate_monotonically_increasing
 
 
 class PiecewiseLinearGPSurrogateHyperconfig(Hyperconfig):
-    type: Literal[
+    type: Literal["PiecewiseLinearGPSurrogateHyperconfig"] = (
         "PiecewiseLinearGPSurrogateHyperconfig"
-    ] = "PiecewiseLinearGPSurrogateHyperconfig"
+    )
     inputs: Inputs = Inputs(
         features=[
             CategoricalInput(
@@ -44,9 +44,9 @@ class PiecewiseLinearGPSurrogateHyperconfig(Hyperconfig):
         ]
     )
     target_metric: RegressionMetricsEnum = RegressionMetricsEnum.MAE
-    hyperstrategy: Literal[
-        "FactorialStrategy", "SoboStrategy", "RandomStrategy"
-    ] = "FactorialStrategy"
+    hyperstrategy: Literal["FactorialStrategy", "SoboStrategy", "RandomStrategy"] = (
+        "FactorialStrategy"
+    )
 
     @staticmethod
     def _update_hyperparameters(

--- a/bofire/utils/torch_tools.py
+++ b/bofire/utils/torch_tools.py
@@ -4,6 +4,7 @@ from typing import Callable, Dict, List, Optional, Tuple, Type, Union
 import numpy as np
 import pandas as pd
 import torch
+import torch.jit
 from botorch.models.transforms.input import InputTransform
 from torch import Tensor
 from torch.nn import Module


### PR DESCRIPTION
Looks like `ruff format` is complaining about `bofire/data_models/surrogates/shape.py`.