### PR TITLE
pin cyipopt version in conda install

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -57,7 +57,7 @@ jobs:
       - name: Install Dependencies
         shell: bash -l {0}
         run: |
-          conda install -c conda-forge cyipopt
+          conda install -c conda-forge cyipopt=1.5.0
           pip install ".[optimization,tests,cheminfo,xgb,entmoot]"
 
       - name: Run tests
@@ -86,7 +86,7 @@ jobs:
       - name: Install Dependencies
         shell: bash -l {0}
         run: |
-          conda install -c conda-forge cyipopt
+          conda install -c conda-forge cyipopt=1.5.0
           pip install --upgrade git+https://github.com/cornellius-gp/linear_operator.git
           pip install --upgrade git+https://github.com/cornellius-gp/gpytorch.git
           export ALLOW_LATEST_GPYTORCH_LINOP=true
@@ -121,7 +121,7 @@ jobs:
       - name: Install Dependencies
         shell: bash -l {0}
         run: |
-          conda install -c conda-forge cyipopt
+          conda install -c conda-forge cyipopt=1.5.0
           pip install ".[optimization,tests,cheminfo,xgb,entmoot,tutorials]"
 
       - name: Run Notebooks


### PR DESCRIPTION
With py3.10 conda install surpringly by default a super old cyipopt version. This PR pins it.