### PR TITLE
Make candidate_count enforcement less strict

### DIFF
--- a/bofire/data_models/strategies/factorial.py
+++ b/bofire/data_models/strategies/factorial.py
@@ -20,7 +20,7 @@ class FactorialStrategy(Strategy):
     This strategy is deprecated, please use FractionalFactorialStrategy instead.
     """
 
-    type: Literal["FactorialStrategy"] = "FactorialStrategy"
+    type: Literal["FactorialStrategy"] = "FactorialStrategy"  # type: ignore
 
     @classmethod
     def is_constraint_implemented(cls, my_type: Type[Constraint]) -> bool:

--- a/bofire/strategies/fractional_factorial.py
+++ b/bofire/strategies/fractional_factorial.py
@@ -1,3 +1,4 @@
+import warnings
 from typing import Optional
 
 import numpy as np
@@ -58,10 +59,11 @@ class FractionalFactorialStrategy(Strategy):
 
     def _ask(self, candidate_count: Optional[int] = None) -> pd.DataFrame:
         if candidate_count is not None:
-            raise ValueError(
+            warnings.warn(
                 "FractionalFactorialStrategy will ignore the specified value of candidate_count. "
                 "The strategy automatically determines how many candidates to "
                 "propose.",
+                UserWarning,
             )
         design = None
         if len(self.domain.inputs.get(ContinuousInput)) > 0:

--- a/bofire/strategies/shortest_path.py
+++ b/bofire/strategies/shortest_path.py
@@ -1,3 +1,4 @@
+import warnings
 from typing import Optional, Tuple
 
 import cvxpy as cp
@@ -127,10 +128,11 @@ class ShortestPathStrategy(Strategy):
 
         """
         if candidate_count is not None:
-            raise ValueError(
-                "ShortestPath will ignore the specified value of candidate_count. "
+            warnings.warn(
+                "ShortestPathStrategy will ignore the specified value of candidate_count. "
                 "The strategy automatically determines how many candidates to "
                 "propose.",
+                UserWarning,
             )
         start = self.start
         steps = []

--- a/bofire/strategies/strategy.py
+++ b/bofire/strategies/strategy.py
@@ -1,3 +1,4 @@
+import warnings
 from abc import ABC, abstractmethod
 from typing import List, Optional
 
@@ -129,8 +130,9 @@ class Strategy(ABC):
 
         if candidate_count is not None:
             if len(candidates) != candidate_count:
-                raise ValueError(
-                    f"expected {candidate_count} candidates, got {len(candidates)}",
+                warnings.warn(
+                    f"Expected {candidate_count} candidates, got {len(candidates)}",
+                    UserWarning,
                 )
 
         if add_pending:

--- a/tests/bofire/strategies/test_fractional_factorial.py
+++ b/tests/bofire/strategies/test_fractional_factorial.py
@@ -169,10 +169,11 @@ def test_FractionalFactorialStrategy_ask_invalid():
         ),
     )
     strategy = strategies.map(strategy_data)
-    with pytest.raises(
-        ValueError,
+    with pytest.warns(
+        UserWarning,
         match="FractionalFactorialStrategy will ignore the specified value of candidate_count. "
         "The strategy automatically determines how many candidates to "
         "propose.",
     ):
-        strategy.ask(5)
+        candidates = strategy.ask(7)
+    assert len(candidates) == 5

--- a/tests/bofire/strategies/test_shortest_path.py
+++ b/tests/bofire/strategies/test_shortest_path.py
@@ -42,7 +42,9 @@ def test_step():
 def test_ask():
     data_model = specs.valid(data_models.ShortestPathStrategy).obj()
     strategy = strategies.map(data_model=data_model)
-    with pytest.raises(ValueError, match="ShortestPath will ignore the specified "):
+    with pytest.warns(
+        UserWarning, match="ShortestPathStrategy will ignore the specified "
+    ):
         strategy.ask(candidate_count=4)
     steps = strategy.ask()
     assert np.allclose(

--- a/tests/bofire/strategies/test_strategy.py
+++ b/tests/bofire/strategies/test_strategy.py
@@ -449,7 +449,7 @@ def test_strategy_ask_invalid_candidate_count(
         return candidates
 
     with mock.patch.object(dummy.DummyStrategy, "_ask", new=test_ask):
-        with pytest.raises(ValueError):
+        with pytest.warns(UserWarning, match="Expected"):
             strategy.ask(candidate_count=4)
 
 


### PR DESCRIPTION
This PR makes the `candidate_count` enforcement less strict:

- A warning instead of an error is raised if the strategy spits out more candidates than expected. This was also requested by @CompRhys 
- In the `FractionalFactorialStrategy` also values despite `None` for candidate count are allowed, nevertheless it always returns the predefined number of candidates and ignore the value given for `candidate_count`.