### PR TITLE
Suppress import warning prints

### DIFF
--- a/bofire/strategies/predictives/enting.py
+++ b/bofire/strategies/predictives/enting.py
@@ -12,7 +12,8 @@ try:
     from entmoot.optimizers.pyomo_opt import PyomoOptimizer
     from entmoot.problem_config import ProblemConfig
 except ImportError:
-    warnings.warn("entmoot not installed, BoFire's `EntingStrategy` cannot be used.")
+    warnings.warn("entmoot not installed. Please install it to use "
+                  "BoFire's `EntingStrategy`.", ImportWarning)
 
 from typing import Union
 
@@ -36,7 +37,7 @@ from bofire.data_models.objectives.api import MaximizeObjective, MinimizeObjecti
 from bofire.strategies.predictives.predictive import PredictiveStrategy
 
 
-def domain_to_problem_config(
+def _domain_to_problem_config(
     domain: Domain,
     seed: Optional[int] = None,
 ) -> Tuple["ProblemConfig", "pyo.ConcreteModel"]:
@@ -243,7 +244,7 @@ class EntingStrategy(PredictiveStrategy):
         self._kappa_fantasy = data_model.kappa_fantasy
 
     def _init_problem_config(self) -> None:
-        cfg = domain_to_problem_config(self.domain, self.seed)
+        cfg = _domain_to_problem_config(self.domain, self.seed)
         self._problem_config: ProblemConfig = cfg[0]  # type: ignore
         self._model_pyo: pyo.ConcreteModel = cfg[1]  # type: ignore
 

--- a/bofire/strategies/predictives/enting.py
+++ b/bofire/strategies/predictives/enting.py
@@ -12,8 +12,10 @@ try:
     from entmoot.optimizers.pyomo_opt import PyomoOptimizer
     from entmoot.problem_config import ProblemConfig
 except ImportError:
-    warnings.warn("entmoot not installed. Please install it to use "
-                  "BoFire's `EntingStrategy`.", ImportWarning)
+    warnings.warn(
+        "entmoot not installed. Please install it to use " "BoFire's `EntingStrategy`.",
+        ImportWarning,
+    )
 
 from typing import Union
 

--- a/bofire/strategies/predictives/enting.py
+++ b/bofire/strategies/predictives/enting.py
@@ -37,7 +37,7 @@ from bofire.data_models.objectives.api import MaximizeObjective, MinimizeObjecti
 from bofire.strategies.predictives.predictive import PredictiveStrategy
 
 
-def _domain_to_problem_config(
+def domain_to_problem_config(
     domain: Domain,
     seed: Optional[int] = None,
 ) -> Tuple["ProblemConfig", "pyo.ConcreteModel"]:
@@ -244,7 +244,7 @@ class EntingStrategy(PredictiveStrategy):
         self._kappa_fantasy = data_model.kappa_fantasy
 
     def _init_problem_config(self) -> None:
-        cfg = _domain_to_problem_config(self.domain, self.seed)
+        cfg = domain_to_problem_config(self.domain, self.seed)
         self._problem_config: ProblemConfig = cfg[0]  # type: ignore
         self._model_pyo: pyo.ConcreteModel = cfg[1]  # type: ignore
 

--- a/bofire/surrogates/xgb.py
+++ b/bofire/surrogates/xgb.py
@@ -10,8 +10,11 @@ from bofire.utils.tmpfile import make_tmpfile
 try:
     from xgboost import XGBRegressor
 except ImportError:
-    warnings.warn("xgboost not installed. Please install it to use "
-                  "BoFire's `XGBoostSurrogate`.", ImportWarning)
+    warnings.warn(
+        "xgboost not installed. Please install it to use "
+        "BoFire's `XGBoostSurrogate`.",
+        ImportWarning,
+    )
 
 import uuid
 

--- a/bofire/surrogates/xgb.py
+++ b/bofire/surrogates/xgb.py
@@ -10,7 +10,8 @@ from bofire.utils.tmpfile import make_tmpfile
 try:
     from xgboost import XGBRegressor
 except ImportError:
-    warnings.warn("xgboost not installed, BoFire's `XGBoostSurrogate` cannot be used.")
+    warnings.warn("xgboost not installed. Please install it to use "
+                  "BoFire's `XGBoostSurrogate`.", ImportWarning)
 
 import uuid
 

--- a/bofire/utils/cheminformatics.py
+++ b/bofire/utils/cheminformatics.py
@@ -16,7 +16,7 @@ try:
 except ImportError:
     warnings.warn(
         "rdkit not installed, BoFire's cheminformatics utilities cannot be used.",
-        ImportWarning
+        ImportWarning,
     )
 
 try:
@@ -24,7 +24,7 @@ try:
 except ImportError:
     warnings.warn(
         "mordred not installed. Mordred molecular descriptors cannot be used.",
-        ImportWarning
+        ImportWarning,
     )
 
 # This code is based on GAUCHE: https://github.com/leojklarner/gauche/blob/main/gauche/data_featuriser/featurisation.py

--- a/bofire/utils/cheminformatics.py
+++ b/bofire/utils/cheminformatics.py
@@ -16,6 +16,7 @@ try:
 except ImportError:
     warnings.warn(
         "rdkit not installed, BoFire's cheminformatics utilities cannot be used.",
+        ImportWarning
     )
 
 try:
@@ -23,6 +24,7 @@ try:
 except ImportError:
     warnings.warn(
         "mordred not installed. Mordred molecular descriptors cannot be used.",
+        ImportWarning
     )
 
 # This code is based on GAUCHE: https://github.com/leojklarner/gauche/blob/main/gauche/data_featuriser/featurisation.py

--- a/tests/bofire/strategies/test_enting.py
+++ b/tests/bofire/strategies/test_enting.py
@@ -9,8 +9,10 @@ try:
     import gurobipy
     from entmoot.problem_config import FeatureType, ProblemConfig
 except ImportError:
-    warnings.warn("entmoot not installed, BoFire's `EntingStrategy` cannot be used.",
-                  ImportWarning)
+    warnings.warn(
+        "entmoot not installed, BoFire's `EntingStrategy` cannot be used.",
+        ImportWarning,
+    )
 
 
 import bofire.data_models.strategies.api as data_models

--- a/tests/bofire/strategies/test_enting.py
+++ b/tests/bofire/strategies/test_enting.py
@@ -9,7 +9,8 @@ try:
     import gurobipy
     from entmoot.problem_config import FeatureType, ProblemConfig
 except ImportError:
-    warnings.warn("entmoot not installed, BoFire's `EntingStrategy` cannot be used.")
+    warnings.warn("entmoot not installed, BoFire's `EntingStrategy` cannot be used.",
+                  ImportWarning)
 
 
 import bofire.data_models.strategies.api as data_models


### PR DESCRIPTION
Suppress import warnings related to the packages rdkit, modred, xgboost, and entmoot after installing BoFire via

`pip install bofire[optimization]`