### PR TITLE
Add infrastructure for changing acquisition function optimizers

### DIFF
--- a/bofire/data_models/strategies/predictives/acqf_optimizers.py
+++ b/bofire/data_models/strategies/predictives/acqf_optimizers.py
@@ -1,0 +1,50 @@
+from typing import Literal, Optional
+
+from pydantic import Field, PositiveInt, field_validator
+
+from bofire.data_models.base import BaseModel
+from bofire.data_models.types import IntPowerOfTwo
+
+
+class AcquisitionFunctionOptimizer(BaseModel):
+    """
+    Base data model for acquisition function optimizers
+
+    Attributes:
+        type (Literal): Type of optimizer.
+    """
+
+    type: str
+
+
+class BotorchAcqfOptimizer(AcquisitionFunctionOptimizer):
+    """
+    Botorch optimizers for acquisition function optimization
+
+    Attributes:
+        type (Literal): `BotorchAcqfOptimizer`.
+        num_restarts (PositiveInt): Number of starting points in a multi-start strategy for the continuous subspace of
+            the search domain. The initial points are selected from `num_raw_samples` random samples.
+        num_raw_samples (IntPowerOfTwo): Number of (pseudo-)random samples for initialization of the multi-start
+            strategy. Has to be a power of two.
+        maxiter (PositiveInt): Maximum number of iterations for each optimization.
+        batch_limit (Optional[PositiveInt], optional): Number of optimizations that are batched together in
+            a single call to the optimizer.
+    """
+
+    type: Literal["BotorchAcqfOptimizer"] = "BotorchAcqfOptimizer"
+    num_restarts: PositiveInt = 8
+    num_raw_samples: IntPowerOfTwo = 1024
+    maxiter: PositiveInt = 2000
+    batch_limit: Optional[PositiveInt] = Field(default=None, validate_default=True)
+
+    @field_validator("batch_limit")
+    @classmethod
+    def validate_batch_limit(cls, batch_limit: int, info):
+        batch_limit = min(
+            batch_limit or info.data["num_restarts"], info.data["num_restarts"]
+        )
+        return batch_limit
+
+
+AnyAcqfOptimizer = BotorchAcqfOptimizer

