### PR TITLE
Polynomial feature interaction kernel

### DIFF
--- a/bofire/data_models/kernels/aggregation.py
+++ b/bofire/data_models/kernels/aggregation.py
@@ -3,7 +3,7 @@ from typing import Literal, Optional, Union
 
 from bofire.data_models.kernels.categorical import HammingDistanceKernel
 from bofire.data_models.kernels.continuous import LinearKernel, MaternKernel, RBFKernel
-from bofire.data_models.kernels.kernel import AggregationKernel
+from bofire.data_models.kernels.kernel import AggregationKernel, Kernel
 from bofire.data_models.kernels.molecular import TanimotoKernel
 from bofire.data_models.kernels.shape import WassersteinKernel
 from bofire.data_models.priors.api import AnyGeneralPrior
@@ -56,6 +56,14 @@ class ScaleKernel(AggregationKernel):
         WassersteinKernel,
     ]
     outputscale_prior: Optional[AnyGeneralPrior] = None
+
+
+class PolynomialFeatureInteractionKernel(AggregationKernel):
+    type: Literal["PolynomialFeaturesKernel"] = "PolynomialFeaturesKernel"
+    kernels: Sequence[Kernel]
+    max_degree: int
+    include_self_interactions: bool
+    lengthscale_prior: Optional[AnyGeneralPrior] = None
 
 
 AdditiveKernel.model_rebuild()

--- a/bofire/data_models/kernels/aggregation.py
+++ b/bofire/data_models/kernels/aggregation.py
@@ -2,8 +2,14 @@ from collections.abc import Sequence
 from typing import Literal, Optional, Union
 
 from bofire.data_models.kernels.categorical import HammingDistanceKernel
-from bofire.data_models.kernels.continuous import LinearKernel, MaternKernel, RBFKernel
-from bofire.data_models.kernels.kernel import AggregationKernel, Kernel
+from bofire.data_models.kernels.continuous import (
+    InfiniteWidthBNNKernel,
+    LinearKernel,
+    MaternKernel,
+    PolynomialKernel,
+    RBFKernel,
+)
+from bofire.data_models.kernels.kernel import AggregationKernel
 from bofire.data_models.kernels.molecular import TanimotoKernel
 from bofire.data_models.kernels.shape import WassersteinKernel
 from bofire.data_models.priors.api import AnyGeneralPrior
@@ -59,8 +65,24 @@ class ScaleKernel(AggregationKernel):
 
 
 class PolynomialFeatureInteractionKernel(AggregationKernel):
-    type: Literal["PolynomialFeaturesKernel"] = "PolynomialFeaturesKernel"
-    kernels: Sequence[Kernel]
+    type: Literal["PolynomialFeatureInteractionKernel"] = (
+        "PolynomialFeatureInteractionKernel"
+    )
+    kernels: Sequence[
+        Union[
+            AdditiveKernel,
+            MultiplicativeKernel,
+            ScaleKernel,
+            HammingDistanceKernel,
+            LinearKernel,
+            PolynomialKernel,
+            MaternKernel,
+            RBFKernel,
+            TanimotoKernel,
+            InfiniteWidthBNNKernel,
+            WassersteinKernel,
+        ]
+    ]
     max_degree: int
     include_self_interactions: bool
     lengthscale_prior: Optional[AnyGeneralPrior] = None

--- a/bofire/data_models/kernels/aggregation.py
+++ b/bofire/data_models/kernels/aggregation.py
@@ -85,7 +85,7 @@ class PolynomialFeatureInteractionKernel(AggregationKernel):
     ]
     max_degree: int
     include_self_interactions: bool
-    lengthscale_prior: Optional[AnyGeneralPrior] = None
+    outputscale_prior: Optional[AnyGeneralPrior] = None
 
 
 AdditiveKernel.model_rebuild()

--- a/bofire/data_models/kernels/aggregation.py
+++ b/bofire/data_models/kernels/aggregation.py
@@ -65,6 +65,45 @@ class ScaleKernel(AggregationKernel):
 
 
 class PolynomialFeatureInteractionKernel(AggregationKernel):
