### PR TITLE
[QOL] cancel tests on same PR

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -7,6 +7,11 @@ on:
     branches:
       - main
 
+concurrency:
+  # Cancel only on same PR number
+  group: ${{ github.workflow }}-pr-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 jobs:
   testing_data_models:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Often I end up pushing then spotting an issue that's quick to fix. In the instance that pushes are made in quick succession this will reduce the CI bill (free? but still worth saving energy)