### PR TITLE
Add categoricals for `FractionalFactorialStrategy`

### DIFF
--- a/bofire/data_models/strategies/factorial.py
+++ b/bofire/data_models/strategies/factorial.py
@@ -1,4 +1,7 @@
+import warnings
 from typing import Literal, Type
+
+from pydantic import model_validator
 
 from bofire.data_models.constraints.api import Constraint
 from bofire.data_models.features.api import (
@@ -12,6 +15,11 @@ from bofire.data_models.strategies.strategy import Strategy
 
 
 class FactorialStrategy(Strategy):
+    """Factorial design strategy.
+
+    This strategy is deprecated, please use FractionalFactorialStrategy instead.
+    """
+
     type: Literal["FactorialStrategy"] = "FactorialStrategy"
 
     @classmethod
@@ -26,3 +34,11 @@ class FactorialStrategy(Strategy):
             CategoricalDescriptorInput,
             ContinuousOutput,
         ]
+
+    @model_validator(mode="after")
+    def raise_depreaction_warning(self):
+        warnings.warn(
+            "`FactorialStrategy is deprecated, use `FractionalFactorialStrategy` instead.",
+            DeprecationWarning,
+        )
+        return self

--- a/bofire/data_models/strategies/fractional_factorial.py
+++ b/bofire/data_models/strategies/fractional_factorial.py
@@ -3,16 +3,45 @@ from typing import Annotated, Literal, Type
 from pydantic import Field, model_validator
 
 from bofire.data_models.constraints.api import Constraint
-from bofire.data_models.features.api import ContinuousInput, ContinuousOutput, Feature
+from bofire.data_models.features.api import (
+    CategoricalDescriptorInput,
+    CategoricalInput,
+    CategoricalMolecularInput,
+    ContinuousInput,
+    ContinuousOutput,
+    DiscreteInput,
+    Feature,
+)
 from bofire.data_models.strategies.strategy import Strategy
 from bofire.utils.doe import get_generator, validate_generator
 
 
 class FractionalFactorialStrategy(Strategy):
+    """Fractional factorial design strategy.
+
+    This strategy generates a fractional factorial two level design for the continuous
+    part of the domain, which is then combined with the categorical part of the domain.
+    For every categorical combination, the continuous part of the design is repeated.
+    """
+
     type: Literal["FractionalFactorialStrategy"] = "FractionalFactorialStrategy"
-    n_repetitions: Annotated[int, Field(description="Number of repetitions", ge=0)] = 1
-    n_center: Annotated[int, Field(description="Number of center points", ge=0)] = 1
-    generator: Annotated[str, Field(description="Generator for the design.")] = ""
+    n_repetitions: Annotated[
+        int,
+        Field(
+            description="Number of repetitions of the continuous part of the design",
+            ge=0,
+        ),
+    ] = 1
+    n_center: Annotated[
+        int,
+        Field(
+            description="Number of center points in the continuous part of the design",
+            ge=0,
+        ),
+    ] = 1
+    generator: Annotated[
+        str, Field(description="Generator for the continuous part of the design.")
+    ] = ""
     n_generators: Annotated[
         int,
         Field(description="Number of reducing factors", ge=0),
@@ -24,7 +53,14 @@ class FractionalFactorialStrategy(Strategy):
 
     @classmethod
     def is_feature_implemented(cls, my_type: Type[Feature]) -> bool:
-        return my_type in [ContinuousOutput, ContinuousInput]
+        return my_type in [
+            ContinuousOutput,
+            ContinuousInput,
+            CategoricalInput,
+            DiscreteInput,
+            CategoricalDescriptorInput,
+            CategoricalMolecularInput,
+        ]
 
     @model_validator(mode="after")
     def validate(self):

--- a/bofire/data_models/surrogates/mixed_single_task_gp.py
+++ b/bofire/data_models/surrogates/mixed_single_task_gp.py
@@ -26,8 +26,6 @@ from bofire.data_models.priors.api import (
     THREESIX_SCALE_PRIOR,
     AnyPrior,
 )
-
-# from bofire.data_models.strategies.api import FactorialStrategy
 from bofire.data_models.surrogates.trainable import Hyperconfig
 from bofire.data_models.surrogates.trainable_botorch import TrainableBotorchSurrogate
 
@@ -45,9 +43,9 @@ class MixedSingleTaskGPHyperconfig(Hyperconfig):
         ],
     )
     target_metric: RegressionMetricsEnum = RegressionMetricsEnum.MAE