+    """
+    This kernel efficiently computes degree-n interactions between different
+    kernels, possibly including self-interactions. This is most useful when
+    there are different kernels for different feature types (e.g. continuous,
+    and categorical) and we want to compute interactions between them.
+
+    For example, given three input kernels k1, k2, and k3, this kernel with
+    `max_degree=2` and `include_self_interactions=True` would be equivalent
+    to the following kernel, but much faster to compute:
+
+    ```
+    k = AdditiveKernel(kernels=[
+        # constant (degree-0)
+        ConstantKernel(),
+
+        # individual kernels (degree-1)
+        ScaleKernel(base_kernel=k1),
+        ScaleKernel(base_kernel=k2),
+        ScaleKernel(base_kernel=k3),
+
+        # interactions (degree-2)
+        ScaleKernel(base_kernel=MultiplicativeKernel(kernels=[k1, k2])),
+        ScaleKernel(base_kernel=MultiplicativeKernel(kernels=[k1, k3])),
+        ScaleKernel(base_kernel=MultiplicativeKernel(kernels=[k2, k3])),
+
+        # self-interactions (degree-2)
+        ScaleKernel(base_kernel=MultiplicativeKernel(kernels=[k1, k1])),
+        ScaleKernel(base_kernel=MultiplicativeKernel(kernels=[k2, k2])),
+        ScaleKernel(base_kernel=MultiplicativeKernel(kernels=[k3, k3])),
+    ])
+    ```
+
+    Attributes:
+        kernels: The base kernels that should interact.
+        max_degree: Maximum degree of interactions computed.
+        include_self_interactions: Whether a kernel is allowed to interact with itself.
+        outputscale_prior: The prior used to scale each interaction term before summing.
+    """
+
     type: Literal["PolynomialFeatureInteractionKernel"] = (
         "PolynomialFeatureInteractionKernel"
     )