--- a/bofire/strategies/predictives/acqf_optimizers.py
+++ b/bofire/strategies/predictives/acqf_optimizers.py
@@ -1,0 +1,254 @@
+from abc import ABC, abstractmethod
+from typing import Callable, Dict, List, Optional, Tuple, Type
+
+from botorch.acquisition.acquisition import AcquisitionFunction
+from botorch.optim.optimize import (
+    optimize_acqf,
+    optimize_acqf_list,
+    optimize_acqf_mixed,
+)
+from torch import Tensor
+
+from bofire.data_models.constraints.api import (
+    LinearEqualityConstraint,
+    LinearInequalityConstraint,
+    NChooseKConstraint,
+    ProductConstraint,
+)
+from bofire.data_models.domain.api import Domain
+from bofire.data_models.strategies.predictives import acqf_optimizers as data_models
+from bofire.data_models.strategies.predictives.acqf_optimizers import (
+    AcquisitionFunctionOptimizer as BaseDataModel,
+)
+from bofire.data_models.strategies.predictives.acqf_optimizers import (
+    BotorchAcqfOptimizer as BotorchDataModel,
+)
+from bofire.utils.torch_tools import get_interpoint_constraints, get_linear_constraints
+
+
+class AcquisitionFunctionOptimizer(ABC):
+    """Base class for all acquisition function optimizers.
+
+    Attributes:
+    """
+
+    def __init__(
+        self,
+        data_model: BaseDataModel,
+    ):
+        pass
+
+    @classmethod
+    def from_spec(cls, data_model: BaseDataModel) -> "AcquisitionFunctionOptimizer":
+        """Used by the mapper to map from data model to functional strategy."""
+        return cls(data_model=data_model)
+
+    @abstractmethod
+    def optimize(
+        self,
+        domain: Domain,
+        candidate_count: int,
+        acqfs: List[AcquisitionFunction],
+        bounds: Tensor,
+        ic_generator: Callable,
+        ic_gen_kwargs: Dict,
+        nonlinear_constraints: List[Callable[[Tensor], float]],
+        fixed_features: Optional[Dict[int, float]],
+        fixed_features_list: Optional[List[Dict[int, float]]],
+    ) -> Tuple[Tensor, Tensor]:
+        """Abstract method to optimize the acquisition function.
+
+        Args:
+            domain (bofire.data_models.domain.api.domain): Search domain.
+            candidate_count (int): Number of candidates to produce.
+            acqfs (List[AcquisitionFunction]): List of acquisition functions. If there is more than
+                one element, the acquisition functions are optimized in sequence with previous candidates
+                set as pending. This is also known as sequential greedy optimization.
+            bounds (Tensor): A `2 x d` tensor of lower and upper bounds for each factor. If suitable
+                constraints are provided, these bounds can be `-inf` and `+inf`, respectively.
+            ic_generator (Callable): Function for generating initial conditions. Must be specified
+                for nonlinear inequality constraints.
+            ic_gen_kwargs: Additional keyword arguments passed to function specified by
+                `ic_generator`.
+            nonlinear_constraints (List[Callable[[Tensor], float]]): A list of tuples representing
+                the nonlinear inequality constraints. The first element in the tuple is a callable
+                representing a constraint of the form `callable(x) >= 0`. In case of an
+                intra-point constraint, `callable()` takes in a one-dimensional tensor of
+                shape `d` and returns a scalar. In case of an inter-point constraint,
+                `callable()` takes a two dimensional tensor of shape `candidate_count x d` and again
+                returns a scalar. The second element is a boolean, indicating if it is an
+                intra-point (`True`) or inter-point (`False`) constraint.
+            fixed_features (Optional[Dict[int, float]]): A map `{feature_index: value}` for features
+                that should be fixed to a particular value during generation.
+            fixed_features_list (Optional[List[Dict[int, float]]]): A list of maps `{feature_index: value}`.
+                The i-th item represents the fixed_feature for the i-th optimization. If
+                `fixed_features_list` is provided, `optimize_acqf_mixed` is invoked.
+        Returns:
+            Tuple[Tensor, Tensor]: A two-element tuple containing
+                - a `candidate_count x d`-dim tensor of generated candidates.
+                - a `candidate_count`-dim tensor of associated acquisition values.
+        """
+        pass
+
+
+class BotorchAcqfOptimizer(AcquisitionFunctionOptimizer):
+    def __init__(
+        self,
+        data_model: BotorchDataModel,
+        **kwargs,
+    ):
+        super().__init__(data_model=data_model)
+
+        self.num_restarts = data_model.num_restarts
+        self.num_raw_samples = data_model.num_raw_samples
+        self.maxiter = data_model.maxiter
+        self.batch_limit = data_model.batch_limit
+
+    def _get_optimizer_options(self, domain: Domain) -> Dict[str, int]:
+        """Returns a dictionary of settings passed to `optimize_acqf` controlling
+        the behavior of the optimizer.
+
+        Args:
+            domain (bofire.data_models.domain.api.Domain): Search domain.
+
+        Returns:
+            Dict[str, int]: The dictionary with the settings.
+        """
+        return {
+            "batch_limit": (  # type: ignore
+                self.batch_limit
+                if len(domain.constraints.get([NChooseKConstraint, ProductConstraint]))
+                == 0
+                else 1
+            ),
+            "maxiter": self.maxiter,
+        }
+
+    def optimize(
+        self,
+        domain: Domain,
+        candidate_count: int,
+        acqfs: List[AcquisitionFunction],
+        bounds: Tensor,
+        ic_generator: Callable,
+        ic_gen_kwargs: Dict,
+        nonlinear_constraints: List[Callable[[Tensor], float]],
+        fixed_features: Optional[Dict[int, float]],
+        fixed_features_list: Optional[List[Dict[int, float]]],
+    ) -> Tuple[Tensor, Tensor]:
+        """Uses Botorch (and subsequently scipy) to optimize the acquisition function.
+
+        Args:
+            domain (bofire.data_models.domain.api.domain): Search domain.
+            candidate_count (int): Number of candidates to produce.
+            acqfs (List[AcquisitionFunction]): List of acquisition functions. If there is more than
+                one element, the acquisition functions are optimized in sequence with previous candidates
+                set as pending. This is also known as sequential greedy optimization.
+            bounds (Tensor): A `2 x d` tensor of lower and upper bounds for each factor. If suitable
+                constraints are provided, these bounds can be `-inf` and `+inf`, respectively.
+            ic_generator (Callable): Function for generating initial conditions. Must be specified
+                for nonlinear inequality constraints.
+            ic_gen_kwargs: Additional keyword arguments passed to function specified by
+                `ic_generator`.
+            nonlinear_constraints (List[Callable[[Tensor], float]]): A list of tuples representing
+                the nonlinear inequality constraints. The first element in the tuple is a callable
+                representing a constraint of the form `callable(x) >= 0`. In case of an
+                intra-point constraint, `callable()` takes in a one-dimensional tensor of
+                shape `d` and returns a scalar. In case of an inter-point constraint,
+                `callable()` takes a two dimensional tensor of shape `candidate_count x d` and again
+                returns a scalar. The second element is a boolean, indicating if it is an
+                intra-point (`True`) or inter-point (`False`) constraint.
+            fixed_features (Optional[Dict[int, float]]): A map `{feature_index: value}` for features
+                that should be fixed to a particular value during generation.
+            fixed_features_list (Optional[List[Dict[int, float]]]): A list of maps `{feature_index: value}`.
+                The i-th item represents the fixed_feature for the i-th optimization. If
+                `fixed_features_list` is provided, `optimize_acqf_mixed` is invoked.
+        Returns:
+            Tuple[Tensor, Tensor]: A two-element tuple containing
+                - a `candidate_count x d`-dim tensor of generated candidates.
+                - a `candidate_count`-dim tensor of associated acquisition values.
+        """
+        if len(acqfs) > 1:
+            candidates, acqf_vals = optimize_acqf_list(
+                acq_function_list=acqfs,
+                bounds=bounds,
+                num_restarts=self.num_restarts,
+                raw_samples=self.num_raw_samples,
+                equality_constraints=get_linear_constraints(
+                    domain=domain,
+                    constraint=LinearEqualityConstraint,
+                ),
+                inequality_constraints=get_linear_constraints(
+                    domain=domain,
+                    constraint=LinearInequalityConstraint,
+                ),
+                nonlinear_inequality_constraints=nonlinear_constraints,  # type: ignore
+                fixed_features=fixed_features,
+                fixed_features_list=fixed_features_list,
+                ic_gen_kwargs=ic_gen_kwargs,
+                ic_generator=ic_generator,
+                options=self._get_optimizer_options(domain),  # type: ignore
+            )
+        else:
+            if fixed_features_list:
+                candidates, acqf_vals = optimize_acqf_mixed(
+                    acq_function=acqfs[0],
+                    bounds=bounds,
+                    q=candidate_count,
+                    num_restarts=self.num_restarts,
+                    raw_samples=self.num_raw_samples,
+                    equality_constraints=get_linear_constraints(
+                        domain=domain,
+                        constraint=LinearEqualityConstraint,
+                    ),
+                    inequality_constraints=get_linear_constraints(
+                        domain=domain,
+                        constraint=LinearInequalityConstraint,
+                    ),
+                    nonlinear_inequality_constraints=nonlinear_constraints,  # type: ignore
+                    fixed_features_list=fixed_features_list,
+                    ic_generator=ic_generator,
+                    ic_gen_kwargs=ic_gen_kwargs,
+                    options=self._get_optimizer_options(domain),  # type: ignore
+                )
+            else:
+                interpoints = get_interpoint_constraints(
+                    domain=domain, n_candidates=candidate_count
+                )
+                candidates, acqf_vals = optimize_acqf(
+                    acq_function=acqfs[0],
+                    bounds=bounds,
+                    q=candidate_count,
+                    num_restarts=self.num_restarts,
+                    raw_samples=self.num_raw_samples,
+                    equality_constraints=get_linear_constraints(
+                        domain=domain,
+                        constraint=LinearEqualityConstraint,
+                    )
+                    + interpoints,
+                    inequality_constraints=get_linear_constraints(
+                        domain=domain,
+                        constraint=LinearInequalityConstraint,
+                    ),
+                    fixed_features=fixed_features,
+                    nonlinear_inequality_constraints=nonlinear_constraints,  # type: ignore
+                    return_best_only=True,
+                    options=self._get_optimizer_options(domain),  # type: ignore
+                    ic_generator=ic_generator,
+                    **ic_gen_kwargs,
+                )
+        return candidates, acqf_vals
+
+
+ACQFOPT_MAP: Dict[
+    Type[data_models.AcquisitionFunctionOptimizer], Type[AcquisitionFunctionOptimizer]
+] = {
+    data_models.BotorchAcqfOptimizer: BotorchAcqfOptimizer,
+}
+
+
+def map(
+    data_model: data_models.AcquisitionFunctionOptimizer,
+) -> AcquisitionFunctionOptimizer:
+    cls = ACQFOPT_MAP[data_model.__class__]
+    return cls.from_spec(data_model=data_model)

--- a/tests/bofire/data_models/specs/strategies.py
+++ b/tests/bofire/data_models/specs/strategies.py
@@ -20,6 +20,9 @@ from bofire.data_models.features.api import (
     DiscreteInput,
     TaskInput,
 )
+from bofire.data_models.strategies.predictives.acqf_optimizers import (
+    BotorchAcqfOptimizer,
+)
 from bofire.data_models.surrogates.api import BotorchSurrogates, MultiTaskGPSurrogate
 from bofire.strategies.enum import OptimalityCriterionEnum
 from tests.bofire.data_models.specs.api import domain
@@ -30,8 +33,9 @@ specs = Specs([])
 
 
 strategy_commons = {
-    "num_raw_samples": 1024,
-    "num_restarts": 8,
+    "acqf_optimizer": BotorchAcqfOptimizer(
+        num_restarts=8, num_raw_samples=1024, maxiter=2000, batch_limit=6
+    ).model_dump(),
     "descriptor_method": CategoricalMethodEnum.EXHAUSTIVE,
     "categorical_method": CategoricalMethodEnum.EXHAUSTIVE,
     "discrete_method": CategoricalMethodEnum.EXHAUSTIVE,
@@ -42,8 +46,6 @@ strategy_commons = {
     "frequency_check": 1,
     "frequency_hyperopt": 0,
     "folds": 5,
-    "maxiter": 2000,
-    "batch_limit": 6,
 }
 
 
@@ -131,7 +133,7 @@ specs.add_valid(
                         key="b",
                         bounds=(0, 1),
                     ),
-                ],
+                ]
             ),
             outputs=Outputs(features=[ContinuousOutput(key="alpha")]),
         ).model_dump(),
@@ -154,10 +156,10 @@ specs.add_invalid(
                         key="b",
                         bounds=(0, 1),
                     ),