-    hyperstrategy: Literal["FactorialStrategy", "SoboStrategy", "RandomStrategy"] = (
-        "FactorialStrategy"
-    )
+    hyperstrategy: Literal[
+        "FractionalFactorialStrategy", "SoboStrategy", "RandomStrategy"
+    ] = "FractionalFactorialStrategy"
 
     @staticmethod
     def _update_hyperparameters(

--- a/bofire/data_models/surrogates/multi_task_gp.py
+++ b/bofire/data_models/surrogates/multi_task_gp.py
@@ -20,8 +20,6 @@ from bofire.data_models.priors.api import (
     AnyPrior,
 )
 from bofire.data_models.priors.lkj import LKJPrior
-
-# from bofire.data_models.strategies.api import FactorialStrategy
 from bofire.data_models.surrogates.trainable import Hyperconfig
 from bofire.data_models.surrogates.trainable_botorch import TrainableBotorchSurrogate
 
@@ -39,9 +37,9 @@ class MultiTaskGPHyperconfig(Hyperconfig):
         ],
     )
     target_metric: RegressionMetricsEnum = RegressionMetricsEnum.MAE
-    hyperstrategy: Literal["FactorialStrategy", "SoboStrategy", "RandomStrategy"] = (
-        "FactorialStrategy"
-    )
+    hyperstrategy: Literal[
+        "FractionalFactorialStrategy", "SoboStrategy", "RandomStrategy"
+    ] = "FractionalFactorialStrategy"
 
     @staticmethod
     def _update_hyperparameters(

--- a/bofire/data_models/surrogates/polynomial.py
+++ b/bofire/data_models/surrogates/polynomial.py
@@ -6,8 +6,6 @@ from bofire.data_models.domain.api import Inputs, Outputs
 from bofire.data_models.features.api import AnyOutput, ContinuousOutput
 from bofire.data_models.kernels.api import PolynomialKernel
 from bofire.data_models.priors.api import THREESIX_NOISE_PRIOR, AnyPrior
-
-# from bofire.data_models.strategies.api import FactorialStrategy
 from bofire.data_models.surrogates.trainable_botorch import TrainableBotorchSurrogate
 
 

--- a/bofire/data_models/surrogates/shape.py
+++ b/bofire/data_models/surrogates/shape.py
@@ -5,8 +5,6 @@ from pydantic import AfterValidator, Field, PositiveInt, model_validator
 
 from bofire.data_models.domain.api import Inputs
 from bofire.data_models.enum import RegressionMetricsEnum
-
-# from bofire.data_models.strategies.api import FactorialStrategy
 from bofire.data_models.features.api import (
     AnyOutput,
     CategoricalInput,
@@ -23,8 +21,6 @@ from bofire.data_models.priors.api import (
     AnyPrior,
     LogNormalPrior,
 )
-
-# from bofire.data_models.strategies.api import FactorialStrategy
 from bofire.data_models.surrogates.trainable import Hyperconfig
 from bofire.data_models.surrogates.trainable_botorch import TrainableBotorchSurrogate
 from bofire.data_models.types import Bounds, validate_monotonically_increasing
@@ -45,9 +41,9 @@ class PiecewiseLinearGPSurrogateHyperconfig(Hyperconfig):
         ],
     )
     target_metric: RegressionMetricsEnum = RegressionMetricsEnum.MAE
