### PR TITLE
Slowdown due to Scipy 1.15

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
     "numpy",
     "pandas",
     "pydantic>=2.5",
-    "scipy>=1.7",
+    "scipy>=1.7,<1.15",
     "typing-extensions",
 ]
 


### PR DESCRIPTION
BoTorch is slowed down massively by scipy 1.15: https://github.com/pytorch/botorch/issues/2668. We should fix it.