### PR TITLE
Fix wrong desirabilities in predictive strategies

### DIFF
--- a/bofire/data_models/domain/features.py
+++ b/bofire/data_models/domain/features.py
@@ -807,13 +807,15 @@ class Outputs(_BaseFeatures[AnyOutput]):
                 "If predictions are used, `experiments_adapt` has to be provided.",
             )
         else:
-            experiments_adapt = experiments
+            experiments_adapt = (
+                experiments if experiments_adapt is None else experiments_adapt
+            )
 
         desis = pd.concat(
             [
                 feat(
                     experiments[f"{feat.key}_pred" if predictions else feat.key],
-                    experiments_adapt[f"{feat.key}"].dropna(),
+                    experiments_adapt[feat.key].dropna(),
                 )
                 for feat in self.features
                 if feat.objective is not None

--- a/bofire/strategies/predictives/predictive.py
+++ b/bofire/strategies/predictives/predictive.py
@@ -156,7 +156,9 @@ class PredictiveStrategy(Strategy):
             predictions=predictions,
             outputs=self.domain.outputs,
         )
-        desis = self.domain.outputs(predictions, predictions=True)
+        desis = self.domain.outputs(
+            predictions, experiments_adapt=self.experiments, predictions=True
+        )
         predictions = pd.concat((predictions, desis), axis=1)
         predictions.index = experiments.index
         return predictions

--- a/bofire/strategies/predictives/predictive.py
+++ b/bofire/strategies/predictives/predictive.py
@@ -156,10 +156,10 @@ class PredictiveStrategy(Strategy):
             predictions=predictions,
             outputs=self.domain.outputs,
         )
-        desis = self.domain.outputs(
+        objectives = self.domain.outputs(
             predictions, experiments_adapt=self.experiments, predictions=True
         )
-        predictions = pd.concat((predictions, desis), axis=1)
+        predictions = pd.concat((predictions, objectives), axis=1)
         predictions.index = experiments.index
         return predictions
 

--- a/tests/bofire/data_models/domain/test_outputs.py
+++ b/tests/bofire/data_models/domain/test_outputs.py
@@ -12,6 +12,7 @@ from bofire.data_models.objectives.api import (
     ConstrainedObjective,
     MaximizeObjective,
     MaximizeSigmoidObjective,
+    MovingMaximizeSigmoidObjective,
     Objective,
     TargetObjective,
 )
@@ -298,6 +299,32 @@ def test_outputs_call(features, samples):
         )
         + features.get_keys(CategoricalOutput)
     ]
+
+
+def test_outputs_call_adapt_experiment():
+    outputs = Outputs(
+        features=[
+            ContinuousOutput(key="of1", objective=MaximizeObjective()),
+            ContinuousOutput(
+                key="of2",
+                objective=MovingMaximizeSigmoidObjective(tp=0, steepness=10, w=1.0),
+            ),
+        ],
+    )
+    candidates = pd.DataFrame(
+        columns=["of1_pred", "of2_pred"], data=[[1.0, 5.0], [2.0, 5.0]]
+    )
+
+    experiments = pd.DataFrame(columns=["of1", "of2"], data=[[1.0, 5.0], [2.0, 6.0]])
+
+    with pytest.raises(
+        ValueError,
+        match="If predictions are used, `experiments_adapt` has to be provided.",
+    ):
+        outputs(candidates, predictions=True)
+
+    outputs(experiments)
+    outputs(candidates, experiments_adapt=experiments, predictions=True)
 
 
 def test_categorical_objective_methods():


### PR DESCRIPTION
This PR fixes the issue that the predicted desirabilities from the strategies are wrong in case that one uses something like a `MovingMaximizeSigmoidObjective`.