-                ],
+                ]
             ),
             outputs=Outputs(
-                features=[ContinuousOutput(key="alpha"), ContinuousOutput(key="beta")],
+                features=[ContinuousOutput(key="alpha"), ContinuousOutput(key="beta")]
             ),
         ).model_dump(),
         "acquisition_function": qNegIntPosVar(
@@ -246,7 +248,7 @@ specs.add_valid(
             strategies.Step(
                 strategy_data=strategies.QehviStrategy(
                     domain=tempdomain,
-                    batch_limit=1,
+                    acqf_optimizer=BotorchAcqfOptimizer(batch_limit=1),
                 ),
                 condition=strategies.NumberOfExperimentsCondition(n_experiments=30),
             ).model_dump(),
@@ -264,8 +266,8 @@ specs.add_valid(
                 features=[
                     CategoricalInput(key="alpha", categories=["a", "b", "c"]),
                     DiscreteInput(key="beta", values=[1.0, 2, 3.0, 4.0]),
-                ],
-            ),
+                ]
+            )
         ).model_dump(),
         "seed": 42,
     },
@@ -278,32 +280,24 @@ specs.add_valid(
             inputs=Inputs(
                 features=[
                     ContinuousInput(
-                        key="a",
-                        bounds=(0, 1),
-                        local_relative_bounds=(0.2, 0.2),
+                        key="a", bounds=(0, 1), local_relative_bounds=(0.2, 0.2)
                     ),
                     ContinuousInput(
-                        key="b",
-                        bounds=(0, 1),
-                        local_relative_bounds=(0.1, 0.1),
+                        key="b", bounds=(0, 1), local_relative_bounds=(0.1, 0.1)
                     ),
                     ContinuousInput(key="c", bounds=(0.1, 0.1)),
                     CategoricalInput(key="d", categories=["a", "b", "c"]),
-                ],
+                ]
             ),
             constraints=Constraints(
                 constraints=[
                     LinearEqualityConstraint(
-                        features=["a", "b", "c"],
-                        coefficients=[1.0, 1.0, 1.0],
-                        rhs=1.0,
+                        features=["a", "b", "c"], coefficients=[1.0, 1.0, 1.0], rhs=1.0
                     ),
                     LinearInequalityConstraint(
-                        features=["a", "b"],
-                        coefficients=[1.0, 1.0],
-                        rhs=0.95,
+                        features=["a", "b"], coefficients=[1.0, 1.0], rhs=0.95
                     ),
-                ],
+                ]
             ),
         ).model_dump(),
         "seed": 42,
@@ -320,27 +314,21 @@ specs.add_invalid(
             inputs=Inputs(
                 features=[
                     ContinuousInput(
-                        key="a",
-                        bounds=(0, 1),
-                        local_relative_bounds=(0.2, 0.2),
+                        key="a", bounds=(0, 1), local_relative_bounds=(0.2, 0.2)
                     ),
                     ContinuousInput(
-                        key="b",
-                        bounds=(0, 1),
-                        local_relative_bounds=(0.1, 0.1),
+                        key="b", bounds=(0, 1), local_relative_bounds=(0.1, 0.1)
                     ),
                     ContinuousInput(key="c", bounds=(0.1, 0.1)),
                     CategoricalInput(key="d", categories=["a", "b", "c"]),
-                ],
+                ]
             ),
             constraints=Constraints(
                 constraints=[
                     LinearEqualityConstraint(
-                        features=["a", "b", "c"],
-                        coefficients=[1.0, 1.0, 1.0],
-                        rhs=1.0,
-                    ),
-                ],
+                        features=["a", "b", "c"], coefficients=[1.0, 1.0, 1.0], rhs=1.0
+                    )
+                ]
             ),
         ).model_dump(),
         "seed": 42,
@@ -358,27 +346,21 @@ specs.add_invalid(
             inputs=Inputs(
                 features=[
                     ContinuousInput(
-                        key="a",
-                        bounds=(0, 1),
-                        local_relative_bounds=(0.2, 0.2),
+                        key="a", bounds=(0, 1), local_relative_bounds=(0.2, 0.2)
                     ),
                     ContinuousInput(
-                        key="b",
-                        bounds=(0, 1),
-                        local_relative_bounds=(0.1, 0.1),
+                        key="b", bounds=(0, 1), local_relative_bounds=(0.1, 0.1)
                     ),
                     ContinuousInput(key="c", bounds=(0.1, 0.1)),
                     CategoricalInput(key="d", categories=["a", "b", "c"]),
-                ],
+                ]
             ),
             constraints=Constraints(
                 constraints=[
                     LinearEqualityConstraint(
-                        features=["a", "b", "c"],
-                        coefficients=[1.0, 1.0, 1.0],
-                        rhs=1.0,
-                    ),
-                ],
+                        features=["a", "b", "c"], coefficients=[1.0, 1.0, 1.0], rhs=1.0
+                    )
+                ]
             ),
         ).model_dump(),
         "seed": 42,
@@ -397,27 +379,21 @@ specs.add_invalid(
             inputs=Inputs(
                 features=[
                     ContinuousInput(
-                        key="a",
-                        bounds=(0, 1),
-                        local_relative_bounds=(0.2, 0.2),
+                        key="a", bounds=(0, 1), local_relative_bounds=(0.2, 0.2)
                     ),
                     ContinuousInput(
-                        key="b",
-                        bounds=(0, 1),
-                        local_relative_bounds=(0.1, 0.1),
+                        key="b", bounds=(0, 1), local_relative_bounds=(0.1, 0.1)
                     ),
                     ContinuousInput(key="c", bounds=(0.1, 0.1)),
                     CategoricalInput(key="d", categories=["a", "b", "c"]),
-                ],
+                ]
             ),
             constraints=Constraints(
                 constraints=[
                     LinearEqualityConstraint(
-                        features=["a", "b", "c"],
-                        coefficients=[1.0, 1.0, 1.0],
-                        rhs=1.0,
-                    ),
-                ],
+                        features=["a", "b", "c"], coefficients=[1.0, 1.0, 1.0], rhs=1.0
+                    )
+                ]
             ),
         ).model_dump(),
         "seed": 42,
@@ -445,16 +421,14 @@ specs.add_invalid(
                     ),
                     ContinuousInput(key="c", bounds=(0.1, 0.1)),
                     CategoricalInput(key="d", categories=["a", "b", "c"]),
-                ],
+                ]
             ),
             constraints=Constraints(
                 constraints=[
                     LinearEqualityConstraint(
-                        features=["a", "b", "c"],
-                        coefficients=[1.0, 1.0, 1.0],
-                        rhs=1.0,
-                    ),
-                ],
+                        features=["a", "b", "c"], coefficients=[1.0, 1.0, 1.0], rhs=1.0
+                    )
+                ]
             ),
         ).model_dump(),
         "seed": 42,
@@ -472,7 +446,7 @@ specs.add_invalid(
             inputs=Inputs(
                 features=[
                     CategoricalInput(key="d", categories=["a", "b", "c"]),
-                ],
+                ]
             ),
         ).model_dump(),
         "seed": 42,
@@ -490,12 +464,10 @@ specs.add_invalid(
             inputs=Inputs(
                 features=[
                     ContinuousInput(
-                        key=k,
-                        bounds=(0, 1),
-                        local_relative_bounds=(0.1, 0.1),
+                        key=k, bounds=(0, 1), local_relative_bounds=(0.1, 0.1)
                     )
                     for k in ["a", "b", "c"]
-                ],
+                ]
             ),
             outputs=Outputs(features=[ContinuousOutput(key="alpha")]),
             constraints=Constraints(
@@ -505,8 +477,8 @@ specs.add_invalid(
                         min_count=1,
                         max_count=2,
                         none_also_valid=False,
-                    ),
-                ],
+                    )
+                ]
             ),
         ).model_dump(),
         "local_search_config": strategies.LSRBO(),
