### PR TITLE
Small Refactorings to the DoE Strategy

### DIFF
--- a/bofire/data_models/domain/features.py
+++ b/bofire/data_models/domain/features.py
@@ -366,19 +366,22 @@ class Inputs(_BaseFeatures[AnyInput]):
     def validate_experiments(
         self,
         experiments: pd.DataFrame,
-        strict=False,
+        strict: bool = False,
+        check_nan: bool = True,
+        check_missing_cols: bool = True,
     ) -> pd.DataFrame:
         for feature in self:
-            if feature.key not in experiments:
+            if (feature.key not in experiments) and check_missing_cols:
                 raise ValueError(f"no col for input feature `{feature.key}`")
             experiments[feature.key] = feature.validate_experimental(
                 experiments[feature.key],
                 strict=strict,
             )
-        if experiments[self.get_keys()].isnull().to_numpy().any():
-            raise ValueError("there are null values")
-        if experiments[self.get_keys()].isna().to_numpy().any():
-            raise ValueError("there are na values")
+        if check_nan:
+            if experiments[self.get_keys()].isnull().to_numpy().any():
+                raise ValueError("there are null values")
+            if experiments[self.get_keys()].isna().to_numpy().any():
+                raise ValueError("there are na values")
         return experiments
 
     def get_categorical_combinations(

--- a/bofire/strategies/strategy.py
+++ b/bofire/strategies/strategy.py
@@ -25,6 +25,7 @@ class Strategy(ABC):
         self.domain = data_model.domain
         self.seed = data_model.seed or np.random.default_rng().integers(1000)
         self.rng = np.random.default_rng(self.seed)
+        self._allow_partially_filled_candidates = False
         self._experiments = None
         self._candidates = None
 
@@ -195,6 +196,8 @@ class Strategy(ABC):
         candidates = self.domain.inputs.validate_experiments(
             candidates[self.domain.inputs.get_keys()],
             strict=False,
+            check_nan=self._allow_partially_filled_candidates is False,
+            check_missing_cols=self._allow_partially_filled_candidates is False,
         )
         self._candidates = candidates[self.domain.inputs.get_keys()]
 


### PR DESCRIPTION
I was looking to the `DoEStrategy`and spotted some issues and possible improvements:
- Make `strategy.set_candidates` versatile enough to be able to deal also with partially fixed one without overwriting the method just for the `DoEStrategy`.
- For dealing with categoricals, a one-hot encoding is performed and new continuous features are introduced. We should use there the already implemented method for one-hot encoding of categoricals, so that we do not duplicate code. Furthermore, the continuous features are named based on the category names, but this will break when you have two categorical variables which share at least one category with the same name. We should follow there the general convention to name it always <feature.key>_<category_name>.
- Currently, it is only conditioning the generated experiments on the `candidates`. It should also do this for `self.experiments`, as this is the usual way most ACB APIs work, by using ask and tell and conditioning on self.experiments. For this, I assume that it needs to be combined with the partially_fixed_candidates under the hood.

As I am not so deep in the DoEStrategy, I only started to work on these improvements. Maybe you @Osburg have time to proceed on it. I assume that you are much faster on this as I am. I was struggling especially on how to combine the candidates and experiments. The rest is in principle done. If you do not have time, just feel free to tell, then I dig deeper ;)

cc: @dlinzner-bcs 