### PR TITLE
Make pyright a seperate test job

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -32,11 +32,6 @@ jobs:
       - name: Run pre-commit
         run: pre-commit run --all-files --show-diff-on-failure
 
-      - name: Pyright
-        uses: jakebailey/pyright-action@v2
-        with:
-          version: 1.1.305  # is there any reason not to use the latest?
-
   types:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -36,3 +36,27 @@ jobs:
         uses: jakebailey/pyright-action@v2
         with:
           version: 1.1.305  # is there any reason not to use the latest?
+
+  types:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repo
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v2
+        with:
+          enable-cache: true
+
+      - name: Install dependencies
+        run: uv pip install pre-commit ".[all]" --system
+
+      - name: Pyright
+        uses: jakebailey/pyright-action@v2
+        with:
+          version: 1.1.305  # is there any reason not to use the latest?

--- a/bofire/plot/api.py
+++ b/bofire/plot/api.py
@@ -1,5 +1,5 @@
 from bofire.plot.duplicates import plot_duplicates_plotly
 from bofire.plot.feature_importance import plot_feature_importance_by_feature_plotly
+from bofire.plot.gp_slice import plot_gp_slice_plotly
 from bofire.plot.objective import plot_objective_plotly
 from bofire.plot.prior import plot_prior_pdf_plotly
-from bofire.plot.gp_slice import plot_gp_slice_plotly

--- a/bofire/plot/gp_slice.py
+++ b/bofire/plot/gp_slice.py
@@ -1,12 +1,12 @@
-from typing import Optional, List, Tuple
-
-from bofire.data_models.surrogates.api import SingleTaskGPSurrogate
-from bofire.data_models.features.api import ContinuousInput, ContinuousOutput
+from typing import List, Optional, Tuple
 
 import numpy as np
 import pandas as pd
-
 import plotly.graph_objects as go