@@ -522,17 +494,15 @@ specs.add_invalid(
             inputs=Inputs(
                 features=[
                     ContinuousInput(
-                        key=k,
-                        bounds=(0, 1),
-                        local_relative_bounds=(0.1, 0.1),
+                        key=k, bounds=(0, 1), local_relative_bounds=(0.1, 0.1)
                     )
                     for k in ["a", "b", "c"]
                 ]
-                + [CategoricalInput(key="d", categories=["a", "b", "c"])],
+                + [CategoricalInput(key="d", categories=["a", "b", "c"])]
             ),
             outputs=Outputs(features=[ContinuousOutput(key="alpha")]),
             constraints=Constraints(
-                constraints=[InterpointEqualityConstraint(feature="a")],
+                constraints=[InterpointEqualityConstraint(feature="a")]
             ),
         ).model_dump(),
     },
@@ -548,7 +518,7 @@ specs.add_valid(
                 features=[
                     ContinuousInput(key="a", bounds=(0, 1)),
                     ContinuousInput(key="b", bounds=(0, 1)),
-                ],
+                ]
             ),
         ).model_dump(),
         "seed": 42,
@@ -567,7 +537,7 @@ specs.add_invalid(
                 features=[
                     ContinuousInput(key="a", bounds=(0, 1)),
                     ContinuousInput(key="b", bounds=(0, 1)),
-                ],
+                ]
             ),
         ).model_dump(),
         "seed": 42,
@@ -588,7 +558,7 @@ specs.add_invalid(
                 features=[
                     ContinuousInput(key="a", bounds=(0, 1)),
                     ContinuousInput(key="b", bounds=(0, 1)),
-                ],
+                ]
             ),
         ).model_dump(),
         "seed": 42,
@@ -613,7 +583,7 @@ specs.add_invalid(
                         allowed=[True, True],
                     ),
                     ContinuousInput(key="x", bounds=(0, 1)),
-                ],
+                ]
             ),
             outputs=Outputs(features=[ContinuousOutput(key="y")]),
         ).model_dump(),
@@ -628,70 +598,13 @@ specs.add_invalid(
                                 allowed=[True, True],
                             ),
                             ContinuousInput(key="x", bounds=(0, 1)),
-                        ],
+                        ]
                     ),
                     outputs=Outputs(features=[ContinuousOutput(key="y")]),
-                ),
-            ],
+                )
+            ]
         ).model_dump(),
     },
     error=ValueError,
     message="Exactly one allowed task category must be specified for strategies with MultiTask models.",
-)
-
-specs.add_valid(
-    strategies.MultiFidelityStrategy,
-    lambda: {
-        "domain": Domain(
-            inputs=Inputs(
-                features=[
-                    ContinuousInput(key="a", bounds=(0, 1)),
-                    TaskInput(
-                        key="task", categories=["task_hf", "task_lf"], fidelities=[0, 1]
-                    ),
-                ]
-            ),
-            outputs=Outputs(features=[ContinuousOutput(key="alpha")]),
-        ).model_dump(),
-        **strategy_commons,
-        "acquisition_function": qEI().model_dump(),
-        "fidelity_thresholds": 0.1,
-    },
-)
-
-specs.add_invalid(
-    strategies.MultiFidelityStrategy,
-    lambda: {
-        "domain": Domain(
-            inputs=Inputs(features=[ContinuousInput(key="a", bounds=(0, 1))]),
-            outputs=Outputs(features=[ContinuousOutput(key="alpha")]),
-        ).model_dump(),
-        **strategy_commons,
-        "acquisition_function": qEI().model_dump(),
-        "fidelity_thresholds": 0.1,
-    },
-    error=ValueError,
-    message="Exactly one task input is required for multi-task GPs.",
-)
-
-specs.add_invalid(
-    strategies.MultiFidelityStrategy,
-    lambda: {
-        "domain": Domain(
-            inputs=Inputs(
-                features=[
-                    ContinuousInput(key="a", bounds=(0, 1)),
-                    TaskInput(
-                        key="task", categories=["task_hf", "task_lf"], fidelities=[0, 0]
-                    ),
-                ]
-            ),
-            outputs=Outputs(features=[ContinuousOutput(key="alpha")]),
-        ).model_dump(),
-        **strategy_commons,
-        "acquisition_function": qEI().model_dump(),
-        "fidelity_thresholds": 0.1,
-    },
-    error=ValueError,
-    message="Only one task can be the target fidelity",
 )

--- a/tests/bofire/data_models/strategies/predictives/test_botorch.py
+++ b/tests/bofire/data_models/strategies/predictives/test_botorch.py
@@ -3,6 +3,9 @@ import pytest
 from bofire.data_models.domain.api import Domain
 from bofire.data_models.features.api import ContinuousInput, ContinuousOutput
 from bofire.data_models.strategies.api import LSRBO, SoboStrategy
+from bofire.data_models.strategies.predictives.acqf_optimizers import (
+    BotorchAcqfOptimizer,
+)
 
 
 @pytest.mark.parametrize(
@@ -22,9 +25,20 @@ def test_validate_batch_limit():
         outputs=[ContinuousOutput(key="b")],
     )
     strategy_data = SoboStrategy(domain=domain)
-    assert strategy_data.batch_limit == strategy_data.num_restarts
-    strategy_data = SoboStrategy(domain=domain, batch_limit=50)
-    assert strategy_data.batch_limit == strategy_data.num_restarts
-    strategy_data = SoboStrategy(domain=domain, batch_limit=2, num_restarts=4)
-    assert strategy_data.batch_limit == 2
-    assert strategy_data.num_restarts == 4
+    assert (
+        strategy_data.acqf_optimizer.batch_limit
+        == strategy_data.acqf_optimizer.num_restarts
+    )
+    strategy_data = SoboStrategy(
+        domain=domain, acqf_optimizer=BotorchAcqfOptimizer(batch_limit=50)
+    )
+    assert (
+        strategy_data.acqf_optimizer.batch_limit
+        == strategy_data.acqf_optimizer.num_restarts
+    )
+    strategy_data = SoboStrategy(
+        domain=domain,
+        acqf_optimizer=BotorchAcqfOptimizer(batch_limit=2, num_restarts=4),
+    )
+    assert strategy_data.acqf_optimizer.batch_limit == 2
+    assert strategy_data.acqf_optimizer.num_restarts == 4

--- a/tests/bofire/strategies/test_base.py
+++ b/tests/bofire/strategies/test_base.py
@@ -32,6 +32,9 @@ from bofire.data_models.features.api import (
     Output,
 )
 from bofire.data_models.objectives.api import MaximizeObjective, MinimizeObjective
+from bofire.data_models.strategies.predictives.acqf_optimizers import (
+    BotorchAcqfOptimizer,
+)
 from bofire.utils.torch_tools import (
     get_nchoosek_constraints,
     get_nonlinear_constraints,
@@ -106,41 +109,41 @@ if1 = ContinuousInput(
     **{
         **VALID_CONTINUOUS_INPUT_FEATURE_SPEC,
         "key": "if1",
-    },
+    }
 )
 if2 = ContinuousInput(
     **{
         **VALID_FIXED_CONTINUOUS_INPUT_FEATURE_SPEC,
         "key": "if2",
-    },
+    }
 )
 
 if3 = CategoricalInput(
     **{
         **VALID_CATEGORICAL_INPUT_FEATURE_SPEC,
         "key": "if3",
-    },
+    }
 )
 
 if4 = CategoricalInput(
     **{
         **VALID_FIXED_CATEGORICAL_INPUT_FEATURE_SPEC,
         "key": "if4",
-    },
+    }
 )
 
 if5 = CategoricalDescriptorInput(
     **{
         **VALID_CATEGORICAL_DESCRIPTOR_INPUT_FEATURE_SPEC,
         "key": "if5",
-    },
+    }
 )
 
 if6 = CategoricalDescriptorInput(
     **{
         **VALID_FIXED_CATEGORICAL_DESCRIPTOR_INPUT_FEATURE_SPEC,
         "key": "if6",
-    },
+    }
 )
 
 if7 = DummyFeature(key="if7")
