### PR TITLE
Make the BoFire Data Models OpenAI compatible

### DIFF
--- a/bofire/benchmarks/detergent.py
+++ b/bofire/benchmarks/detergent.py
@@ -57,11 +57,11 @@ class Detergent(Benchmark):
 
         self._domain = Domain.from_lists(
             inputs=[
-                ContinuousInput(key="x1", bounds=(0.0, 0.2)),
-                ContinuousInput(key="x2", bounds=(0.0, 0.3)),
-                ContinuousInput(key="x3", bounds=(0.02, 0.2)),
-                ContinuousInput(key="x4", bounds=(0.0, 0.06)),
-                ContinuousInput(key="x5", bounds=(0.0, 0.04)),
+                ContinuousInput(key="x1", bounds=[0.0, 0.2]),
+                ContinuousInput(key="x2", bounds=[0.0, 0.3]),
+                ContinuousInput(key="x3", bounds=[0.02, 0.2]),
+                ContinuousInput(key="x4", bounds=[0.0, 0.06]),
+                ContinuousInput(key="x5", bounds=[0.0, 0.04]),
             ],
             outputs=[ContinuousOutput(key=f"y{i+1}") for i in range(5)],
             constraints=[

--- a/bofire/benchmarks/multi.py
+++ b/bofire/benchmarks/multi.py
@@ -54,7 +54,7 @@ class DTLZ2(Benchmark):
 
         inputs = []
         for i in range(self.dim):
-            inputs.append(ContinuousInput(key="x_%i" % (i), bounds=(0, 1)))
+            inputs.append(ContinuousInput(key="x_%i" % (i), bounds=[0, 1]))
         outputs = []
         self.k = self.dim - self.num_objectives + 1
         for i in range(self.num_objectives):
@@ -140,8 +140,8 @@ class BNH(Benchmark):
         self._domain = Domain(
             inputs=Inputs(
                 features=[
-                    ContinuousInput(key="x1", bounds=(0, 5)),
-                    ContinuousInput(key="x2", bounds=(0, 3)),
+                    ContinuousInput(key="x1", bounds=[0, 5]),
+                    ContinuousInput(key="x2", bounds=[0, 3]),
                 ],
             ),
             outputs=Outputs(
@@ -187,8 +187,8 @@ class TNK(Benchmark):
         self._domain = Domain(
             inputs=Inputs(
                 features=[
-                    ContinuousInput(key="x1", bounds=(0, math.pi)),
-                    ContinuousInput(key="x2", bounds=(0, math.pi)),
+                    ContinuousInput(key="x1", bounds=[0, math.pi]),
+                    ContinuousInput(key="x2", bounds=[0, math.pi]),
                 ],
             ),
             outputs=Outputs(
@@ -293,13 +293,13 @@ class SnarBenchmark(Benchmark):
         # Decision variables
         # "residence time in minutes"
         inputs = [
-            ContinuousInput(key="tau", bounds=(0.5, 2)),
+            ContinuousInput(key="tau", bounds=[0.5, 2]),
             # "equivalents of pyrrolidine"
-            ContinuousInput(key="equiv_pldn", bounds=(1, 5)),
+            ContinuousInput(key="equiv_pldn", bounds=[1, 5]),
             # "concentration of 2,4 dinitrofluorobenenze at reactor inlet (after mixing) in M"
-            ContinuousInput(key="conc_dfnb", bounds=(0.1, 0.5)),
+            ContinuousInput(key="conc_dfnb", bounds=[0.1, 0.5]),
             # "Reactor temperature in degrees celsius"
-            ContinuousInput(key="temperature", bounds=(30, 120)),
+            ContinuousInput(key="temperature", bounds=[30, 120]),
         ]
         # Objectives
         # "space time yield (kg/m^3/h)"
@@ -442,7 +442,7 @@ class ZDT1(Benchmark):
         super().__init__(**kwargs)
         self.n_inputs = n_inputs
         inputs = [
-            ContinuousInput(key=f"x{i+1}", bounds=(0, 1)) for i in range(n_inputs)
+            ContinuousInput(key=f"x{i+1}", bounds=[0, 1]) for i in range(n_inputs)
         ]
         inputs = Inputs(features=inputs)
         outputs = [
@@ -550,11 +550,11 @@ class CrossCoupling(Benchmark):
                 ],
             ),
             # "base equivalents"
-            ContinuousInput(key="base_eq", bounds=(1, 2.5)),
+            ContinuousInput(key="base_eq", bounds=[1, 2.5]),
             # "Reactor temperature in degrees celsius"
-            ContinuousInput(key="temperature", bounds=(30, 100)),
+            ContinuousInput(key="temperature", bounds=[30, 100]),
             # "residence time in seconds (s)"
-            ContinuousInput(key="t_res", bounds=(60, 1800)),
+            ContinuousInput(key="t_res", bounds=[60, 1800]),
         ]
 
         input_preprocessing_specs = {
@@ -566,11 +566,11 @@ class CrossCoupling(Benchmark):
         outputs = [
             ContinuousOutput(
                 key="yield",
-                objective=MaximizeObjective(w=1.0, bounds=(0.0, 1.0)),
+                objective=MaximizeObjective(w=1.0, bounds=[0.0, 1.0]),
             ),
             ContinuousOutput(
                 key="cost",
-                objective=MinimizeObjective(w=1.0, bounds=(0.0, 1.0)),
+                objective=MinimizeObjective(w=1.0, bounds=[0.0, 1.0]),
             ),
         ]
         self.ref_point = {"yield": 0.0, "cost": 1.0}

--- a/bofire/benchmarks/single.py
+++ b/bofire/benchmarks/single.py
@@ -110,7 +110,7 @@ class Ackley(Benchmark):
         # continuous input features
         for d in range(self.dim):
             input_feature_list.append(
-                ContinuousInput(key=f"x_{d+1}", bounds=(self.lower, self.upper)),
+                ContinuousInput(key=f"x_{d+1}", bounds=[self.lower, self.upper]),
             )
 
         # Objective
@@ -179,7 +179,7 @@ class Hartmann(Benchmark):
         self._domain = Domain(
             inputs=Inputs(
                 features=[
-                    ContinuousInput(key=f"x_{i}", bounds=(0, 1)) for i in range(dim)
+                    ContinuousInput(key=f"x_{i}", bounds=[0, 1]) for i in range(dim)
                 ],
             ),
             outputs=Outputs(
@@ -235,7 +235,7 @@ class Hartmann6plus(Benchmark):
         self._domain = Domain(
             inputs=Inputs(
                 features=[
-                    ContinuousInput(key=f"x_{i}", bounds=(0, 1)) for i in range(dim)
+                    ContinuousInput(key=f"x_{i}", bounds=[0, 1]) for i in range(dim)
                 ]
             ),
             outputs=Outputs(
@@ -291,27 +291,23 @@ class Branin(Benchmark):
                 features=[
                     ContinuousInput(
                         key="x_1",
-                        bounds=(-5.0, 10),
-                        local_relative_bounds=(
-                            (
-                                0.5 * locality_factor,
-                                0.5 * locality_factor,
-                            )
-                            if locality_factor is not None
-                            else None
-                        ),
+                        bounds=[-5.0, 10],
+                        local_relative_bounds=[
+                            0.5 * locality_factor,
+                            0.5 * locality_factor,
+                        ]
+                        if locality_factor is not None
+                        else None,
                     ),
                     ContinuousInput(
                         key="x_2",
-                        bounds=(0.0, 15.0),
-                        local_relative_bounds=(
-                            (
-                                1.5 * locality_factor,
-                                1.5 * locality_factor,
-                            )
-                            if locality_factor is not None
-                            else None
-                        ),
+                        bounds=[0.0, 15.0],
+                        local_relative_bounds=[
+                            1.5 * locality_factor,
+                            1.5 * locality_factor,
+                        ]
+                        if locality_factor is not None
+                        else None,
                     ),
                 ],
             ),
@@ -355,7 +351,7 @@ class Branin30(Benchmark):
         self._domain = Domain(
             inputs=Inputs(
                 features=[
-                    ContinuousInput(key=f"x_{i+1:02d}", bounds=(0, 1))
+                    ContinuousInput(key=f"x_{i+1:02d}", bounds=[0, 1])
                     for i in range(30)
                 ],
             ),
@@ -398,8 +394,8 @@ class Himmelblau(Benchmark):
         self.use_constraints = use_constraints
         inputs = []
 
-        inputs.append(ContinuousInput(key="x_1", bounds=(-6, 6)))
-        inputs.append(ContinuousInput(key="x_2", bounds=(-6, 6)))
+        inputs.append(ContinuousInput(key="x_1", bounds=[-6, 6]))
+        inputs.append(ContinuousInput(key="x_2", bounds=[-6, 6]))
 
         objective = MinimizeObjective(w=1.0)
         output_feature = ContinuousOutput(key="y", objective=objective)
@@ -472,8 +468,8 @@ class MultiTaskHimmelblau(Benchmark):
         inputs = []
 
         inputs.append(TaskInput(key="task_id", categories=["task_1", "task_2"]))
-        inputs.append(ContinuousInput(key="x_1", bounds=(-6, 6)))
-        inputs.append(ContinuousInput(key="x_2", bounds=(-6, 6)))
+        inputs.append(ContinuousInput(key="x_1", bounds=[-6, 6]))
+        inputs.append(ContinuousInput(key="x_2", bounds=[-6, 6]))
 
         objective = MinimizeObjective(w=1.0)
         output_feature = ContinuousOutput(key="y", objective=objective)
@@ -645,7 +641,7 @@ class Multinormalpdfs(Benchmark):
         self._domain = Domain(
             inputs=Inputs(
                 features=[
-                    ContinuousInput(key=f"x_{i}", bounds=(0, 1))
+                    ContinuousInput(key=f"x_{i}", bounds=[0, 1])
                     for i in range(self.dim)
                 ],
             ),

--- a/bofire/data_models/features/continuous.py
+++ b/bofire/data_models/features/continuous.py
@@ -27,7 +27,7 @@ class ContinuousInput(NumericalInput):
 
     bounds: Bounds
     local_relative_bounds: Optional[
-        Tuple[Annotated[float, Field(gt=0)], Annotated[float, Field(gt=0)]]
+        Annotated[List[Annotated[float, Field(gt=0)]], Field(min_items=2, max_items=2)]  # type: ignore
     ] = None
     stepsize: Optional[float] = None
 

--- a/bofire/data_models/objectives/identity.py
+++ b/bofire/data_models/objectives/identity.py
@@ -1,10 +1,11 @@
-from typing import Literal, Optional, Tuple, Union
+from typing import Literal, Optional, Union
 
 import numpy as np
 import pandas as pd
 from pydantic import field_validator
 
 from bofire.data_models.objectives.objective import Objective, TWeight
+from bofire.data_models.types import Bounds
 
 
 class IdentityObjective(Objective):
@@ -17,9 +18,9 @@ class IdentityObjective(Objective):
 
     """
 
-    type: Literal["IdentityObjective"] = "IdentityObjective"
+    type: Literal["IdentityObjective"] = "IdentityObjective"  # type: ignore
     w: TWeight = 1
-    bounds: Tuple[float, float] = (0, 1)
+    bounds: Bounds = [0, 1]
 
     @property
     def lower_bound(self) -> float:

--- a/bofire/data_models/types.py
+++ b/bofire/data_models/types.py
@@ -1,5 +1,5 @@
 from collections.abc import Sequence
-from typing import Annotated, Dict, List, Tuple, Union
+from typing import Annotated, Dict, List, Union
 
 from pydantic import AfterValidator, Field, PositiveInt
 
@@ -92,7 +92,8 @@ Descriptors = Annotated[
 ]
 
 Bounds = Annotated[
-    Tuple[float, float],
+    List[float],
+    Field(min_length=2, max_length=2),
     AfterValidator(validate_monotonically_increasing),
 ]
 

--- a/bofire/strategies/doe/objective.py
+++ b/bofire/strategies/doe/objective.py
@@ -40,7 +40,7 @@ class Objective:
         else:
             self.transform = MinMaxTransform(
                 inputs=self.domain.inputs,
-                feature_range=transform_range,
+                feature_range=tuple(transform_range),  # type: ignore
             )
 
         self.n_experiments = n_experiments

--- a/bofire/strategies/doe/utils_categorical_discrete.py
+++ b/bofire/strategies/doe/utils_categorical_discrete.py
@@ -255,7 +255,7 @@ def NChooseKGroup_with_quantity(
         # if we use_legacy_class is true this constraint will be added by the discrete_to_relaxable_domain_mapper function
         pick_exactly_one_of_group_const = []
     else:
-        category = [ContinuousInput(key=k, bounds=(0, 1)) for k in keys]
+        category = [ContinuousInput(key=k, bounds=[0, 1]) for k in keys]
         pick_exactly_one_of_group_const = [
             LinearEqualityConstraint(
                 features=list(keys),
@@ -293,7 +293,7 @@ def _generate_quantity_var_constr(
     quantity_var = [
         ContinuousInput(
             key=unique_group_identifier + "_" + k + "_quantity",
-            bounds=(0, q[1]),
+            bounds=[0, q[1]],
         )
         for k, q in zip(keys, quantity_if_picked)
     ]
@@ -469,7 +469,7 @@ def NChooseKGroup(
     # adding the new possible combinations to the list of keys
     keys = combined_keys
 
-    category = [ContinuousInput(key=k, bounds=(0, 1)) for k in keys]
+    category = [ContinuousInput(key=k, bounds=[0, 1]) for k in keys]
     pick_exactly_one_of_group_const = [
         LinearEqualityConstraint(
             features=list(keys),
@@ -489,7 +489,7 @@ def NChooseKGroup(
 def generate_mixture_constraints(
     keys: List[str],
 ) -> Tuple[LinearEqualityConstraint, List[ContinuousInput]]:
-    binary_vars = (ContinuousInput(key=x, bounds=(0, 1)) for x in keys)
+    binary_vars = (ContinuousInput(key=x, bounds=[0, 1]) for x in keys)
 
     mixture_constraint = LinearEqualityConstraint(
         features=keys,

--- a/bofire/strategies/random.py
+++ b/bofire/strategies/random.py
@@ -147,7 +147,7 @@ class RandomStrategy(Strategy):
                 for key in u:
                     feat = domain.inputs.get_by_key(key=key)
                     assert isinstance(feat, ContinuousInput)
-                    feat.bounds = (0, 0)
+                    feat.bounds = [0.0, 0.0]
                 # setup then sampler for this situation
                 samples.append(
                     self._sample_from_polytope(

--- a/bofire/utils/reduce.py
+++ b/bofire/utils/reduce.py
@@ -347,7 +347,7 @@ def remove_eliminated_inputs(domain: Domain, transform: AffineTransform) -> Doma
                     feat: ContinuousInput = ContinuousInput(
                         **domain.inputs.get_by_key(_features[0]).model_dump(),
                     )
-                    feat.bounds = (_coefficients[0], _coefficients[0])
+                    feat.bounds = [_coefficients[0], _coefficients[0]]
                     totally_removed = True
             elif len(_features) > 1:
                 _c = LinearInequalityConstraint(
@@ -430,6 +430,6 @@ def adjust_boundary(feature: ContinuousInput, coef: float, rhs: float):
     boundary = rhs / coef
     if coef > 0:
         if boundary > feature.lower_bound:
-            feature.bounds = (boundary, feature.upper_bound)
+            feature.bounds = [boundary, feature.upper_bound]
     elif boundary < feature.upper_bound:
-        feature.bounds = (feature.lower_bound, boundary)
+        feature.bounds = [feature.lower_bound, boundary]

--- a/tests/bofire/data_models/specs/features.py
+++ b/tests/bofire/data_models/specs/features.py
@@ -1,4 +1,3 @@
-import math
 import random
 import uuid
 
@@ -40,16 +39,16 @@ specs.add_valid(
     features.ContinuousInput,
     lambda: {
         "key": str(uuid.uuid4()),
-        "bounds": (3, 5.3),
+        "bounds": [3, 5.3],
         "unit": random.choice(["°C", "mg", "mmol/l", None]),
-        "local_relative_bounds": (math.inf, math.inf),
+        "local_relative_bounds": None,
         "stepsize": None,
     },
 )
 
 specs.add_invalid(
     features.ContinuousInput,
-    lambda: {"key": "a", "bounds": (5, 3)},
+    lambda: {"key": "a", "bounds": [5, 3]},
     error=ValueError,
     message="Sequence is not monotonically increasing.",
 )
@@ -58,11 +57,11 @@ specs.add_valid(
     features.ContinuousDescriptorInput,
     lambda: {
         "key": str(uuid.uuid4()),
-        "bounds": (3, 5.3),
+        "bounds": [3, 5.3],
         "descriptors": ["d1", "d2"],
         "values": [1.0, 2.0],
         "unit": random.choice(["°C", "mg", "mmol/l", None]),
-        "local_relative_bounds": (math.inf, math.inf),
+        "local_relative_bounds": None,
         "stepsize": None,
     },
 )

--- a/tests/bofire/data_models/specs/objectives.py
+++ b/tests/bofire/data_models/specs/objectives.py
@@ -14,7 +14,7 @@ specs.add_valid(
 )
 specs.add_valid(
     objectives.MaximizeObjective,
-    lambda: {"w": 1.0, "bounds": (0.1, 0.9)},
+    lambda: {"w": 1.0, "bounds": [0.1, 0.9]},
 )
 specs.add_valid(
     objectives.MaximizeSigmoidObjective,
@@ -26,7 +26,7 @@ specs.add_valid(
 )
 specs.add_valid(
     objectives.MinimizeObjective,
-    lambda: {"w": 1.0, "bounds": (0.1, 0.9)},
+    lambda: {"w": 1.0, "bounds": [0.1, 0.9]},
 )
 
 specs.add_valid(

--- a/tests/bofire/data_models/specs/strategies.py
+++ b/tests/bofire/data_models/specs/strategies.py
@@ -237,7 +237,7 @@ specs.add_valid(
         "sampling_fraction": 0.3,
         "ipopt_options": {"maxiter": 200, "disp": 0},
         "seed": 42,
-        "transform_range": (-1, 1),
+        "transform_range": [-1, 1],
     },
 )
 

--- a/tests/bofire/data_models/specs/surrogates.py
+++ b/tests/bofire/data_models/specs/surrogates.py
@@ -45,8 +45,8 @@ specs.add_valid(
     lambda: {
         "inputs": Inputs(
             features=[
-                ContinuousInput(key="a", bounds=(0, 1)),
-                ContinuousInput(key="b", bounds=(0, 1)),
+                ContinuousInput(key="a", bounds=[0, 1]),
+                ContinuousInput(key="b", bounds=[0, 1]),
             ],
         ).model_dump(),
         "outputs": Outputs(
@@ -670,7 +670,7 @@ specs.add_valid(
             + [ContinuousInput(key=f"t_{3}", bounds=(2, 60))],
         ).model_dump(),
         "outputs": Outputs(features=[ContinuousOutput(key="alpha")]).model_dump(),
-        "interpolation_range": (0, 1),
+        "interpolation_range": [0, 1],
         "n_interpolation_points": 1000,
         "x_keys": ["t_1", "t_2"],
         "y_keys": [f"phi_{i}" for i in range(4)],


### PR DESCRIPTION
By playing around with pydanticAI and GPT4o to setup domains for optimization problems described in natural language (which works extremely well), I went into errors for all data model attributes that are tuples as openai does not support tuples in json schema (https://github.com/pydantic/pydantic-ai/issues/372). This PR replaces the tuples by lists. 