### PR TITLE
Fix that BoFire is not working without cyipopt

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -38,6 +38,32 @@ jobs:
       - name: Run data model tests
         run: pytest tests/bofire/data_models
 
+  testing_optimization_only:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [ '3.12' ]
+    steps:
+      - name: Check out repo
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v2
+        with:
+          enable-cache: true
+
+      - name: Install Dependencies
+        run: uv pip install ".[optimization, tests]" --system
+
+      - name: Run tests
+        shell: bash -l {0}
+        run: pytest -ra --cov=bofire --cov-report term-missing tests
+
   testing:
     runs-on: ubuntu-latest
     strategy:

--- a/bofire/strategies/doe/design.py
+++ b/bofire/strategies/doe/design.py
@@ -61,12 +61,10 @@ def find_local_max_ipopt(
     # warn user if IPOPT scipy interface is not available
     try:
         from cyipopt import minimize_ipopt  # type: ignore
-    except ImportError as e:
-        warnings.warn(e.msg)
-        warnings.warn(
-            "please run `conda install -c conda-forge cyipopt` for this functionality.",
+    except ImportError:
+        raise ImportError(
+            "cyipopt is not installed. Install it via `conda install -c conda-forge cyipopt`"
         )
-        raise e
 
     objective_function = get_objective_function(
         criterion, domain=domain, n_experiments=n_experiments

--- a/bofire/strategies/doe/objective.py
+++ b/bofire/strategies/doe/objective.py
@@ -205,12 +205,10 @@ class IOptimality(ModelBasedObjective):
 
         try:
             from cyipopt import minimize_ipopt  # type: ignore
-        except ImportError as e:
-            warnings.warn(e.msg)
-            warnings.warn(
-                "please run `conda install -c conda-forge cyipopt` for this functionality.",
+        except ImportError:
+            raise ImportError(
+                "cyipopt is not installed. Install it via `conda install -c conda-forge cyipopt`"
             )
-            raise e
 
         if transform_range is not None:
             raise ValueError(

--- a/bofire/strategies/doe/objective.py
+++ b/bofire/strategies/doe/objective.py
@@ -7,7 +7,6 @@ from typing import Optional
 import numpy as np
 import pandas as pd
 import torch
-from cyipopt import minimize_ipopt  # type: ignore
 from formulaic import Formula
 from scipy.optimize._minimize import standardize_constraints
 from torch import Tensor
@@ -203,6 +202,15 @@ class IOptimality(ModelBasedObjective):
             ipopt_options (dict, optional): Options for the Ipopt solver to generate space filling point.
                 If None is provided, the default options (maxiter = 500) are used.
         """
+
+        try:
+            from cyipopt import minimize_ipopt  # type: ignore
+        except ImportError as e:
+            warnings.warn(e.msg)
+            warnings.warn(
+                "please run `conda install -c conda-forge cyipopt` for this functionality.",
+            )
+            raise e
 
         if transform_range is not None:
             raise ValueError(

--- a/tests/bofire/strategies/doe/test_objective.py
+++ b/tests/bofire/strategies/doe/test_objective.py
@@ -1,3 +1,5 @@
+import importlib
+
 import numpy as np
 import pandas as pd
 import pytest
@@ -30,12 +32,15 @@ from bofire.strategies.doe.objective import (
 from bofire.strategies.doe.utils import get_formula_from_string
 
 
+CYIPOPT_AVAILABLE = importlib.util.find_spec("cyipopt") is not None
+
+
 def test_Objective_model_jacobian_t():
     # "small" model
     domain = Domain.from_lists(
         inputs=[
             ContinuousInput(
-                key=f"x{i+1}",
+                key=f"x{i + 1}",
                 bounds=(0, 1),
             )
             for i in range(3)
@@ -98,7 +103,7 @@ def test_Objective_model_jacobian_t():
     domain = Domain.from_lists(
         inputs=[
             ContinuousInput(
-                key=f"x{i+1}",
+                key=f"x{i + 1}",
                 bounds=(0, 1),
             )
             for i in range(5)
@@ -383,7 +388,7 @@ def test_Objective_convert_input_to_model_tensor():
     domain = Domain.from_lists(
         inputs=[
             ContinuousInput(
-                key=f"x{i+1}",
+                key=f"x{i + 1}",
                 bounds=(0, 1),
             )
             for i in range(3)
@@ -404,7 +409,7 @@ def test_DOptimality_instantiation():
     domain = Domain.from_lists(
         inputs=[
             ContinuousInput(
-                key=f"x{i+1}",
+                key=f"x{i + 1}",
                 bounds=(0, 1),
             )
             for i in range(3)
@@ -451,7 +456,7 @@ def test_DOptimality_instantiation():
     domain = Domain.from_lists(
         inputs=[
             ContinuousInput(
-                key=f"x{i+1}",
+                key=f"x{i + 1}",
                 bounds=(0, 1),
             )
             for i in range(3)
@@ -487,7 +492,7 @@ def test_DOptimality_evaluate_jacobian():
     domain = Domain.from_lists(
         inputs=[
             ContinuousInput(
-                key=f"x{i+1}",
+                key=f"x{i + 1}",
                 bounds=(0, 1),
             )
             for i in range(2)
@@ -642,7 +647,7 @@ def test_DOptimality_evaluate():
     domain = Domain.from_lists(
         inputs=[
             ContinuousInput(
-                key=f"x{i+1}",
+                key=f"x{i + 1}",
                 bounds=(0, 1),
             )
             for i in range(3)
@@ -660,7 +665,7 @@ def test_AOptimality_evaluate():
     domain = Domain.from_lists(
         inputs=[
             ContinuousInput(
-                key=f"x{i+1}",
+                key=f"x{i + 1}",
                 bounds=(0, 1),
             )
             for i in range(3)
@@ -888,6 +893,7 @@ def test_MinMaxTransform():
             )
 
 
+@pytest.mark.skipif(not CYIPOPT_AVAILABLE, reason="requires cyipopt")
 def test_IOptimality_instantiation():
     # no constraints
     domain = Domain.from_lists(
@@ -906,7 +912,7 @@ def test_IOptimality_instantiation():
 
     # inequality constraints
     domain = Domain.from_lists(
-        inputs=[ContinuousInput(key=f"x{i+1}", bounds=(0, 1)) for i in range(2)],
+        inputs=[ContinuousInput(key=f"x{i + 1}", bounds=(0, 1)) for i in range(2)],
         outputs=[ContinuousOutput(key="y")],
         constraints=[
             LinearInequalityConstraint(
@@ -930,7 +936,7 @@ def test_IOptimality_instantiation():
 
     # equality constraints
     domain = Domain.from_lists(
-        inputs=[ContinuousInput(key=f"x{i+1}", bounds=(0, 1)) for i in range(2)],
+        inputs=[ContinuousInput(key=f"x{i + 1}", bounds=(0, 1)) for i in range(2)],
         outputs=[ContinuousOutput(key="y")],
         constraints=[
             LinearEqualityConstraint(features=["x1", "x2"], coefficients=[1, 1], rhs=1)

--- a/tests/bofire/strategies/doe/test_objective.py
+++ b/tests/bofire/strategies/doe/test_objective.py
@@ -808,6 +808,7 @@ def test_SpaceFilling_evaluate_jacobian():
     assert np.allclose(space_filling.evaluate_jacobian(x), [-1, -1, 2, 0])
 
 
+@pytest.mark.skipif(not CYIPOPT_AVAILABLE, reason="requires cyipopt")
 def test_MinMaxTransform():
     domain = Domain.from_lists(
         inputs=[ContinuousInput(key="x1", bounds=(0, 1))],

--- a/tests/bofire/surrogates/test_gps.py
+++ b/tests/bofire/surrogates/test_gps.py
@@ -337,6 +337,7 @@ def test_SingleTaskGPModel_feature_subsets():
     assert gp_mapped.model.covar_module.kernels[1].active_dims.tolist() == [2, 3, 4, 5]
 
 
+@pytest.mark.skipif(not RDKIT_AVAILABLE, reason="requires rdkit")
 def test_SingleTaskGPModel_mixed_features():
     """test that we can use a single task gp with mixed features"""
     inputs = Inputs(
@@ -542,6 +543,7 @@ def test_MixedSingleTaskGPModel(kernel, scaler, output_scaler):
     assert_frame_equal(preds, preds2)
 
 
+@pytest.mark.skipif(not RDKIT_AVAILABLE, reason="requires rdkit")
 @pytest.mark.parametrize(
     "kernel, scaler, output_scaler",
     [

--- a/tests/bofire/surrogates/test_gps.py
+++ b/tests/bofire/surrogates/test_gps.py
@@ -79,7 +79,7 @@ def test_SingleTaskGPModel(kernel, scaler, output_scaler):
     inputs = Inputs(
         features=[
             ContinuousInput(
-                key=f"x_{i+1}",
+                key=f"x_{i + 1}",
                 bounds=(-4, 4),
             )
             for i in range(2)
@@ -136,6 +136,7 @@ def test_SingleTaskGPModel(kernel, scaler, output_scaler):
     assert_frame_equal(preds, preds2)
 
 
+@pytest.mark.skipif(not RDKIT_AVAILABLE, reason="requires rdkit")
 @pytest.mark.parametrize(
     "kernel, scaler, output_scaler",
     [
@@ -400,7 +401,7 @@ def test_MixedSingleTaskGPHyperconfig():
     inputs = Inputs(
         features=[
             ContinuousInput(
-                key=f"x_{i+1}",
+                key=f"x_{i + 1}",
                 bounds=(-4, 4),
             )
             for i in range(2)
@@ -440,7 +441,7 @@ def test_MixedSingleTaskGPModel_invalid_preprocessing():
     inputs = Inputs(
         features=[
             ContinuousInput(
-                key=f"x_{i+1}",
+                key=f"x_{i + 1}",
                 bounds=(-4, 4),
             )
             for i in range(2)
@@ -469,7 +470,7 @@ def test_MixedSingleTaskGPModel(kernel, scaler, output_scaler):
     inputs = Inputs(
         features=[
             ContinuousInput(
-                key=f"x_{i+1}",
+                key=f"x_{i + 1}",
                 bounds=(-4, 4),
             )
             for i in range(2)

--- a/tests/bofire/surrogates/test_utils.py
+++ b/tests/bofire/surrogates/test_utils.py
@@ -133,7 +133,7 @@ def test_get_scaler(
     inputs = Inputs(
         features=[
             ContinuousInput(
-                key=f"x_{i+1}",
+                key=f"x_{i + 1}",
                 bounds=(-4, 4),
             )
             for i in range(2)
@@ -171,6 +171,7 @@ def test_get_scaler(
             assert (scaler.coefficient == expected_coefficient).all()
 
 
+@pytest.mark.skipif(not RDKIT_AVAILABLE, reason="requires rdkit")
 @pytest.mark.parametrize(
     "scaler_enum, input_preprocessing_specs, expected_scaler, expected_indices",
     [
@@ -233,7 +234,7 @@ def test_get_scaler_molecular(
     inputs = Inputs(
         features=[
             ContinuousInput(
-                key=f"x_{i+1}",
+                key=f"x_{i + 1}",
                 bounds=(0, 5),
             )
             for i in range(2)


### PR DESCRIPTION
@jkeupp reported that the current BoFire version on pypi is not working when cyipopt is not installed. The reason is that cyipopt is used in the instantiation of I-optimal criterion and that we do not guard the import there. This PR fixes it and adds a test where we just install the optimization package of BoFire to prevent it in the future.

After having this in, we should also make a release.

cc: @Osburg @dlinzner-bcs @bertiqwerty 