@@ -149,28 +152,28 @@ if8 = CategoricalDescriptorInput(
     **{
         **VALID_ALLOWED_CATEGORICAL_DESCRIPTOR_INPUT_FEATURE_SPEC,
         "key": "if8",
-    },
+    }
 )
 
 if9 = DiscreteInput(
     **{
         **VALID_DISCRETE_INPUT_FEATURE_SPEC,
         "key": "if9",
-    },
+    }
 )
 
 of1 = ContinuousOutput(
     **{
         **VALID_CONTINUOUS_OUTPUT_FEATURE_SPEC,
         "key": "of1",
-    },
+    }
 )
 
 of2 = ContinuousOutput(
     **{
         **VALID_CONTINUOUS_OUTPUT_FEATURE_SPEC,
         "key": "of2",
-    },
+    }
 )
 
 domains = [
@@ -241,7 +244,7 @@ data = [
             "if9": [1.0, 2.0, 1.0, 2.0],
             "of1": [10, 11, 12, 13],
             "valid_of1": [1, 0, 1, 0],
-        },
+        }
     ),
     pd.DataFrame.from_dict(
         {
@@ -254,7 +257,7 @@ data = [
             "if9": [1.0, 2.0, 1.0, 2.0],
             "of1": [10, 11, 12, 13],
             "valid_of1": [1, 0, 1, 0],
-        },
+        }
     ),
     pd.DataFrame.from_dict(
         {
@@ -269,7 +272,7 @@ data = [
             "of2": [100, 103, 105, 110],
             "valid_of1": [1, 0, 1, 0],
             "valid_of2": [0, 1, 1, 0],
-        },
+        }
     ),
     pd.DataFrame.from_dict(
         {
@@ -277,7 +280,7 @@ data = [
             "if2": [3, 3, 3, 3],
             "of1": [10, 11, 12, 13],
             "valid_of1": [1, 0, 1, 0],
-        },
+        }
     ),
     pd.DataFrame.from_dict(
         {
@@ -289,7 +292,7 @@ data = [
             "of2": [100, 103, 105, 110],
             "valid_of1": [1, 0, 1, 0],
             "valid_of2": [0, 1, 1, 0],
-        },
+        }
     ),
 ]
 
@@ -300,7 +303,9 @@ def test_base_create(domain: Domain):
         ValueError,
         match="Argument is not power of two.",
     ):
-        DummyStrategyDataModel(domain=domain, num_raw_samples=5)
+        DummyStrategyDataModel(
+            domain=domain, acqf_optimizer=BotorchAcqfOptimizer(num_raw_samples=5)
+        )
 
 
 def test_base_invalid_descriptor_method():
@@ -312,7 +317,7 @@ def test_base_invalid_descriptor_method():
                     inputs=domains[0].inputs,
                     outputs=domains[0].outputs,
                     input_preprocessing_specs={"if5": CategoricalEncodingEnum.ONE_HOT},
-                ),
+                )
             ],
             descriptor_method="FREE",
             categorical_method="EXHAUSTIVE",
@@ -348,8 +353,8 @@ def test_base_invalid_descriptor_method():
                             "if5": CategoricalEncodingEnum.ONE_HOT,
                             "if6": CategoricalEncodingEnum.ONE_HOT,
                         },
-                    ),
-                ],
+                    )
+                ]
             ),
             "EXHAUSTIVE",
             "EXHAUSTIVE",
@@ -362,14 +367,14 @@ def test_base_invalid_descriptor_method():
                     surrogate_data_models.SingleTaskGPSurrogate(
                         inputs=domains[1].inputs,
                         outputs=domains[1].outputs,
-                    ),
-                ],
+                    )
+                ]
             ),
             "FREE",
             "EXHAUSTIVE",
             {1: 3, 5: 1, 6: 2, 10: 1, 11: 0, 12: 0},
         ),
-        (
+        (  #
             domains[1],
             surrogate_data_models.BotorchSurrogates(
                 surrogates=[
@@ -380,8 +385,8 @@ def test_base_invalid_descriptor_method():
                             "if5": CategoricalEncodingEnum.ONE_HOT,
                             "if6": CategoricalEncodingEnum.ONE_HOT,
                         },
-                    ),
-                ],
+                    )
+                ]
             ),
             "FREE",
             "FREE",
@@ -404,8 +409,8 @@ def test_base_invalid_descriptor_method():
                         input_preprocessing_specs={
                             "if8": CategoricalEncodingEnum.ONE_HOT,
                         },
-                    ),
-                ],
+                    )
+                ]
             ),
             "FREE",
             "FREE",
@@ -428,11 +433,7 @@ def test_base_invalid_descriptor_method():
     ],
 )
 def test_base_get_fixed_features(
-    domain,
-    surrogate_specs,
-    categorical_method,
-    descriptor_method,
-    expected,
+    domain, surrogate_specs, categorical_method, descriptor_method, expected
 ):
     data_model = DummyStrategyDataModel(
         domain=domain,
@@ -511,8 +512,8 @@ def test_base_get_fixed_features(
                         input_preprocessing_specs={
                             "if5": CategoricalEncodingEnum.ONE_HOT,
                         },
-                    ),
-                ],
+                    )
+                ]
             ),
             [
                 {2: 1.0, 3: 0.0, 4: 0.0, 5: 1.0, 6: 0.0, 7: 0.0, 1: 1},
@@ -548,8 +549,8 @@ def test_base_get_fixed_features(
                         input_preprocessing_specs={
                             "if5": CategoricalEncodingEnum.ONE_HOT,
                         },
-                    ),
-                ],
+                    )
+                ]
             ),
             [
                 {2: 1.0, 3: 0.0, 4: 0.0, 5: 1.0, 6: 0.0, 7: 0.0},
@@ -573,8 +574,8 @@ def test_base_get_fixed_features(
                     surrogate_data_models.SingleTaskGPSurrogate(
                         inputs=domains[0].inputs,
                         outputs=domains[0].outputs,
-                    ),
-                ],
+                    )
+                ]
             ),
             [{2: 1.0, 3: 2.0}, {2: 3.0, 3: 7.0}, {2: 5.0, 3: 1.0}],
         ),
@@ -588,8 +589,8 @@ def test_base_get_fixed_features(
                     surrogate_data_models.SingleTaskGPSurrogate(
                         inputs=domains[0].inputs,
                         outputs=domains[0].outputs,
-                    ),
-                ],
+                    )
+                ]
             ),
             [{1: 1.0}, {1: 2.0}],
         ),
@@ -603,8 +604,8 @@ def test_base_get_fixed_features(
                     surrogate_data_models.SingleTaskGPSurrogate(
                         inputs=domains[0].inputs,
                         outputs=domains[0].outputs,
-                    ),
-                ],
+                    )
+                ]
             ),
             [
                 {2: 1.0, 3: 2.0, 1: 1.0},
@@ -626,10 +627,10 @@ def test_base_get_fixed_features(
                         inputs=domains[0].inputs,
                         outputs=domains[0].outputs,
                         input_preprocessing_specs={
-                            "if5": CategoricalEncodingEnum.ONE_HOT,
+                            "if5": CategoricalEncodingEnum.ONE_HOT
                         },
-                    ),
-                ],
+                    )
+                ]
             ),
             [{}],
         ),