+
+from bofire.data_models.features.api import ContinuousInput, ContinuousOutput
+from bofire.data_models.surrogates.api import SingleTaskGPSurrogate
+
 
 def _create_contour_slice(
     X: np.ndarray,
@@ -21,29 +21,31 @@ def _create_contour_slice(
     fixed_values: List[float],
     input_features: List[ContinuousInput],
     output_feature: ContinuousOutput,
-    observed_data: Optional[pd.DataFrame] = None
+    observed_data: Optional[pd.DataFrame] = None,
 ) -> go.Figure:
     fig = go.Figure()
 
     # plot the contour plot
-    fig.add_trace(go.Contour(
-        x=X.flatten(),
-        y=Y.flatten(),
-        z=Z,
-        zmin=zmin,
-        zmax=zmax,
-        colorscale='Viridis',
-        showscale=True,
-        opacity=0.8,
-        contours=dict(
-            showlabels=True,
-            labelfont=dict(
-                family='Raleway',
-                size=12,
-                color='white',
-            )
-        ),
-    ))
+    fig.add_trace(
+        go.Contour(
+            x=X.flatten(),
+            y=Y.flatten(),
+            z=Z,
+            zmin=zmin,
+            zmax=zmax,
+            colorscale="Viridis",
+            showscale=True,
+            opacity=0.8,
+            contours={
+                "showlabels": True,
+                "labelfont": {
+                    "family": "Raleway",
+                    "size": 12,
+                    "color": "white",
+                },
+            },
+        )
+    )
 
     # add datapoints in and out of the slice if observed data is provided
     if observed_data is not None:
@@ -52,52 +54,72 @@ def _create_contour_slice(
         mask = mask.all(axis=1)
         observed_data_in_slice = observed_data[mask]
 
-        fig.add_trace(go.Scatter(
-            x=observed_data_in_slice[input_features[0].key],
-            y=observed_data_in_slice[input_features[1].key],
-            mode='markers',
-            marker=dict(
-                size=8,
-                color='red',
-                symbol='circle-open'
-            ),
-            name='Observed data in slice',
-            showlegend=True,
-            hoverinfo='text',
-            text=[f"Index: {index}<br>" + "<br>".join([f"{key}: {row[key]}" for key in fixed_input_keys]) +
-                  f"<br>{input_features[0].key}: {row[input_features[0].key]}<br>{input_features[1].key}: {row[input_features[1].key]}<br>{output_feature.key}: {row[output_feature.key]}" for index, row in observed_data_in_slice.iterrows()]
-        ))
+        fig.add_trace(
+            go.Scatter(
+                x=observed_data_in_slice[input_features[0].key],
+                y=observed_data_in_slice[input_features[1].key],
+                mode="markers",
+                marker={"size": 8, "color": "red", "symbol": "circle-open"},
+                name="Observed data in slice",
+                showlegend=True,
+                hoverinfo="text",
+                text=[
+                    f"Index: {index}<br>"
+                    + "<br>".join([f"{key}: {row[key]}" for key in fixed_input_keys])
+                    + f"<br>{input_features[0].key}: {row[input_features[0].key]}<br>{input_features[1].key}: {row[input_features[1].key]}<br>{output_feature.key}: {row[output_feature.key]}"
+                    for index, row in observed_data_in_slice.iterrows()
+                ],
+            )
+        )
 
         observed_data_not_in_slice = observed_data[~mask]
 
-        fig.add_trace(go.Scatter(
-            x=observed_data_not_in_slice[input_features[0].key],
-            y=observed_data_not_in_slice[input_features[1].key],
-            mode='markers',
-            marker=dict(
-                size=8,
-                color=observed_data_not_in_slice[output_feature.key],
-                cmin=zmin,
-                cmax=zmax,
-                colorscale='Viridis',
-                symbol='cross'
-            ),
-            name='Observed data not in slice',
-            showlegend=True,
-            hoverinfo='text',
-            text=[
-                f"Index: {index}<br>" + "<br>".join([f"{key}: {row[key]}" for key in fixed_input_keys]) +
-                f"<br>{input_features[0].key}: {row[input_features[0].key]}<br>{input_features[1].key}: {row[input_features[1].key]}<br>{output_feature.key}: {row[output_feature.key]}"
-                for index, row in observed_data_not_in_slice.iterrows()
-            ]
-        ))
+        fig.add_trace(
+            go.Scatter(
+                x=observed_data_not_in_slice[input_features[0].key],
+                y=observed_data_not_in_slice[input_features[1].key],
+                mode="markers",
+                marker={
+                    "size": 8,
+                    "color": observed_data_not_in_slice[output_feature.key],
+                    "cmin": zmin,
+                    "cmax": zmax,
+                    "colorscale": "Viridis",
+                    "symbol": "cross",
+                },
+                name="Observed data not in slice",
+                showlegend=True,
+                hoverinfo="text",
+                text=[
+                    f"Index: {index}<br>"
+                    + "<br>".join([f"{key}: {row[key]}" for key in fixed_input_keys])
+                    + f"<br>{input_features[0].key}: {row[input_features[0].key]}<br>{input_features[1].key}: {row[input_features[1].key]}<br>{output_feature.key}: {row[output_feature.key]}"
+                    for index, row in observed_data_not_in_slice.iterrows()
+                ],
+            )
+        )
 
     # set the axis labels and title
-    fig.update_xaxes(title_text=xaxis_title, range=[X.min() - 0.01 * (X.max() - X.min()), X.max() + 0.01 * (X.max() - X.min())])
-    fig.update_yaxes(title_text=yaxis_title, range=[Y.min() - 0.01 * (Y.max() - Y.min()), Y.max() + 0.01 * (Y.max() - Y.min())])
-    fig.update_layout(title=title, legend=dict(yanchor="top", y=-0.2, xanchor="left", x=0.01))
+    fig.update_xaxes(
+        title_text=xaxis_title,
+        range=[
+            X.min() - 0.01 * (X.max() - X.min()),
+            X.max() + 0.01 * (X.max() - X.min()),
+        ],
+    )
+    fig.update_yaxes(
+        title_text=yaxis_title,
+        range=[
+            Y.min() - 0.01 * (Y.max() - Y.min()),
+            Y.max() + 0.01 * (Y.max() - Y.min()),
+        ],
+    )
+    fig.update_layout(
+        title=title, legend={"yanchor": "top", "y": -0.2, "xanchor": "left", "x": 0.01}
+    )
 
     return fig
+
 
 def plot_gp_slice_plotly(
     surrogate: SingleTaskGPSurrogate,
@@ -130,41 +152,60 @@ def plot_gp_slice_plotly(
     # Raise a Valuerror if there are more than two input features
     if len(varied_input_features) != 2:
         raise ValueError("This function requires two input features.")
-    
+
     # Raise a value error if fixed_values and fixed_input_features do not have the same length
     if len(fixed_values) != len(fixed_input_features):
-        raise ValueError("The length of fixed_values and fixed_input_features should be the same.")
-    
+        raise ValueError(
+            "The length of fixed_values and fixed_input_features should be the same."
+        )
+
     # check if input features are in the model
     for feature in fixed_input_features + varied_input_features:
         if feature not in surrogate.inputs.features:
             raise ValueError(f"Input feature {feature.key} not in model")
-        
+
     # check if output feature is in the model
     if output_feature not in surrogate.outputs.features:
         raise ValueError(f"Output feature {output_feature} not in model")
-    
+
     # check if the in and output features keys are in the observed data
     if observed_data is not None:
         for feature in fixed_input_features + varied_input_features + [output_feature]:
             if feature.key not in observed_data.columns:
                 raise ValueError(f"Feature {feature.key} not in observed data")
-    
+
     fixed_input_keys = [inp.key for inp in fixed_input_features]
-    
-    x1 = np.linspace(varied_input_features[0].bounds[0], varied_input_features[0].bounds[1], resolution)
-    x2 = np.linspace(varied_input_features[1].bounds[0], varied_input_features[1].bounds[1], resolution)
+
+    x1 = np.linspace(
+        varied_input_features[0].bounds[0],
+        varied_input_features[0].bounds[1],
+        resolution,
+    )
+    x2 = np.linspace(
+        varied_input_features[1].bounds[0],
+        varied_input_features[1].bounds[1],
+        resolution,
+    )
 
     X, Y = np.meshgrid(x1, x2)
 
-    samples = pd.DataFrame({varied_input_features[0].key: X.flatten(), varied_input_features[1].key: Y.flatten()}, index=range(resolution**2))
-    rows = pd.DataFrame([pd.Series(index=[inp.key for inp in fixed_input_features], data=fixed_values)], index=range(resolution**2))
+    samples = pd.DataFrame(
+        {
+            varied_input_features[0].key: X.flatten(),
+            varied_input_features[1].key: Y.flatten(),
+        },
+        index=range(resolution**2),
+    )
+    rows = pd.DataFrame(
+        [pd.Series(index=[inp.key for inp in fixed_input_features], data=fixed_values)],
+        index=range(resolution**2),
+    )
     samples = pd.concat([samples, rows], axis=1)
 
     y = surrogate.predict(samples)
     output_pred = y[f"{output_feature.key}_pred"]
     output_sd = y[f"{output_feature.key}_sd"]
-    
+
     if observed_data is not None:
         output_min = min(output_pred.min(), observed_data[output_feature.key].min())
         output_max = max(output_pred.max(), observed_data[output_feature.key].max())
@@ -172,10 +213,44 @@ def plot_gp_slice_plotly(
         output_min = output_pred.min()
         output_max = output_pred.max()
 
-    title_mean = f"{output_feature.key} slice with fixed features: " + ", ".join([f"{key}={value:.2f}" for key, value in zip(fixed_input_keys, fixed_values)])
-    fig_mean = _create_contour_slice(X, Y, output_pred, output_min, output_max, title_mean, varied_input_features[0].key, varied_input_features[1].key, fixed_input_features, fixed_values, varied_input_features, output_feature, observed_data)
+    title_mean = f"{output_feature.key} slice with fixed features: " + ", ".join(
+        [f"{key}={value:.2f}" for key, value in zip(fixed_input_keys, fixed_values)]
+    )
+    fig_mean = _create_contour_slice(
+        X,
+        Y,
+        output_pred,
+        output_min,
+        output_max,
+        title_mean,
+        varied_input_features[0].key,
+        varied_input_features[1].key,
+        fixed_input_features,
+        fixed_values,
+        varied_input_features,
+        output_feature,
+        observed_data,
+    )
 
-    title_sd = f"{output_feature.key} standard deviation slice with fixed features: " + ", ".join([f"{key}={value:.2f}" for key, value in zip(fixed_input_keys, fixed_values)])
-    fig_sd = _create_contour_slice(X, Y, output_sd, 0, output_sd.max(), title_sd, varied_input_features[0].key, varied_input_features[1].key, fixed_input_features, fixed_values, varied_input_features, output_feature)
+    title_sd = (
+        f"{output_feature.key} standard deviation slice with fixed features: "
+        + ", ".join(
+            [f"{key}={value:.2f}" for key, value in zip(fixed_input_keys, fixed_values)]
+        )
+    )
+    fig_sd = _create_contour_slice(
+        X,
+        Y,
+        output_sd,
+        0,
+        output_sd.max(),
+        title_sd,
+        varied_input_features[0].key,
+        varied_input_features[1].key,
+        fixed_input_features,
+        fixed_values,
+        varied_input_features,
+        output_feature,
+    )
 
     return fig_mean, fig_sd


### PR DESCRIPTION
As discussed in issue https://github.com/experimental-design/bofire/issues/503, we have currently problems with pyright that leads to fails in the linting pipeline, so we currently ignore the linting pipeline when looking at PRs, which is not good, because one does not see on the first glance if there are maybe also problems with ruff etc. 

This PR makes pyright a seperate pipeline job so that one sees if there are other issues.