### PR TITLE
Fix enum serialization problems

### DIFF
--- a/bofire/data_models/enum.py
+++ b/bofire/data_models/enum.py
@@ -1,13 +1,13 @@
 from enum import Enum
 
 
-class SamplingMethodEnum(Enum):
+class SamplingMethodEnum(str, Enum):
     UNIFORM = "UNIFORM"
     SOBOL = "SOBOL"
     LHS = "LHS"
 
 
-class CategoricalMethodEnum(Enum):
+class CategoricalMethodEnum(str, Enum):
     """Enumeration class of supported methods how to handle categorical features
     Currently, exhaustive search and free relaxation are implemented.
     """
@@ -17,7 +17,7 @@ class CategoricalMethodEnum(Enum):
     # PR = "PR" available soon
 
 
-class CategoricalEncodingEnum(Enum):
+class CategoricalEncodingEnum(str, Enum):
     """Enumeration class of implemented categorical encodings
     Currently, one-hot and ordinal encoding are implemented.
     """
@@ -28,19 +28,19 @@ class CategoricalEncodingEnum(Enum):
     DESCRIPTOR = "DESCRIPTOR"  # only possible for categorical with descriptors
 
 
-class ClassificationMetricsEnum(Enum):
+class ClassificationMetricsEnum(str, Enum):
     """Enumeration class for classification metrics."""
 
     ACCURACY = "ACCURACY"
     F1 = "F1"
 
 
-class OutputFilteringEnum(Enum):
+class OutputFilteringEnum(str, Enum):
     ALL = "ALL"
     ANY = "ANY"
 
 
-class RegressionMetricsEnum(Enum):
+class RegressionMetricsEnum(str, Enum):
     """Enumeration class for regression metrics."""
 
     R2 = "R2"
@@ -52,7 +52,7 @@ class RegressionMetricsEnum(Enum):
     FISHER = "FISHER"
 
 
-class UQRegressionMetricsEnum(Enum):
+class UQRegressionMetricsEnum(str, Enum):
     """Enumeration class for ucertainty regression metrics."""
 
     PEARSON_UQ = "PEARSON_UQ"

--- a/bofire/data_models/surrogates/scaler.py
+++ b/bofire/data_models/surrogates/scaler.py
@@ -1,7 +1,7 @@
 from enum import Enum
 
 
-class ScalerEnum(Enum):
+class ScalerEnum(str, Enum):
     """Enumeration class of supported scalers
     Currently, normalization and standardization are implemented.
     """

--- a/bofire/strategies/enum.py
+++ b/bofire/strategies/enum.py
@@ -1,7 +1,7 @@
 from enum import Enum
 
 
-class OptimalityCriterionEnum(Enum):
+class OptimalityCriterionEnum(str, Enum):
     D_OPTIMALITY = "D_OPTIMALITY"
     E_OPTIMALITY = "E_OPTIMALITY"
     A_OPTIMALITY = "A_OPTIMALITY"


### PR DESCRIPTION
As outlined here https://stackoverflow.com/questions/69541613/how-to-json-serialize-enum-classes-in-pydantic-basemodel, the `json` module has problems with serializing plain enums, so far we had to use always pydantics `model_dump_json`. This can lead to problems and confusion. 

Setting up enums which also inherit from `str` solves this issue. In py3.11 is a new datatype available which does exactly this called `StrEnum` (https://docs.python.org/3/library/enum.html#enum.StrEnum). But due to backwards compatibility, I implemented the solution to explicitly inherit from `str`.