@@ -694,37 +695,25 @@ def test_base_invalid_pair_encoding_method(domain):
         (
             domains[0],
             generate_experiments(
-                domains[0],
-                row_count=5,
-                tol=1.0,
-                force_all_categories=True,
+                domains[0], row_count=5, tol=1.0, force_all_categories=True
             ),
         ),
         (
             domains[1],
             generate_experiments(
-                domains[1],
-                row_count=5,
-                tol=1.0,
-                force_all_categories=True,
+                domains[1], row_count=5, tol=1.0, force_all_categories=True
             ),
         ),
         (
             domains[2],
             generate_experiments(
-                domains[2],
-                row_count=5,
-                tol=1.0,
-                force_all_categories=True,
+                domains[2], row_count=5, tol=1.0, force_all_categories=True
             ),
         ),
         (
             domains[4],
             generate_experiments(
-                domains[4],
-                row_count=5,
-                tol=1.0,
-                force_all_categories=True,
+                domains[4], row_count=5, tol=1.0, force_all_categories=True
             ),
         ),
     ],
@@ -743,20 +732,14 @@ def test_base_fit(domain, data):
         (
             domains[0],
             generate_experiments(
-                domains[0],
-                row_count=10,
-                tol=1.0,
-                force_all_categories=True,
+                domains[0], row_count=10, tol=1.0, force_all_categories=True
             ),
             specs.acquisition_functions.valid().obj(),
         ),
         (
             domains[1],
             generate_experiments(
-                domains[1],
-                row_count=10,
-                tol=1.0,
-                force_all_categories=True,
+                domains[1], row_count=10, tol=1.0, force_all_categories=True
             ),
             specs.acquisition_functions.valid().obj(),
         ),
@@ -780,7 +763,7 @@ def test_base_fit(domain, data):
 )
 def test_base_predict(domain, data, acquisition_function):
     data_model = DummyStrategyDataModel(
-        domain=domain,
+        domain=domain
     )  # , acquisition_function=acquisition_function
     # )
     myStrategy = DummyStrategy(data_model=data_model)
@@ -797,13 +780,11 @@ def test_base_predict(domain, data, acquisition_function):
             [CategoricalMethodEnum.FREE, CategoricalMethodEnum.EXHAUSTIVE],
             [CategoricalMethodEnum.FREE, CategoricalMethodEnum.EXHAUSTIVE],
             [CategoricalMethodEnum.FREE, CategoricalMethodEnum.EXHAUSTIVE],
-        ),
+        )
     ),
 )
 def test_base_setup_ask_fixed_features(
-    categorical_method,
-    descriptor_method,
-    discrete_method,
+    categorical_method, descriptor_method, discrete_method
 ):
     # test for fixed features list
     data_model = DummyStrategyDataModel(
@@ -818,8 +799,8 @@ def test_base_setup_ask_fixed_features(
                     inputs=domains[0].inputs,
                     outputs=domains[0].outputs,
                     # input_preprocessing_specs={"if5": CategoricalEncodingEnum.ONE_HOT},
-                ),
-            ],
+                )
+            ]
         ),
     )
     myStrategy = DummyStrategy(data_model=data_model)
@@ -878,8 +859,7 @@ def test_base_setup_ask():
     )
     myStrategy = DummyStrategy(data_model=data_model)
     myStrategy._experiments = benchmark.f(
-        benchmark.domain.inputs.sample(3),
-        return_complete=True,
+        benchmark.domain.inputs.sample(3), return_complete=True
     )
     (
         bounds,
@@ -911,8 +891,7 @@ def test_base_setup_ask():
     )
     myStrategy = DummyStrategy(data_model=data_model)
     myStrategy._experiments = benchmark.f(
-        benchmark.domain.inputs.sample(3),
-        return_complete=True,
+        benchmark.domain.inputs.sample(3), return_complete=True
     )
     (
         bounds,
@@ -936,10 +915,8 @@ def test_base_setup_ask():
     benchmark = Hartmann(dim=6, allowed_k=3)
     benchmark.domain.constraints.constraints.append(
         ProductInequalityConstraint(
-            features=["x_1", "x_2", "x_3"],
-            exponents=[1, 1, 1],
-            rhs=50,
-        ),
+            features=["x_1", "x_2", "x_3"], exponents=[1, 1, 1], rhs=50
+        )
     )
     data_model = DummyStrategyDataModel(
         domain=benchmark.domain,
@@ -947,8 +924,7 @@ def test_base_setup_ask():
     )
     myStrategy = DummyStrategy(data_model=data_model)
     myStrategy._experiments = benchmark.f(
-        benchmark.domain.inputs.sample(3),
-        return_complete=True,
+        benchmark.domain.inputs.sample(3), return_complete=True
     )
     (
         bounds,

--- a/tests/bofire/strategies/test_qparego.py
+++ b/tests/bofire/strategies/test_qparego.py
@@ -19,6 +19,9 @@ from bofire.benchmarks.multi import C2DTLZ2, DTLZ2, CrossCoupling
 from bofire.data_models.acquisition_functions.api import qEI, qLogEI, qLogNEI, qNEI
 from bofire.data_models.domain.api import Outputs
 from bofire.data_models.strategies.api import RandomStrategy as RandomStrategyDataModel
+from bofire.data_models.strategies.predictives.acqf_optimizers import (
+    BotorchAcqfOptimizer,
+)
 from bofire.strategies.api import QparegoStrategy, RandomStrategy
 from tests.bofire.strategies.test_base import domains
 from tests.bofire.utils.test_multiobjective import invalid_domains
@@ -36,7 +39,7 @@ VALID_BOTORCH_QPAREGO_STRATEGY_SPEC = {
                 inputs=domains[6].inputs,
                 outputs=Outputs(features=[domains[6].outputs.get_by_key("of2")]),
             ),
-        ],
+        ]
     ),
     "descriptor_method": "FREE",
     # "acquisition_function": specs.acquisition_functions.valid().obj(),
@@ -67,16 +70,16 @@ BOTORCH_QPAREGO_STRATEGY_SPECS = {
                     surrogate_data_models.MixedSingleTaskGPSurrogate(
                         inputs=domains[2].inputs,
                         outputs=Outputs(
-                            features=[domains[2].outputs.get_by_key("of1")],
+                            features=[domains[2].outputs.get_by_key("of1")]
                         ),
                     ),
                     surrogate_data_models.MixedSingleTaskGPSurrogate(
                         inputs=domains[2].inputs,
                         outputs=Outputs(
-                            features=[domains[2].outputs.get_by_key("of2")],
+                            features=[domains[2].outputs.get_by_key("of2")]
                         ),
                     ),
-                ],
+                ]
             ),
             "descriptor_method": "EXHAUSTIVE",
             "categorical_method": "EXHAUSTIVE",
@@ -112,7 +115,7 @@ def test_qparego(num_test_candidates):
     # generate data
     benchmark = DTLZ2(dim=6)
     random_strategy = RandomStrategy(
-        data_model=RandomStrategyDataModel(domain=benchmark.domain),
+        data_model=RandomStrategyDataModel(domain=benchmark.domain)
     )
     experiments = benchmark.f(random_strategy.ask(10), return_complete=True)
     # init strategy
@@ -126,8 +129,7 @@ def test_qparego(num_test_candidates):
     i = random.choice([0, 1, 2, 3])
 
     data_model = data_models.QparegoStrategy(
-        domain=benchmark.domain,
-        acquisition_function=acqfs[i],
+        domain=benchmark.domain, acquisition_function=acqfs[i]
     )
     my_strategy = QparegoStrategy(data_model=data_model)
     my_strategy.tell(experiments)