--- a/bofire/data_models/kernels/api.py
+++ b/bofire/data_models/kernels/api.py
@@ -3,6 +3,7 @@ from typing import Union
 from bofire.data_models.kernels.aggregation import (
     AdditiveKernel,
     MultiplicativeKernel,
+    PolynomialFeatureInteractionKernel,
     ScaleKernel,
 )
 from bofire.data_models.kernels.categorical import (
@@ -50,6 +51,7 @@ AnyMolecularKernel = TanimotoKernel
 AnyKernel = Union[
     AdditiveKernel,
     MultiplicativeKernel,
+    PolynomialFeatureInteractionKernel,
     ScaleKernel,
     HammingDistanceKernel,
     LinearKernel,

--- a/bofire/kernels/aggregation.py
+++ b/bofire/kernels/aggregation.py
@@ -31,7 +31,7 @@ class PolynomialFeatureInteractionKernel(gpytorch.kernels.Kernel):
             for n in range(1, self.max_degree + 1)
         ]
 
-        n = sum(len(idx) for idx in self.indices)
+        n = 1 + sum(len(idx) for idx in self.indices)
         outputscale = (
             torch.zeros(*self.batch_shape, n)
             if len(self.batch_shape)
@@ -93,8 +93,8 @@ class PolynomialFeatureInteractionKernel(gpytorch.kernels.Kernel):
         )
 
         os = self.outputscale
-        result = torch.zeros_like(base_kernels[0])
-        i = 0
+        result = os[0] * torch.ones_like(base_kernels[0])
+        i = 1
         for idx_n in self.indices:
             for idx_k in idx_n:
                 result += os[i] * base_kernels[idx_k, ...].prod(dim=0)

--- a/bofire/kernels/aggregation.py
+++ b/bofire/kernels/aggregation.py
@@ -1,0 +1,102 @@
+import functools
+import itertools
+from typing import Any, Optional
+
+import gpytorch
+import gpytorch.constraints
+import torch
+from torch import Tensor
+
+
+class PolynomialFeatureInteractionKernel(gpytorch.kernels.Kernel):
+    def __init__(
+        self,
+        kernels: list[gpytorch.kernels.Kernel],
+        max_degree: int,
+        include_self_interactions: bool,
+        lengthscale_prior: Optional[gpytorch.priors.Prior] = None,
+        lengthscale_constraint: Optional[gpytorch.constraints.Interval] = None,
+        *args: Any,
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(*args, **kwargs)
+
+        self.kernels = kernels
+        self.max_degree = max_degree
+        self.indices = [
+            kk
+            for n in range(1, self.max_degree + 1)
+            for kk in (
+                itertools.combinations_with_replacement(range(len(kernels)), n)
+                if include_self_interactions
+                else itertools.combinations(range(len(kernels)), n)
+            )
+        ]
+
+        self.coefs = torch.nn.Parameter(
+            torch.sqrt(torch.ones(len(self.indices)) / len(self.indices))
+        )
+
+        lengthscale = (
+            torch.zeros(*self.batch_shape, len(self.indices))
+            if len(self.batch_shape)
+            else torch.zeros(len(self.indices))
+        )
+        self.register_parameter(
+            name="raw_lengthscale", parameter=torch.nn.Parameter(lengthscale)
+        )
+        if lengthscale_prior is not None:
+            if not isinstance(lengthscale_prior, gpytorch.priors.Prior):
+                raise TypeError(
+                    "Expected gpytorch.priors.Prior but got "
+                    + type(lengthscale_prior).__name__
+                )
+            self.register_prior(
+                "lengthscale_prior",
+                lengthscale_prior,
+                self._lengthscale_param,
+                self._lengthscale_closure,
+            )
+        if lengthscale_constraint is None:
+            lengthscale_constraint = gpytorch.constraints.Positive()
+        self.register_constraint("raw_lengthscale", lengthscale_constraint)
+
+    @property
+    def lengthscale(self):
+        return self.raw_lengthscale_constraint.transform(self.raw_lengthscale)
+
+    @lengthscale.setter
+    def lengthscale(self, value):
+        self._set_lengthscale(value)
+
+    def _set_lengthscale(self, value):
+        if not torch.is_tensor(value):
+            value = torch.as_tensor(value).to(self.raw_lengthscale)
+        self.initialize(
+            raw_lengthscale=self.raw_lengthscale_constraint.inverse_transform(value)
+        )
+
+    def forward(
+        self,
+        x1: Tensor,
+        x2: Tensor,
+        diag: bool = False,
+        last_dim_is_batch: bool = False,
+    ) -> Tensor:
+        # FIXME we have to use to_dense otherwise there can be issues with mismatching dtypes during backward
+        ks = [
+            k(x1, x2, diag=diag, last_dim_is_batch=last_dim_is_batch).to_dense()
+            for k in self.kernels
+        ]
+
+        terms = torch.stack(
+            [
+                functools.reduce(lambda x, y: x * y, (ks[j] for j in ix))
+                for ix in self.indices
+            ],
+            dim=-1,
+        )
+
+        res = torch.sum(terms * self.lengthscale, dim=-1)
+
+        return res

--- a/bofire/kernels/aggregation.py
+++ b/bofire/kernels/aggregation.py
@@ -22,7 +22,10 @@ class PolynomialFeatureInteractionKernel(gpytorch.kernels.Kernel):
 
         self.kernels = kernels
         self.max_degree = max_degree
-        self.indices = [
+
+        # each item corresponds to a different interaction term
+        # and contains the indices of the kernels that interact
+        self.indices: list[tuple[int, ...]] = [
             idx
             for n in range(1, self.max_degree + 1)
             for idx in (
@@ -93,9 +96,12 @@ class PolynomialFeatureInteractionKernel(gpytorch.kernels.Kernel):
         )
 
         os = self.outputscale
-        result = os[0] * torch.ones_like(base_kernels[0])
+        result = os[0] * torch.ones_like(base_kernels[0])  # constant term
         i = 1
         for idx in self.indices:
+            # compute each interaction term between specified kernels,
+            # that is, the product of the individual kernels scaled
+            # by the outputscale of the interaction
             result += os[i] * base_kernels[idx, ...].prod(dim=0)
             i += 1
 

--- a/bofire/kernels/aggregation.py
+++ b/bofire/kernels/aggregation.py
@@ -84,7 +84,7 @@ class PolynomialFeatureInteractionKernel(gpytorch.kernels.Kernel):
         diag: bool = False,
         last_dim_is_batch: bool = False,
     ) -> Tensor:
-        ks = torch.stack(
+        base_kernels = torch.stack(
             [
                 k(x1, x2, diag=diag, last_dim_is_batch=last_dim_is_batch).to_dense()
                 for k in self.kernels
@@ -93,11 +93,11 @@ class PolynomialFeatureInteractionKernel(gpytorch.kernels.Kernel):
         )
 
         os = self.outputscale
-        rr = torch.zeros_like(ks[0])
+        result = torch.zeros_like(base_kernels[0])
         i = 0
         for idx_n in self.indices:
-            for kk in idx_n:
-                rr += os[i] * ks[kk, ...].prod(dim=0)
+            for idx_k in idx_n:
+                result += os[i] * base_kernels[idx_k, ...].prod(dim=0)
                 i += 1
 
-        return rr
+        return result

--- a/bofire/kernels/mapper.py
+++ b/bofire/kernels/mapper.py
@@ -294,9 +294,9 @@ def map_PolynomialFeatureInteractionKernel(
         ks,
         max_degree=data_model.max_degree,
         include_self_interactions=data_model.include_self_interactions,
-        lengthscale_prior=(
-            priors.map(data_model.lengthscale_prior, d=len(active_dims))
-            if data_model.lengthscale_prior is not None
+        outputscale_prior=(
+            priors.map(data_model.outputscale_prior, d=len(active_dims))
+            if data_model.outputscale_prior is not None
             else None
         ),
     )

--- a/bofire/kernels/mapper.py
+++ b/bofire/kernels/mapper.py
@@ -9,6 +9,7 @@ from gpytorch.kernels import Kernel as GpytorchKernel
 
 import bofire.data_models.kernels.api as data_models
 import bofire.priors.api as priors
+from bofire.kernels.aggregation import PolynomialFeatureInteractionKernel
 from bofire.kernels.categorical import HammingKernelWithOneHots
 from bofire.kernels.fingerprint_kernels.tanimoto_kernel import TanimotoKernel
 from bofire.kernels.shape import WassersteinKernel
@@ -271,6 +272,36 @@ def map_WassersteinKernel(
     )
 
 
+def map_PolynomialFeatureInteractionKernel(
+    data_model: data_models.PolynomialFeatureInteractionKernel,
+    batch_shape: torch.Size,
+    ard_num_dims: int,
+    active_dims: List[int],
+    features_to_idx_mapper: Optional[Callable[[List[str]], List[int]]],
+) -> PolynomialFeatureInteractionKernel:
+    ks = [
+        map(
+            k,  # type: ignore
+            active_dims=active_dims,
+            ard_num_dims=ard_num_dims,
+            batch_shape=batch_shape,
+            features_to_idx_mapper=features_to_idx_mapper,
+        )
+        for k in data_model.kernels
+    ]
+
+    return PolynomialFeatureInteractionKernel(
+        ks,
+        max_degree=data_model.max_degree,
+        include_self_interactions=data_model.include_self_interactions,
+        lengthscale_prior=(
+            priors.map(data_model.lengthscale_prior, d=len(active_dims))
+            if data_model.lengthscale_prior is not None
+            else None
+        ),
+    )
+
+
 KERNEL_MAP = {
     data_models.WassersteinKernel: map_WassersteinKernel,
     data_models.RBFKernel: map_RBFKernel,
@@ -283,6 +314,7 @@ KERNEL_MAP = {
     data_models.TanimotoKernel: map_TanimotoKernel,
     data_models.HammingDistanceKernel: map_HammingDistanceKernel,
     data_models.InfiniteWidthBNNKernel: map_InfiniteWidthBNNKernel,
+    data_models.PolynomialFeatureInteractionKernel: map_PolynomialFeatureInteractionKernel,
 }
 
 

--- a/bofire/strategies/doe/objective.py
+++ b/bofire/strategies/doe/objective.py
@@ -250,9 +250,6 @@ class IOptimality(ModelBasedObjective):
             )
             bounds = nchoosek_constraints_as_bounds(domain, n_space_filling_points)
 
-            # import optional dependency only upon usage
-            from cyipopt import minimize_ipopt  # type: ignore
-
             result = minimize_ipopt(
                 objective.evaluate,
                 x0=x0,

--- a/bofire/strategies/doe/objective.py
+++ b/bofire/strategies/doe/objective.py
@@ -250,6 +250,9 @@ class IOptimality(ModelBasedObjective):
             )
             bounds = nchoosek_constraints_as_bounds(domain, n_space_filling_points)
 
+            # import optional dependency only upon usage
+            from cyipopt import minimize_ipopt  # type: ignore
+
             result = minimize_ipopt(
                 objective.evaluate,
                 x0=x0,

--- a/tests/bofire/data_models/specs/kernels.py
+++ b/tests/bofire/data_models/specs/kernels.py
@@ -111,6 +111,6 @@ specs.add_valid(
             specs.valid(kernels.LinearKernel).obj().model_dump(),
             specs.valid(kernels.MaternKernel).obj().model_dump(),
         ],
-        "lengthscale_prior": priors.valid(LogNormalPrior).obj().model_dump(),
+        "outputscale_prior": priors.valid(LogNormalPrior).obj().model_dump(),
     },
 )

--- a/tests/bofire/data_models/specs/kernels.py
+++ b/tests/bofire/data_models/specs/kernels.py
@@ -102,3 +102,15 @@ specs.add_valid(
         "features": None,
     },
 )
+specs.add_valid(
+    kernels.PolynomialFeatureInteractionKernel,
+    lambda: {
+        "max_degree": 2,
+        "include_self_interactions": False,
+        "kernels": [
+            specs.valid(kernels.LinearKernel).obj().model_dump(),
+            specs.valid(kernels.MaternKernel).obj().model_dump(),
+        ],
+        "lengthscale_prior": priors.valid(LogNormalPrior).obj().model_dump(),
+    },
+)

--- a/tests/bofire/kernels/test_aggregation.py
+++ b/tests/bofire/kernels/test_aggregation.py
@@ -1,0 +1,44 @@
+import itertools
+
+import pytest
+import torch
+from gpytorch.kernels import CosineKernel, MaternKernel, RBFKernel, ScaleKernel
+
+from bofire.kernels.aggregation import PolynomialFeatureInteractionKernel
+
+
+@pytest.mark.parametrize(
+    "include_self_interactions, diag, last_dim_is_batch",
+    list(itertools.product([True, False], repeat=3)),
+)
+def test_PolynomialFeatureInteractionKernel(
+    include_self_interactions, diag, last_dim_is_batch
+):
+    k1 = RBFKernel()
+    k2 = MaternKernel()
+    k3 = CosineKernel()
+
+    k_orig = (
+        ScaleKernel(k1)
+        + ScaleKernel(k2)
+        + ScaleKernel(k3)
+        + ScaleKernel(k1 * k2)
+        + ScaleKernel(k1 * k3)
+        + ScaleKernel(k2 * k3)
+    )
+    if include_self_interactions:
+        k_orig += ScaleKernel(k1 * k1) + ScaleKernel(k2 * k2) + ScaleKernel(k3 * k3)
+
+    k = PolynomialFeatureInteractionKernel(
+        [k1, k2, k3], max_degree=2, include_self_interactions=include_self_interactions
+    )
+
+    torch.manual_seed(0)
+    x1 = torch.randn(5, 10, 3)
+    x2 = torch.randn(5, 10, 3)
+
+    z1 = k_orig(x1, x2, diag=diag, last_dim_is_batch=last_dim_is_batch).to_dense()
+    z2 = k(x1, x2, diag=diag, last_dim_is_batch=last_dim_is_batch).to_dense()
+
+    assert z1.shape == z2.shape
+    assert torch.allclose(z1, z2, atol=1e-6)

--- a/tests/bofire/kernels/test_aggregation.py
+++ b/tests/bofire/kernels/test_aggregation.py
@@ -2,7 +2,13 @@ import itertools
 
 import pytest
 import torch
-from gpytorch.kernels import CosineKernel, MaternKernel, RBFKernel, ScaleKernel
+from gpytorch.kernels import (
+    ConstantKernel,
+    CosineKernel,
+    MaternKernel,
+    RBFKernel,
+    ScaleKernel,
+)
 
 from bofire.kernels.aggregation import PolynomialFeatureInteractionKernel
 
@@ -19,7 +25,8 @@ def test_PolynomialFeatureInteractionKernel(
     k3 = CosineKernel()
 
     k_orig = (
-        ScaleKernel(k1)
+        ConstantKernel()
+        + ScaleKernel(k1)
         + ScaleKernel(k2)
         + ScaleKernel(k3)
         + ScaleKernel(k1 * k2)

--- a/tests/bofire/kernels/test_mapper.py
+++ b/tests/bofire/kernels/test_mapper.py
@@ -456,7 +456,7 @@ def test_map_PolynomialFeatureInteractionKernel():
 
     assert isinstance(k, aggregationKernels.PolynomialFeatureInteractionKernel)
     assert k.indices == [[(0,), (1,)], [(0, 1)]]
-    assert k.outputscale.shape == (3,)
+    assert k.outputscale.shape == (4,)
 
     assert isinstance(k.kernels[0], gpytorch.kernels.RBFKernel)
     assert k.kernels[0].active_dims.tolist() == [1, 2]

--- a/tests/bofire/kernels/test_mapper.py
+++ b/tests/bofire/kernels/test_mapper.py
@@ -455,7 +455,7 @@ def test_map_PolynomialFeatureInteractionKernel():
     )
 
     assert isinstance(k, aggregationKernels.PolynomialFeatureInteractionKernel)
-    assert k.indices == [(0,), (1,), (0, 1)]
+    assert k.indices == [[(0,), (1,)], [(0, 1)]]
     assert k.lengthscale.shape == (3,)
 
     assert isinstance(k.kernels[0], gpytorch.kernels.RBFKernel)

--- a/tests/bofire/kernels/test_mapper.py
+++ b/tests/bofire/kernels/test_mapper.py
@@ -446,7 +446,7 @@ def test_map_PolynomialFeatureInteractionKernel():
             ],
             max_degree=2,
             include_self_interactions=False,
-            lengthscale_prior=GammaPrior(concentration=2.0, rate=0.15),
+            outputscale_prior=THREESIX_SCALE_PRIOR(),
         ),
         active_dims=[],
         ard_num_dims=1,
@@ -456,7 +456,7 @@ def test_map_PolynomialFeatureInteractionKernel():
 
     assert isinstance(k, aggregationKernels.PolynomialFeatureInteractionKernel)
     assert k.indices == [[(0,), (1,)], [(0, 1)]]
-    assert k.lengthscale.shape == (3,)
+    assert k.outputscale.shape == (3,)
 
     assert isinstance(k.kernels[0], gpytorch.kernels.RBFKernel)
     assert k.kernels[0].active_dims.tolist() == [1, 2]

--- a/tests/bofire/kernels/test_mapper.py
+++ b/tests/bofire/kernels/test_mapper.py
@@ -6,6 +6,7 @@ from botorch.models.kernels import InfiniteWidthBNNKernel as BNNKernel
 from botorch.models.kernels.categorical import CategoricalKernel
 
 import bofire
+import bofire.kernels.aggregation as aggregationKernels
 import bofire.kernels.api as kernels
 import bofire.kernels.shape as shapeKernels
 from bofire.data_models.kernels.api import (
@@ -40,6 +41,7 @@ EQUIVALENTS = {
     HammingDistanceKernel: CategoricalKernel,
     WassersteinKernel: shapeKernels.WassersteinKernel,
     InfiniteWidthBNNKernel: BNNKernel,
+    PolynomialFeatureInteractionKernel: aggregationKernels.PolynomialFeatureInteractionKernel,
 }
 
 
@@ -452,11 +454,7 @@ def test_map_PolynomialFeatureInteractionKernel():
         features_to_idx_mapper=lambda ks: [int(k[1:]) for k in ks],
     )
 
-    from bofire.kernels.aggregation import (
-        PolynomialFeatureInteractionKernel as RealKernel,
-    )
-
-    assert isinstance(k, RealKernel)
+    assert isinstance(k, aggregationKernels.PolynomialFeatureInteractionKernel)
     assert k.indices == [(0,), (1,), (0, 1)]
     assert k.lengthscale.shape == (3,)
 

--- a/tests/bofire/kernels/test_mapper.py
+++ b/tests/bofire/kernels/test_mapper.py
@@ -455,7 +455,7 @@ def test_map_PolynomialFeatureInteractionKernel():
     )
 
     assert isinstance(k, aggregationKernels.PolynomialFeatureInteractionKernel)
-    assert k.indices == [[(0,), (1,)], [(0, 1)]]
+    assert k.indices == [(0,), (1,), (0, 1)]
     assert k.outputscale.shape == (4,)
 
     assert isinstance(k.kernels[0], gpytorch.kernels.RBFKernel)


### PR DESCRIPTION
Hi, now that we have kernels that work only on subset of features, it would be nice to also combine these kernels to include interactions amongst them. This can be done already but it is a bit tedious for higher-order interactions and quite inefficient since the kernels would be re-computed multiple times with the same inputs.

Essentially one could now replace

```
k1 = RBFKernel(features=["x1", "x2"])
k2 = MaternKernel(features=["x2", "x3"])
k3 = HammingDistanceKernel(features=["x4", "x5"])

k = AdditiveKernel(kernels=[
    ScaleKernel(base_kernel=k1),
    ScaleKernel(base_kernel=k2),
    ScaleKernel(base_kernel=k3),
    ScaleKernel(base_kernel=MultiplicativeKernel(kernels=[k1, k2])),
    ScaleKernel(base_kernel=MultiplicativeKernel(kernels=[k1, k3])),
    ScaleKernel(base_kernel=MultiplicativeKernel(kernels=[k2, k3])),
])
```

with

```
k = PolynomialFeatureInteractionKernel(
    kernels=[k1, k2, k3],
    max_degree=2,
)
```
