### PR TITLE
nonlinear constraints without torch

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -33,7 +33,7 @@ jobs:
           enable-cache: true
 
       - name: Install Dependencies
-        run: uv pip install ".[optimization]" pytest --system
+        run: uv pip install "." pytest --system
 
       - name: Run data model tests
         run: pytest tests/bofire/data_models

--- a/tests/bofire/data_models/constraints/test_constraint_fulfillment.py
+++ b/tests/bofire/data_models/constraints/test_constraint_fulfillment.py
@@ -1,3 +1,5 @@
+import importlib
+import importlib.util
 from typing import List
 
 import pandas as pd
@@ -26,44 +28,265 @@ def get_row(features, value: float = None, values: List[float] = None):
     return pd.DataFrame.from_dict([dict(zip(features, values))])
 
 
-@pytest.mark.parametrize(
-    "df, constraint, fulfilled",
-    [
-        (
-            get_row(F[:4], 1),
-            NonlinearEqualityConstraint(
-                expression="f1 + f2 + f3 + f4 -4",
-            ),
-            True,
+TORCH_AVAILABLE = importlib.util.find_spec("torch") is not None
+parameters = [
+    (
+        get_row(F[:4], 1),
+        NonlinearEqualityConstraint(
+            expression="f1 + f2 + f3 + f4 -4",
         ),
-        (
-            get_row(F[:4], 1),
-            NonlinearEqualityConstraint(
-                expression=lambda f1, f2, f3, f4: f1 + f2 + f3 + f4 - 4,
-            ),
-            True,
+        True,
+    ),
+    (
+        get_row(F[:4], 1),
+        NonlinearEqualityConstraint(
+            expression="f1 + f2 + f3 + f4 -3",
         ),
-        (
-            get_row(F[:4], 1),
-            NonlinearEqualityConstraint(
-                expression="f1 + f2 + f3 + f4 -3",
-            ),
-            False,
+        False,
+    ),
+    (
+        get_row(F[:4], 1),
+        NonlinearInequalityConstraint(
+            expression="f1 + f2 + f3 + f4 -5",
         ),
-        (
-            get_row(F[:4], 1),
-            NonlinearInequalityConstraint(
-                expression="f1 + f2 + f3 + f4 -5",
-            ),
-            True,
+        True,
+    ),
+    (
+        get_row(F[:4], 1),
+        NonlinearInequalityConstraint(
+            expression="f1 + f2 + f3 + f4 -2",
         ),
-        (
-            get_row(F[:4], 1),
-            NonlinearInequalityConstraint(
-                expression="f1 + f2 + f3 + f4 -2",
-            ),
-            False,
+        False,
+    ),
+    (
+        get_row(F[:4], 1),
+        LinearEqualityConstraint(features=F[:4], coefficients=C[:4], rhs=10),
+        True,
+    ),
+    (
+        pd.concat([get_row(F[:4], 1), get_row(F[:4], 1)], ignore_index=True),
+        LinearEqualityConstraint(features=F[:4], coefficients=C[:4], rhs=10),
+        True,
+    ),
+    (
+        pd.concat([get_row(F[:4], 1), get_row(F[:4], 2)]),
+        LinearEqualityConstraint(features=F[:4], coefficients=C[:4], rhs=10),
+        False,
+    ),
+    (
+        get_row(F[:4], 2),
+        LinearEqualityConstraint(features=F[:4], coefficients=C[:4], rhs=20),
+        True,
+    ),
+    (
+        get_row(F[:10], 1),
+        LinearEqualityConstraint(features=F[:10], coefficients=C[:10], rhs=55.001),
+        False,
+    ),
+    (
+        get_row(F[:10], 1),
+        LinearEqualityConstraint(features=F[:10], coefficients=C[:10], rhs=54.999),
+        False,
+    ),
+    (
+        get_row(F[:3], 1),
+        LinearInequalityConstraint.from_greater_equal(
+            features=F[:3],
+            coefficients=C[:3],
+            rhs=6,
         ),
+        True,
+    ),
+    (
+        pd.concat([get_row(F[:3], 1), get_row(F[:3], 1), get_row(F[:3], 2)]),
+        LinearInequalityConstraint.from_greater_equal(
+            features=F[:3],
+            coefficients=C[:3],
+            rhs=6,
+        ),
+        True,
+    ),
+    (
+        pd.concat([get_row(F[:3], 1), get_row(F[:3], 0.5)]),
+        LinearInequalityConstraint.from_greater_equal(
+            features=F[:3],
+            coefficients=C[:3],
+            rhs=6,
+        ),
+        False,
+    ),
+    (
+        get_row(F[:3], 1),
+        LinearInequalityConstraint.from_greater_equal(
+            features=F[:3],
+            coefficients=C[:3],
+            rhs=2,
+        ),
+        True,
+    ),
+    (
+        get_row(F[:3], 1),
+        LinearInequalityConstraint.from_greater_equal(
+            features=F[:3],
+            coefficients=C[:3],
+            rhs=6.001,
+        ),
+        False,
+    ),
+    (
+        get_row(F[:3], values=[1, 1, 1]),
+        NChooseKConstraint(
+            features=F[:3],
+            min_count=0,
+            max_count=3,
+            none_also_valid=True,
+        ),
+        True,
+    ),
+    (
+        pd.concat(
+            [get_row(F[:3], values=[1, 1, 1]), get_row(F[:3], values=[1, 1, 1])],
+        ),
+        NChooseKConstraint(
+            features=F[:3],
+            min_count=0,
+            max_count=3,
+            none_also_valid=True,
+        ),
+        True,
+    ),
+    (
+        get_row(F[:3], values=[0, 2, 3]),
+        NChooseKConstraint(
+            features=F[:3],
+            min_count=2,
+            max_count=3,
+            none_also_valid=False,
+        ),
+        True,
+    ),
+    (
+        get_row(F[:3], values=[1, 2, 3]),
+        NChooseKConstraint(
+            features=F[:3],
+            min_count=2,
+            max_count=2,
+            none_also_valid=False,
+        ),
+        False,
+    ),
+    (
+        get_row(F[:3], values=[0, 0, 3]),
+        NChooseKConstraint(
+            features=F[:3],
+            min_count=2,
+            max_count=3,
+            none_also_valid=False,
+        ),
+        False,
+    ),
+    (
+        get_row(F[:3], values=[0, 0, 0]),
+        NChooseKConstraint(
+            features=F[:3],
+            min_count=2,
+            max_count=3,
+            none_also_valid=False,
+        ),
+        False,
+    ),
+    (
+        get_row(F[:3], values=[0, 0, 0]),
+        NChooseKConstraint(
+            features=F[:3],
+            min_count=2,
+            max_count=3,
+            none_also_valid=True,
+        ),
+        True,
+    ),
+    (
+        pd.concat(
+            [get_row(F[:3], values=[0, 2, 3]), get_row(F[:3], values=[0, 0, 0])],
+        ),
+        NChooseKConstraint(
+            features=F[:3],
+            min_count=2,
+            max_count=2,
+            none_also_valid=False,
+        ),
+        False,
+    ),
+    (
+        pd.concat(
+            [get_row(F[:3], values=[0, 2, 3]), get_row(F[:3], values=[0, 0, 0])],
+        ),
+        NChooseKConstraint(
+            features=F[:3],
+            min_count=2,
+            max_count=2,
+            none_also_valid=True,
+        ),
+        True,
+    ),
+    (
+        pd.DataFrame({"a": [1.0, 1.0, 1.0], "b": [1.0, 2.0, 3.0]}),
+        InterpointEqualityConstraint(feature="a"),
+        True,
+    ),
+    (
+        pd.DataFrame({"a": [1.0, 1.0, 2.0], "b": [1.0, 2.0, 3.0]}),
+        InterpointEqualityConstraint(feature="a"),
+        False,
+    ),
+    (
+        pd.DataFrame({"a": [1.0, 1.0, 2.0, 2.0], "b": [1.0, 2.0, 3.0, 4.0]}),
+        InterpointEqualityConstraint(feature="a", multiplicity=2),
+        True,
+    ),
+    (
+        pd.DataFrame(
+            {"a": [1.0, 1.0, 2.0, 2.0, 3.0], "b": [1.0, 2.0, 3.0, 4.0, 5.0]},
+        ),
+        InterpointEqualityConstraint(feature="a", multiplicity=2),
+        True,
+    ),
+    (
+        pd.DataFrame(
+            {"a": [1.0, 1.0, 2.0, 3.0, 3.0], "b": [1.0, 2.0, 3.0, 4.0, 5.0]},
+        ),
+        InterpointEqualityConstraint(feature="a", multiplicity=2),
+        False,
+    ),
+    (
+        pd.DataFrame({"a": [2.0, 3.0], "b": [3.0, 2.0]}),
+        ProductEqualityConstraint(features=["a", "b"], exponents=[1, 1], rhs=6),
+        True,
+    ),
+    (
+        pd.DataFrame({"a": [2.0, 3.0], "b": [3.0, 3.0]}),
+        ProductEqualityConstraint(features=["a", "b"], exponents=[1, 1], rhs=6),
+        False,
+    ),
+    (
+        pd.DataFrame({"a": [2.0, 3.0], "b": [3.0, 2.0]}),
+        ProductInequalityConstraint(features=["a", "b"], exponents=[2, 1], rhs=18),
+        True,
+    ),
+    (
+        pd.DataFrame({"a": [2.0, 3.0], "b": [3.0, 2.0]}),
+        ProductInequalityConstraint(
+            features=["a", "b"],
+            exponents=[2, 1],
+            rhs=-18,
+            sign=-1,
+        ),
+        False,
+    ),
+]
+
+if TORCH_AVAILABLE:
+    parameters += [
         (
             get_row(F[:4], 1),
             NonlinearInequalityConstraint(
@@ -73,230 +296,14 @@ def get_row(features, value: float = None, values: List[float] = None):
         ),
         (
             get_row(F[:4], 1),
-            LinearEqualityConstraint(features=F[:4], coefficients=C[:4], rhs=10),
-            True,
-        ),
-        (
-            pd.concat([get_row(F[:4], 1), get_row(F[:4], 1)], ignore_index=True),
-            LinearEqualityConstraint(features=F[:4], coefficients=C[:4], rhs=10),
-            True,
-        ),
-        (
-            pd.concat([get_row(F[:4], 1), get_row(F[:4], 2)]),
-            LinearEqualityConstraint(features=F[:4], coefficients=C[:4], rhs=10),
-            False,
-        ),
-        (
-            get_row(F[:4], 2),
-            LinearEqualityConstraint(features=F[:4], coefficients=C[:4], rhs=20),
-            True,
-        ),
-        (
-            get_row(F[:10], 1),
-            LinearEqualityConstraint(features=F[:10], coefficients=C[:10], rhs=55.001),
-            False,
-        ),
-        (
-            get_row(F[:10], 1),
-            LinearEqualityConstraint(features=F[:10], coefficients=C[:10], rhs=54.999),
-            False,
-        ),
-        (
-            get_row(F[:3], 1),
-            LinearInequalityConstraint.from_greater_equal(
-                features=F[:3],
-                coefficients=C[:3],
-                rhs=6,
+            NonlinearEqualityConstraint(
+                expression=lambda f1, f2, f3, f4: f1 + f2 + f3 + f4 - 4,
             ),
             True,
         ),
-        (
-            pd.concat([get_row(F[:3], 1), get_row(F[:3], 1), get_row(F[:3], 2)]),
-            LinearInequalityConstraint.from_greater_equal(
-                features=F[:3],
-                coefficients=C[:3],
-                rhs=6,
-            ),
-            True,
-        ),
-        (
-            pd.concat([get_row(F[:3], 1), get_row(F[:3], 0.5)]),
-            LinearInequalityConstraint.from_greater_equal(
-                features=F[:3],
-                coefficients=C[:3],
-                rhs=6,
-            ),
-            False,
-        ),
-        (
-            get_row(F[:3], 1),
-            LinearInequalityConstraint.from_greater_equal(
-                features=F[:3],
-                coefficients=C[:3],
-                rhs=2,
-            ),
-            True,
-        ),
-        (
-            get_row(F[:3], 1),
-            LinearInequalityConstraint.from_greater_equal(
-                features=F[:3],
-                coefficients=C[:3],
-                rhs=6.001,
-            ),
-            False,
-        ),
-        (
-            get_row(F[:3], values=[1, 1, 1]),
-            NChooseKConstraint(
-                features=F[:3],
-                min_count=0,
-                max_count=3,
-                none_also_valid=True,
-            ),
-            True,
-        ),
-        (
-            pd.concat(
-                [get_row(F[:3], values=[1, 1, 1]), get_row(F[:3], values=[1, 1, 1])],
-            ),
-            NChooseKConstraint(
-                features=F[:3],
-                min_count=0,
-                max_count=3,
-                none_also_valid=True,
-            ),
-            True,
-        ),
-        (
-            get_row(F[:3], values=[0, 2, 3]),
-            NChooseKConstraint(
-                features=F[:3],
-                min_count=2,
-                max_count=3,
-                none_also_valid=False,
-            ),
-            True,
-        ),
-        (
-            get_row(F[:3], values=[1, 2, 3]),
-            NChooseKConstraint(
-                features=F[:3],
-                min_count=2,
-                max_count=2,
-                none_also_valid=False,
-            ),
-            False,
-        ),
-        (
-            get_row(F[:3], values=[0, 0, 3]),
-            NChooseKConstraint(
-                features=F[:3],
-                min_count=2,
-                max_count=3,
-                none_also_valid=False,
-            ),
-            False,
-        ),
-        (
-            get_row(F[:3], values=[0, 0, 0]),
-            NChooseKConstraint(
-                features=F[:3],
-                min_count=2,
-                max_count=3,
-                none_also_valid=False,
-            ),
-            False,
-        ),
-        (
-            get_row(F[:3], values=[0, 0, 0]),
-            NChooseKConstraint(
-                features=F[:3],
-                min_count=2,
-                max_count=3,
-                none_also_valid=True,
-            ),
-            True,
-        ),
-        (
-            pd.concat(
-                [get_row(F[:3], values=[0, 2, 3]), get_row(F[:3], values=[0, 0, 0])],
-            ),
-            NChooseKConstraint(
-                features=F[:3],
-                min_count=2,
-                max_count=2,
-                none_also_valid=False,
-            ),
-            False,
-        ),
-        (
-            pd.concat(
-                [get_row(F[:3], values=[0, 2, 3]), get_row(F[:3], values=[0, 0, 0])],
-            ),
-            NChooseKConstraint(
-                features=F[:3],
-                min_count=2,
-                max_count=2,
-                none_also_valid=True,
-            ),
-            True,
-        ),
-        (
-            pd.DataFrame({"a": [1.0, 1.0, 1.0], "b": [1.0, 2.0, 3.0]}),
-            InterpointEqualityConstraint(feature="a"),
-            True,
-        ),
-        (
-            pd.DataFrame({"a": [1.0, 1.0, 2.0], "b": [1.0, 2.0, 3.0]}),
-            InterpointEqualityConstraint(feature="a"),
-            False,
-        ),
-        (
-            pd.DataFrame({"a": [1.0, 1.0, 2.0, 2.0], "b": [1.0, 2.0, 3.0, 4.0]}),
-            InterpointEqualityConstraint(feature="a", multiplicity=2),
-            True,
-        ),
-        (
-            pd.DataFrame(
-                {"a": [1.0, 1.0, 2.0, 2.0, 3.0], "b": [1.0, 2.0, 3.0, 4.0, 5.0]},
-            ),
-            InterpointEqualityConstraint(feature="a", multiplicity=2),
-            True,
-        ),
-        (
-            pd.DataFrame(
-                {"a": [1.0, 1.0, 2.0, 3.0, 3.0], "b": [1.0, 2.0, 3.0, 4.0, 5.0]},
-            ),
-            InterpointEqualityConstraint(feature="a", multiplicity=2),
-            False,
-        ),
-        (
-            pd.DataFrame({"a": [2.0, 3.0], "b": [3.0, 2.0]}),
-            ProductEqualityConstraint(features=["a", "b"], exponents=[1, 1], rhs=6),
-            True,
-        ),
-        (
-            pd.DataFrame({"a": [2.0, 3.0], "b": [3.0, 3.0]}),
-            ProductEqualityConstraint(features=["a", "b"], exponents=[1, 1], rhs=6),
-            False,
-        ),
-        (
-            pd.DataFrame({"a": [2.0, 3.0], "b": [3.0, 2.0]}),
-            ProductInequalityConstraint(features=["a", "b"], exponents=[2, 1], rhs=18),
-            True,
-        ),
-        (
-            pd.DataFrame({"a": [2.0, 3.0], "b": [3.0, 2.0]}),
-            ProductInequalityConstraint(
-                features=["a", "b"],
-                exponents=[2, 1],
-                rhs=-18,
-                sign=-1,
-            ),
-            False,
-        ),
-    ],
-)
+    ]
+
+
+@pytest.mark.parametrize("df, constraint, fulfilled", parameters)
 def test_fulfillment(df, constraint, fulfilled):
     assert constraint.is_fulfilled(df).all() == fulfilled

--- a/tests/bofire/data_models/constraints/test_nonlinear.py
+++ b/tests/bofire/data_models/constraints/test_nonlinear.py
@@ -1,18 +1,22 @@
 import importlib
+import importlib.util
 
 import numpy as np
 import pandas as pd
 import pytest
-import torch
 
 from bofire.data_models.constraints.api import NonlinearInequalityConstraint
 
 
 SYMPY_AVAILABLE = importlib.util.find_spec("sympy") is not None
+TORCH_AVAILABLE = importlib.util.find_spec("torch") is not None
 
 
 @pytest.mark.skipif(not SYMPY_AVAILABLE, reason="requires rdkit")
+@pytest.mark.skipif(not TORCH_AVAILABLE, reason="requires rdkit")
 def test_nonlinear_constraints_jacobian_expression():
+    import torch
+
     constraint0 = NonlinearInequalityConstraint(
         expression="x1**2 + x2**2 - x3",
         features=["x1", "x2", "x3"],

--- a/tests/bofire/data_models/constraints/test_nonlinear.py
+++ b/tests/bofire/data_models/constraints/test_nonlinear.py
@@ -13,7 +13,7 @@ TORCH_AVAILABLE = importlib.util.find_spec("torch") is not None
 
 
 @pytest.mark.skipif(not SYMPY_AVAILABLE, reason="requires rdkit")
-@pytest.mark.skipif(not TORCH_AVAILABLE, reason="requires rdkit")
+@pytest.mark.skipif(not TORCH_AVAILABLE, reason="requires torch")
 def test_nonlinear_constraints_jacobian_expression():
     import torch
 


### PR DESCRIPTION
This PR should remove errors thrown when using nonlinear constraints without torch being installed. Closes #526 .