@@ -152,13 +154,12 @@ def test_qparego_constraints(num_test_candidates):
     def test(benchmark_factory):
         benchmark = benchmark_factory()
         random_strategy = RandomStrategy(
-            data_model=RandomStrategyDataModel(domain=benchmark.domain),
+            data_model=RandomStrategyDataModel(domain=benchmark.domain)
         )
         experiments = benchmark.f(random_strategy.ask(10), return_complete=True)
         # init strategy
         data_model = data_models.QparegoStrategy(
-            domain=benchmark.domain,
-            num_restarts=1,
+            domain=benchmark.domain, acqf_optimizer=BotorchAcqfOptimizer(num_restarts=1)
         )
         my_strategy = QparegoStrategy(data_model=data_model)
         my_strategy.tell(experiments)
@@ -195,11 +196,10 @@ def test_qparego_constraints(num_test_candidates):
 def test_get_acqf_input(specs, benchmark, num_experiments, num_candidates):
     # generate data
     random_strategy = RandomStrategy(
-        data_model=RandomStrategyDataModel(domain=benchmark.domain),
+        data_model=RandomStrategyDataModel(domain=benchmark.domain)
     )
     experiments = benchmark.f(
-        random_strategy.ask(num_experiments),
-        return_complete=True,
+        random_strategy.ask(num_experiments), return_complete=True
     )
     data_model = data_models.QparegoStrategy(
         domain=benchmark.domain,
@@ -218,7 +218,7 @@ def test_get_acqf_input(specs, benchmark, num_experiments, num_candidates):
     X_train, X_pending = strategy.get_acqf_input_tensors()
 
     _, names = strategy.domain.inputs._get_transform_info(
-        specs=strategy.surrogate_specs.input_preprocessing_specs,
+        specs=strategy.surrogate_specs.input_preprocessing_specs
     )
 
     assert torch.is_tensor(X_train)

--- a/tests/bofire/strategies/test_sobo.py
+++ b/tests/bofire/strategies/test_sobo.py
@@ -44,6 +44,9 @@ from bofire.data_models.objectives.api import (
 )
 from bofire.data_models.strategies.api import LSRBO
 from bofire.data_models.strategies.api import RandomStrategy as RandomStrategyDataModel
+from bofire.data_models.strategies.predictives.acqf_optimizers import (
+    BotorchAcqfOptimizer,
+)
 from bofire.data_models.unions import to_list
 from bofire.strategies.api import CustomSoboStrategy, RandomStrategy, SoboStrategy
 from tests.bofire.strategies.test_base import domains
@@ -54,8 +57,7 @@ from tests.bofire.strategies.test_base import domains
 VALID_BOTORCH_SOBO_STRATEGY_SPEC = {
     "domain": domains[1],
     "acquisition_function": specs.acquisition_functions.valid(
-        SingleObjectiveAcquisitionFunction,
-        exact=False,
+        SingleObjectiveAcquisitionFunction, exact=False
     ).obj(),
     # "num_sobol_samples": 1024,
     # "num_restarts": 8,
@@ -81,8 +83,7 @@ BOTORCH_SOBO_STRATEGY_SPECS = {
 VALID_ADDITIVE_AND_MULTIPLICATIVE_BOTORCH_SOBO_STRATEGY_SPEC = {
     "domain": domains[2],
     "acquisition_function": specs.acquisition_functions.valid(
-        SingleObjectiveAcquisitionFunction,
-        exact=False,
+        SingleObjectiveAcquisitionFunction, exact=False
     ).obj(),
     "descriptor_method": "EXHAUSTIVE",
     "categorical_method": "EXHAUSTIVE",
@@ -145,14 +146,13 @@ def test_SOBO_get_acqf(acqf, expected, num_test_candidates):
     benchmark = Himmelblau()
 
     random_strategy = RandomStrategy(
-        data_model=RandomStrategyDataModel(domain=benchmark.domain),
+        data_model=RandomStrategyDataModel(domain=benchmark.domain)
     )
 
     experiments = benchmark.f(random_strategy.ask(20), return_complete=True)
 
     data_model = data_models.SoboStrategy(
-        domain=benchmark.domain,
-        acquisition_function=acqf,
+        domain=benchmark.domain, acquisition_function=acqf
     )
     strategy = SoboStrategy(data_model=data_model)
 
@@ -169,8 +169,7 @@ def test_SOBO_calc_acquisition():
     experiments = benchmark.f(benchmark.domain.inputs.sample(10), return_complete=True)
     samples = benchmark.domain.inputs.sample(2)
     data_model = data_models.SoboStrategy(
-        domain=benchmark.domain,
-        acquisition_function=qLogEI(),
+        domain=benchmark.domain, acquisition_function=qLogEI()
     )
     strategy = SoboStrategy(data_model=data_model)
     strategy.tell(experiments=experiments)
@@ -187,13 +186,12 @@ def test_SOBO_init_qUCB():
     # generate data
     benchmark = Himmelblau()
     random_strategy = RandomStrategy(
-        data_model=RandomStrategyDataModel(domain=benchmark.domain),
+        data_model=RandomStrategyDataModel(domain=benchmark.domain)
     )
     experiments = benchmark.f(random_strategy.ask(20), return_complete=True)
 
     data_model = data_models.SoboStrategy(
-        domain=benchmark.domain,
-        acquisition_function=acqf,
+        domain=benchmark.domain, acquisition_function=acqf
     )
     strategy = SoboStrategy(data_model=data_model)
     strategy.tell(experiments)
@@ -217,7 +215,7 @@ def test_get_acqf_input(acqf, num_experiments, num_candidates):
     # generate data
     benchmark = Himmelblau()
     random_strategy = RandomStrategy(
-        data_model=RandomStrategyDataModel(domain=benchmark.domain),
+        data_model=RandomStrategyDataModel(domain=benchmark.domain)
     )
     experiments = benchmark.f(
         random_strategy._ask(candidate_count=num_experiments),
@@ -225,8 +223,7 @@ def test_get_acqf_input(acqf, num_experiments, num_candidates):
     )
 
     data_model = data_models.SoboStrategy(
-        domain=benchmark.domain,
-        acquisition_function=acqf,
+        domain=benchmark.domain, acquisition_function=acqf
     )
     strategy = SoboStrategy(data_model=data_model)
 
@@ -236,7 +233,7 @@ def test_get_acqf_input(acqf, num_experiments, num_candidates):
     X_train, X_pending = strategy.get_acqf_input_tensors()
 
     _, names = strategy.domain.inputs._get_transform_info(
-        specs=strategy.surrogate_specs.input_preprocessing_specs,
+        specs=strategy.surrogate_specs.input_preprocessing_specs
     )
 
     assert torch.is_tensor(X_train)
@@ -263,8 +260,7 @@ def test_custom_get_objective():
     benchmark = DTLZ2(3)
     experiments = benchmark.f(benchmark.domain.inputs.sample(5), return_complete=True)
     data_model = data_models.CustomSoboStrategy(
-        domain=benchmark.domain,
-        acquisition_function=qNEI(),
+        domain=benchmark.domain, acquisition_function=qNEI()
     )
     strategy = CustomSoboStrategy(data_model=data_model)
     strategy.f = f
@@ -276,8 +272,7 @@ def test_custom_get_objective():
 def test_custom_get_objective_invalid():
     benchmark = DTLZ2(3)
     data_model = data_models.CustomSoboStrategy(
-        domain=benchmark.domain,
-        acquisition_function=qNEI(),
+        domain=benchmark.domain, acquisition_function=qNEI()
     )
     strategy = CustomSoboStrategy(data_model=data_model)
     experiments = benchmark.f(benchmark.domain.inputs.sample(5), return_complete=True)
@@ -318,8 +313,7 @@ def test_custom_dumps_loads():
     strategy2._experiments = experiments
 
     data_model3 = data_models.CustomSoboStrategy(
-        domain=benchmark.domain,
-        acquisition_function=qNEI(),
+        domain=benchmark.domain, acquisition_function=qNEI()
     )
     strategy3 = CustomSoboStrategy(data_model=data_model3)
     strategy3._experiments = experiments
@@ -343,8 +337,7 @@ def test_custom_dumps_loads():
 def test_custom_dumps_invalid():
     benchmark = DTLZ2(3)
     data_model = data_models.CustomSoboStrategy(
-        domain=benchmark.domain,
-        acquisition_function=qNEI(),
+        domain=benchmark.domain, acquisition_function=qNEI()
     )
     strategy = CustomSoboStrategy(data_model=data_model)
     with pytest.raises(ValueError):
@@ -352,7 +345,7 @@ def test_custom_dumps_invalid():
 
 
 @pytest.mark.parametrize("candidate_count", [1, 2])
-def test_sobo_fully_combinatorial(candidate_count):
+def test_sobo_fully_combinatorical(candidate_count):
     benchmark = _CategoricalDiscreteHimmelblau()
 
     strategy_data = data_models.SoboStrategy(domain=benchmark.domain)
@@ -369,7 +362,7 @@ def test_sobo_fully_combinatorial(candidate_count):
     [
         (
             Outputs(
-                features=[ContinuousOutput(key="alpha", objective=MaximizeObjective())],
+                features=[ContinuousOutput(key="alpha", objective=MaximizeObjective())]
             ),
             GenericMCObjective,
         ),
@@ -379,8 +372,8 @@ def test_sobo_fully_combinatorial(candidate_count):
                     ContinuousOutput(
                         key="alpha",
                         objective=MaximizeSigmoidObjective(steepness=1, tp=1),
-                    ),
-                ],
+                    )
+                ]
             ),
             GenericMCObjective,
         ),
