### PR TITLE
Drop support for Python 3.9

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -19,7 +19,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.12"
+          python-version: "3.10"
 
       - name: Set up uv
         uses: astral-sh/setup-uv@v2
@@ -35,4 +35,4 @@ jobs:
       - name: Pyright
         uses: jakebailey/pyright-action@v2
         with:
-          version: 1.1.345  # is there any reason not to use the latest?
+          version: 1.1.305  # is there any reason not to use the latest?

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -19,7 +19,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.9"
+          python-version: "3.12"
 
       - name: Set up uv
         uses: astral-sh/setup-uv@v2

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -35,4 +35,4 @@ jobs:
       - name: Pyright
         uses: jakebailey/pyright-action@v2
         with:
-          version: 1.1.305  # is there any reason not to use the latest?
+          version: 1.1.391  # is there any reason not to use the latest?

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -35,4 +35,4 @@ jobs:
       - name: Pyright
         uses: jakebailey/pyright-action@v2
         with:
-          version: 1.1.391  # is there any reason not to use the latest?
+          version: 1.1.345  # is there any reason not to use the latest?

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -42,7 +42,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ '3.10', '3.13' ]
+        python-version: [ '3.10', '3.12' ]
     steps:
       - name: Check out repo
         uses: actions/checkout@v4

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.9', '3.10', '3.11' ]
+        python-version: ['3.10', '3.11', '3.12', '3.13']
     steps:
       - name: Check out repo
         uses: actions/checkout@v4
@@ -42,7 +42,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ '3.9', '3.11' ]
+        python-version: [ '3.10', '3.13' ]
     steps:
       - name: Check out repo
         uses: actions/checkout@v4
@@ -72,7 +72,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ '3.10' ]
+        python-version: [ '3.12' ]
     steps:
       - name: Check out repo
         uses: actions/checkout@v4
@@ -106,7 +106,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ '3.10' ]
+        python-version: [ '3.12' ]
     steps:
       - name: Check out repo
         uses: actions/checkout@v4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ classifiers = [
     "Intended Audience :: Developers",
 ]
 readme = {file = "README.md", content-type = "text/markdown"}
-requires-python = ">=3.9.0"
+requires-python = ">=3.10.0"
 dependencies = [
     "numpy",
     "pandas",


### PR DESCRIPTION
This PR drops the support for Python 3.9. It will go EOL this year (https://devguide.python.org/versions/) and causes especially trouble with Entmoot but also in other occassions. 

cc: @TobyBoyne @LukasHebing 