-    hyperstrategy: Literal["FactorialStrategy", "SoboStrategy", "RandomStrategy"] = (
-        "FactorialStrategy"
-    )
+    hyperstrategy: Literal[
+        "FractionalFactorialStrategy", "SoboStrategy", "RandomStrategy"
+    ] = "FractionalFactorialStrategy"
 
     @staticmethod
     def _update_hyperparameters(

--- a/bofire/data_models/surrogates/single_task_gp.py
+++ b/bofire/data_models/surrogates/single_task_gp.py
@@ -5,8 +5,6 @@ from pydantic import Field
 
 from bofire.data_models.domain.api import Inputs
 from bofire.data_models.enum import RegressionMetricsEnum
-
-# from bofire.data_models.strategies.api import FactorialStrategy
 from bofire.data_models.features.api import (
     AnyOutput,
     CategoricalInput,
@@ -47,9 +45,9 @@ class SingleTaskGPHyperconfig(Hyperconfig):
         ],
     )
     target_metric: RegressionMetricsEnum = RegressionMetricsEnum.MAE
-    hyperstrategy: Literal["FactorialStrategy", "SoboStrategy", "RandomStrategy"] = (
-        "FactorialStrategy"
-    )
+    hyperstrategy: Literal[
+        "FractionalFactorialStrategy", "SoboStrategy", "RandomStrategy"
+    ] = "FractionalFactorialStrategy"
 
     @staticmethod
     def _update_hyperparameters(

--- a/bofire/data_models/surrogates/trainable.py
+++ b/bofire/data_models/surrogates/trainable.py
@@ -63,7 +63,7 @@ class Hyperconfig(BaseModel):
             return len(values.data["inputs"]) + 10
         if values.data["hyperstrategy"] == "FractionalFactorialStrategy":
             raise ValueError(
-                "It is not allowed to scpecify the number of its for FractionalFactorialStrategy",
+                "It is not allowed to specify the number of its for FractionalFactorialStrategy",
             )
         if v < len(values.data["inputs"]) + 2:
             raise ValueError(

--- a/bofire/data_models/surrogates/trainable.py
+++ b/bofire/data_models/surrogates/trainable.py
@@ -47,7 +47,9 @@ AnyAggregation = Union[SumAggregation, MeanAggregation]
 
 class Hyperconfig(BaseModel):
     type: str
-    hyperstrategy: Literal["RandomStrategy", "FactorialStrategy", "SoboStrategy"]
+    hyperstrategy: Literal[
+        "RandomStrategy", "FractionalFactorialStrategy", "SoboStrategy"
+    ]
     inputs: Inputs
     n_iterations: Optional[Annotated[int, Field(ge=1)]] = None
     target_metric: RegressionMetricsEnum = RegressionMetricsEnum.MAE
@@ -56,12 +58,12 @@ class Hyperconfig(BaseModel):
     @classmethod
     def validate_n_iterations(cls, v, values):
         if v is None:
-            if values.data["hyperstrategy"] == "FactorialStrategy":
+            if values.data["hyperstrategy"] == "FractionalFactorialStrategy":
                 return v
             return len(values.data["inputs"]) + 10
-        if values.data["hyperstrategy"] == "FactorialStrategy":
+        if values.data["hyperstrategy"] == "FractionalFactorialStrategy":
             raise ValueError(
-                "It is not allowed to scpecify the number of its for FactorialStrategy",
+                "It is not allowed to scpecify the number of its for FractionalFactorialStrategy",
             )
         if v < len(values.data["inputs"]) + 2:
             raise ValueError(

--- a/bofire/runners/hyperoptimize.py
+++ b/bofire/runners/hyperoptimize.py
@@ -10,7 +10,7 @@ from bofire.data_models.domain.api import Domain
 from bofire.data_models.enum import RegressionMetricsEnum
 from bofire.data_models.objectives.api import MinimizeObjective
 from bofire.data_models.strategies.api import (
-    FactorialStrategy,
+    FractionalFactorialStrategy,
     RandomStrategy,
     SoboStrategy,
 )
@@ -50,8 +50,8 @@ def hyperoptimize(
         random_state=random_state,
     )
 
-    if surrogate_data.hyperconfig.hyperstrategy == "FactorialStrategy":
-        strategy = strategies.map(FactorialStrategy(domain=benchmark.domain))
+    if surrogate_data.hyperconfig.hyperstrategy == "FractionalFactorialStrategy":
+        strategy = strategies.map(FractionalFactorialStrategy(domain=benchmark.domain))
         experiments = benchmark.f(
             strategy.ask(candidate_count=None),
             return_complete=True,

--- a/bofire/strategies/fractional_factorial.py
+++ b/bofire/strategies/fractional_factorial.py
@@ -3,6 +3,11 @@ from typing import Optional
 import numpy as np
 import pandas as pd
 
+from bofire.data_models.features.api import (
+    CategoricalInput,
+    ContinuousInput,
+    DiscreteInput,
+)
 from bofire.data_models.strategies.api import FractionalFactorialStrategy as DataModel
 from bofire.strategies.strategy import Strategy
 from bofire.utils.doe import fracfact, get_generator
@@ -20,6 +25,37 @@ class FractionalFactorialStrategy(Strategy):
         self.n_generators = data_model.n_generators
         self.generator = data_model.generator
 
+    def _get_continuous_design(self) -> pd.DataFrame:
+        continuous_inputs = self.domain.inputs.get(ContinuousInput)
+        gen = self.generator or get_generator(
+            n_factors=len(continuous_inputs),
+            n_generators=self.n_generators,
+        )
+        design = pd.DataFrame(fracfact(gen=gen), columns=continuous_inputs.get_keys())
+        # setup the repetitions
+        if self.n_repetitions > 1:
+            design = pd.concat([design] * (self.n_repetitions), ignore_index=True)
+        # setup the center points
+        centers = pd.DataFrame(
+            {key: [0] * self.n_center for key in continuous_inputs.get_keys()},
+        )
+        design = pd.concat([design, centers], ignore_index=True)
+        # scale the design to 0 and 1
+        design = (design + 1.0) / 2.0
+        # scale to correct bounds
+        lower, upper = continuous_inputs.get_bounds(specs={})
+        lower, upper = np.array(lower), np.array(upper)
+        design = design * (upper - lower).reshape(1, -1) + lower.reshape(1, -1)
+        return design
+
+    def _get_categorical_design(self) -> pd.DataFrame:
+        return pd.DataFrame(
+            [
+                {e[0]: e[1] for e in combi}
+                for combi in self.domain.inputs.get_categorical_combinations()
+            ],
+        )
+
     def _ask(self, candidate_count: Optional[int] = None) -> pd.DataFrame:
         if candidate_count is not None:
             raise ValueError(
@@ -27,26 +63,27 @@ class FractionalFactorialStrategy(Strategy):
                 "The strategy automatically determines how many candidates to "
                 "propose.",
             )
-        gen = self.generator or get_generator(
-            n_factors=len(self.domain.inputs),
-            n_generators=self.n_generators,
-        )
-        design = pd.DataFrame(fracfact(gen=gen), columns=self.domain.inputs.get_keys())
-        # setup the repetitions
-        if self.n_repetitions > 1:
-            design = pd.concat([design] * (self.n_repetitions), ignore_index=True)
-        # setup the center points
-        centers = pd.DataFrame(
-            {key: [0] * self.n_center for key in self.domain.inputs.get_keys()},
-        )
-        design = pd.concat([design, centers], ignore_index=True)
-        # scale the design to 0 and 1
-        design = (design + 1.0) / 2.0
-        # scale to correct bounds
-        lower, upper = self.domain.inputs.get_bounds(specs={})
-        lower, upper = np.array(lower), np.array(upper)
-        design = design * (upper - lower).reshape(1, -1) + lower.reshape(1, -1)
-        return design
+        design = None
+        if len(self.domain.inputs.get(ContinuousInput)) > 0:
+            design = self._get_continuous_design()
+            if len(self.domain.inputs.get(ContinuousInput)) == len(self.domain.inputs):
+                return design
+
+        categorical_design = self._get_categorical_design()
+        if len(self.domain.inputs.get([CategoricalInput, DiscreteInput])) == len(
+            self.domain.inputs
+        ):
+            return categorical_design
+
+        assert isinstance(design, pd.DataFrame)
+        # combine the two designs
+        return pd.concat(
+            [
+                pd.concat([design] * len(categorical_design), ignore_index=True),
+                pd.concat([categorical_design] * len(design), ignore_index=True),
+            ],
+            axis=1,
+        ).sort_values(by=self.domain.inputs.get_keys([CategoricalInput, DiscreteInput]))
 
     def has_sufficient_experiments(self) -> bool:
         return True

--- a/bofire/strategies/fractional_factorial.py
+++ b/bofire/strategies/fractional_factorial.py
@@ -80,7 +80,7 @@ class FractionalFactorialStrategy(Strategy):
         return pd.concat(
             [
                 pd.concat([design] * len(categorical_design), ignore_index=True),
-                pd.concat([categorical_design] * len(design), ignore_index=True),
+                pd.concat([categorical_design] * len(design), ignore_index=True),  # type: ignore
             ],
             axis=1,
         ).sort_values(by=self.domain.inputs.get_keys([CategoricalInput, DiscreteInput]))

--- a/tests/bofire/strategies/test_fractional_factorial.py
+++ b/tests/bofire/strategies/test_fractional_factorial.py
@@ -4,7 +4,11 @@ from pandas.testing import assert_frame_equal
 
 import bofire.strategies.api as strategies
 from bofire.data_models.domain.api import Domain, Inputs
-from bofire.data_models.features.api import ContinuousInput
+from bofire.data_models.features.api import (
+    CategoricalInput,
+    ContinuousInput,
+    DiscreteInput,
+)
 from bofire.data_models.strategies.api import FractionalFactorialStrategy
 
 
@@ -121,6 +125,36 @@ def test_FractionalFactorialStrategy_ask():
     candidates_gen = strategy.ask(None)
     with pytest.raises(AssertionError):
         assert_frame_equal(candidates_auto, candidates_gen)
+    # here we test a purely categorical space
+    strategy_data = FractionalFactorialStrategy(
+        domain=Domain(
+            inputs=Inputs(
+                features=[
+                    CategoricalInput(key="alpha", categories=["a", "b", "c"]),
+                    DiscreteInput(key="beta", values=[1.0, 2, 3.0, 4.0]),
+                ],
+            ),
+        ),
+    )
+    strategy = strategies.map(strategy_data)
+    candidates = strategy.ask(None)
+    assert len(candidates) == 12
+    # here we test a mixed space
+    strategy_data = FractionalFactorialStrategy(
+        domain=Domain(
+            inputs=Inputs(
+                features=[
+                    ContinuousInput(key="a", bounds=(0, 1)),
+                    ContinuousInput(key="b", bounds=(0, 1)),
+                    CategoricalInput(key="alpha", categories=["a", "b"]),
+                ],
+            ),
+        ),
+        n_center=1,
+    )
+    strategy = strategies.map(strategy_data)
+    candidates = strategy.ask(None)
+    assert len(candidates) == 10
 
 
 def test_FractionalFactorialStrategy_ask_invalid():

--- a/tests/bofire/surrogates/test_gps.py
+++ b/tests/bofire/surrogates/test_gps.py
@@ -229,7 +229,7 @@ def test_hyperconfig_domain(target_metric: RegressionMetricsEnum):
 def test_hyperconfig_invalid():
     with pytest.raises(
         ValueError,
-        match="It is not allowed to scpecify the number of its for FactorialStrategy",
+        match="It is not allowed to specify the number of its for FractionalFactorialStrategy",
     ):
         SingleTaskGPHyperconfig(n_iterations=5)
     with pytest.raises(


### PR DESCRIPTION
This PR adds categorical features for the fractional factorial strategy.

It is done by creating a full factorial design for the categoricals and running the (fractional) two level factorial design of the continuous ones for every categorical combination. Doing this makes then also the `FactorialStrategy` obsolete, as one can use the `FractionalFactorialStrategy` now also with only categoricals.