@@ -391,7 +384,7 @@ def test_sobo_get_objective(outputs, expected_objective):
         domain=Domain(
             inputs=Inputs(features=[ContinuousInput(key="a", bounds=(0, 1))]),
             outputs=outputs,
-        ),
+        )
     )
     experiments = pd.DataFrame({"a": [0.5], "alpha": [0.5], "valid_alpha": [1]})
     strategy = SoboStrategy(data_model=strategy_data)
@@ -405,8 +398,7 @@ def test_sobo_get_constrained_objective():
     experiments = benchmark.f(benchmark.domain.inputs.sample(5), return_complete=True)
     domain = benchmark.domain
     domain.outputs.get_by_key("f_1").objective = MaximizeSigmoidObjective(  # type: ignore
-        tp=1.5,
-        steepness=2.0,
+        tp=1.5, steepness=2.0
     )
     strategy_data = data_models.SoboStrategy(domain=domain, acquisition_function=qUCB())
     strategy = SoboStrategy(data_model=strategy_data)
@@ -420,12 +412,10 @@ def test_sobo_get_constrained_objective2():
     experiments = benchmark.f(benchmark.domain.inputs.sample(5), return_complete=True)
     domain = benchmark.domain
     domain.outputs.get_by_key("f_1").objective = MaximizeSigmoidObjective(  # type: ignore
-        tp=1.5,
-        steepness=2.0,
+        tp=1.5, steepness=2.0
     )
     strategy_data = data_models.SoboStrategy(
-        domain=domain,
-        acquisition_function=qLogEI(),
+        domain=domain, acquisition_function=qLogEI()
     )
     strategy = SoboStrategy(data_model=strategy_data)
     strategy.tell(experiments=experiments)
@@ -437,14 +427,12 @@ def test_sobo_hyperoptimize():
     benchmark = Himmelblau()
     experiments = benchmark.f(benchmark.domain.inputs.sample(3), return_complete=True)
     strategy_data = data_models.SoboStrategy(
-        domain=benchmark.domain,
-        acquisition_function=qLogEI(),
-        frequency_hyperopt=1,
+        domain=benchmark.domain, acquisition_function=qLogEI(), frequency_hyperopt=1
     )
     strategy_data.surrogate_specs.surrogates[0].hyperconfig = None  # type: ignore
     strategy = SoboStrategy(data_model=strategy_data)
     with pytest.warns(
-        match="No hyperopt is possible as no hyperopt config is available. Returning initial config.",
+        match="No hyperopt is possible as no hyperopt config is available. Returning initial config."
     ):
         strategy.tell(experiments=experiments)
 
@@ -469,9 +457,7 @@ def test_sobo_lsrbo():
     ]
     # local search
     strategy_data = data_models.SoboStrategy(
-        domain=bench.domain,
-        seed=42,
-        local_search_config=LSRBO(gamma=0),
+        domain=bench.domain, seed=42, local_search_config=LSRBO(gamma=0)
     )
     strategy = SoboStrategy(data_model=strategy_data)
     strategy.tell(experiments)
@@ -479,9 +465,7 @@ def test_sobo_lsrbo():
     np.allclose(candidates.loc[0, ["x_1", "x_2"]].tolist(), [-2.55276, 11.192913])  # type: ignore
     # global search
     strategy_data = data_models.SoboStrategy(
-        domain=bench.domain,
-        seed=42,
-        local_search_config=LSRBO(gamma=500000),
+        domain=bench.domain, seed=42, local_search_config=LSRBO(gamma=500000)
     )
     strategy = SoboStrategy(data_model=strategy_data)
     strategy.tell(experiments)
@@ -497,9 +481,14 @@ def test_sobo_get_optimizer_options():
         ],
         outputs=[ContinuousOutput(key="c")],  # type: ignore
     )
-    strategy_data = data_models.SoboStrategy(domain=domain, maxiter=500, batch_limit=4)
+    strategy_data = data_models.SoboStrategy(
+        domain=domain, acqf_optimizer=BotorchAcqfOptimizer(maxiter=500, batch_limit=4)
+    )
     strategy = SoboStrategy(data_model=strategy_data)
-    assert strategy._get_optimizer_options() == {"maxiter": 500, "batch_limit": 4}
+    assert strategy.acqf_optimizer._get_optimizer_options(strategy.domain) == {
+        "maxiter": 500,
+        "batch_limit": 4,
+    }
     domain = Domain(
         inputs=[  # type: ignore
             ContinuousInput(key="a", bounds=(0, 1)),
@@ -508,16 +497,18 @@ def test_sobo_get_optimizer_options():
         outputs=[ContinuousOutput(key="c")],  # type: ignore
         constraints=[  # type: ignore
             NChooseKConstraint(
-                features=["a", "b"],
-                max_count=1,
-                min_count=0,
-                none_also_valid=True,
-            ),
+                features=["a", "b"], max_count=1, min_count=0, none_also_valid=True
+            )
         ],
     )
-    strategy_data = data_models.SoboStrategy(domain=domain, maxiter=500, batch_limit=4)
+    strategy_data = data_models.SoboStrategy(
+        domain=domain, acqf_optimizer=BotorchAcqfOptimizer(maxiter=500, batch_limit=4)
+    )
     strategy = SoboStrategy(data_model=strategy_data)
-    assert strategy._get_optimizer_options() == {"maxiter": 500, "batch_limit": 1}
+    assert strategy.acqf_optimizer._get_optimizer_options(strategy.domain) == {
+        "maxiter": 500,
+        "batch_limit": 1,
+    }
 
 
 def test_sobo_interpoint():


### PR DESCRIPTION
The `BotorchStrategy` is expanded to modularize the acquisition function optimizer. Every acquisition function optimizer has to derive from the newly created base class `AcquisitionFunctionOptimizer`. The current Botorch-based optimizer is moved into the separate class `BotorchAcqfOptimizer`.

This PR includes a **breaking change in the data model**: A new data model for acquisition function optimizers is created. The Botorch-optimizer params stored in the `BotorchStrategy` are moved to the new `BotorchAcqfOptimizer`.

Due to the modularization, we can later add different optimizers for the acquisition function (e.g., genetic algorithm).