### PR TITLE
Proper error message for `strategy.predict`

### DIFF
--- a/bofire/strategies/predictives/predictive.py
+++ b/bofire/strategies/predictives/predictive.py
@@ -134,6 +134,11 @@ class PredictiveStrategy(Strategy):
         """
         if self.is_fitted is not True:
             raise ValueError("Model not yet fitted.")
+        if self.experiments is None:
+            raise ValueError(
+                "No experiments available. Strategy needs experiments to perform "
+                "predictions. Use `tell` to provide experimental data.",
+            )
         # TODO: validate also here the experiments but only for the input_columns
         # transformed = self.transformer.transform(experiments)
         transformed = self.domain.inputs.transform(

--- a/tests/bofire/strategies/test_strategy.py
+++ b/tests/bofire/strategies/test_strategy.py
@@ -591,9 +591,13 @@ def test_predictive_strategy_predict(domain, experiments):
         ),
     ],
 )
-def test_predictive_strategy_predict_not_fitted(domain):
+def test_predictive_strategy_predict_not_ready(domain):
     strategy = dummy.DummyPredictiveStrategy(
         data_model=dummy.DummyPredictiveStrategyDataModel(domain=domain),
     )
-    with pytest.raises(ValueError):
-        strategy.predict(generate_candidates(domain=domain))
+    candidates = generate_candidates(domain=domain)
+    with pytest.raises(ValueError, match="Model not yet fitted."):
+        strategy.predict(candidates)
+    strategy.is_fitted = True
+    with pytest.raises(ValueError, match="No experiments available."):
+        strategy.predict(candidates)


### PR DESCRIPTION
Raise a proper error message when calling `strategy.predict` but no `self.experiments` are available. They are needed for the desirabilities.

cc: @jkeupp 