### PR TITLE
Information-based Mutlifidelity

### DIFF
--- a/bofire/data_models/acquisition_functions/acquisition_function.py
+++ b/bofire/data_models/acquisition_functions/acquisition_function.py
@@ -98,6 +98,7 @@ class qMFMES(MultiFideltyAcquisitionFunction):
     num_fantasies: IntPowerOfTwo = 16
     num_mv_samples: int = 10
     num_y_samples: IntPowerOfTwo = 128
+    fidelity_costs: list[float] 
 
 
 class qMFGibbon(MultiFideltyAcquisitionFunction):
@@ -105,6 +106,7 @@ class qMFGibbon(MultiFideltyAcquisitionFunction):
     num_fantasies: IntPowerOfTwo = 16
     num_mv_samples: int = 10
     num_y_samples: IntPowerOfTwo = 128
+    fidelity_costs: list[float] 
 
 
 class qMFVariance(MultiFideltyAcquisitionFunction):

--- a/bofire/data_models/acquisition_functions/acquisition_function.py
+++ b/bofire/data_models/acquisition_functions/acquisition_function.py
@@ -109,4 +109,5 @@ class qMFGibbon(MultiFideltyAcquisitionFunction):
 
 class qMFVariance(MultiFideltyAcquisitionFunction):
     type: Literal["qMFVariance"] = "qMFVariance"
+    beta: Annotated[float, Field(ge=0)] = 0.2
     fidelity_thresholds: Union[List[float], float] = 0.1

--- a/bofire/data_models/acquisition_functions/acquisition_function.py
+++ b/bofire/data_models/acquisition_functions/acquisition_function.py
@@ -1,4 +1,4 @@
-from typing import Annotated, Dict, Literal, Optional
+from typing import Annotated, Dict, List, Literal, Optional, Union
 
 from pydantic import Field, PositiveFloat
 
@@ -15,6 +15,10 @@ class SingleObjectiveAcquisitionFunction(AcquisitionFunction):
 
 
 class MultiObjectiveAcquisitionFunction(AcquisitionFunction):
+    type: str
+
+
+class MultiFideltyAcquisitionFunction(AcquisitionFunction):
     type: str
 
 
@@ -87,3 +91,22 @@ class qNegIntPosVar(SingleObjectiveAcquisitionFunction):
     type: Literal["qNegIntPosVar"] = "qNegIntPosVar"
     n_mc_samples: IntPowerOfTwo = 512
     weights: Optional[Dict[str, PositiveFloat]] = Field(default_factory=lambda: None)
+
+
+class qMFMES(MultiFideltyAcquisitionFunction):
+    type: Literal["qMFMES"] = "qMFMES"
+    num_fantasies: IntPowerOfTwo = 16
+    num_mv_samples: int = 10
+    num_y_samples: IntPowerOfTwo = 128
+
+
+class qMFGibbon(MultiFideltyAcquisitionFunction):
+    type: Literal["qMFGibbon"] = "qMFGibbon"
+    num_fantasies: IntPowerOfTwo = 16
+    num_mv_samples: int = 10
+    num_y_samples: IntPowerOfTwo = 128
+
+
+class qMFVariance(MultiFideltyAcquisitionFunction):
+    type: Literal["qMFVariance"] = "qMFVariance"
+    fidelity_thresholds: Union[List[float], float] = 0.1

--- a/bofire/data_models/acquisition_functions/acquisition_function.py
+++ b/bofire/data_models/acquisition_functions/acquisition_function.py
@@ -98,15 +98,7 @@ class qMFMES(MultiFideltyAcquisitionFunction):
     num_fantasies: IntPowerOfTwo = 16
     num_mv_samples: int = 10
     num_y_samples: IntPowerOfTwo = 128
-    fidelity_costs: list[float] 
-
-
-class qMFGibbon(MultiFideltyAcquisitionFunction):
-    type: Literal["qMFGibbon"] = "qMFGibbon"
-    num_fantasies: IntPowerOfTwo = 16
-    num_mv_samples: int = 10
-    num_y_samples: IntPowerOfTwo = 128
-    fidelity_costs: list[float] 
+    fidelity_costs: list[float]
 
 
 class qMFVariance(MultiFideltyAcquisitionFunction):

--- a/bofire/data_models/acquisition_functions/api.py
+++ b/bofire/data_models/acquisition_functions/api.py
@@ -11,7 +11,6 @@ from bofire.data_models.acquisition_functions.acquisition_function import (
     qLogEI,
     qLogNEHVI,
     qLogNEI,
-    qMFGibbon,
     qMFMES,
     qMFVariance,
     qNegIntPosVar,
@@ -59,4 +58,4 @@ AnyMultiObjectiveAcquisitionFunction = Union[qEHVI, qLogEHVI, qNEHVI, qLogNEHVI]
 
 AnyActiveLearningAcquisitionFunction = qNegIntPosVar
 
-AnyMultiFidelityAcquisitionFunction = Union[qMFMES, qMFGibbon, qMFVariance]
+AnyMultiFidelityAcquisitionFunction = Union[qMFMES, qMFVariance]

--- a/bofire/data_models/acquisition_functions/api.py
+++ b/bofire/data_models/acquisition_functions/api.py
@@ -2,6 +2,7 @@ from typing import Union
 
 from bofire.data_models.acquisition_functions.acquisition_function import (
     AcquisitionFunction,
+    MultiFideltyAcquisitionFunction,
     MultiObjectiveAcquisitionFunction,
     SingleObjectiveAcquisitionFunction,
     qEHVI,
@@ -10,6 +11,9 @@ from bofire.data_models.acquisition_functions.acquisition_function import (
     qLogEI,
     qLogNEHVI,
     qLogNEI,
+    qMFGibbon,
+    qMFMES,
+    qMFVariance,
     qNegIntPosVar,
     qNEHVI,
     qNEI,
@@ -23,6 +27,7 @@ AbstractAcquisitionFunction = [
     AcquisitionFunction,
     SingleObjectiveAcquisitionFunction,
     MultiObjectiveAcquisitionFunction,
+    MultiFideltyAcquisitionFunction,
 ]
 
 AnyAcquisitionFunction = Union[
@@ -53,3 +58,5 @@ AnySingleObjectiveAcquisitionFunction = Union[
 AnyMultiObjectiveAcquisitionFunction = Union[qEHVI, qLogEHVI, qNEHVI, qLogNEHVI]
 
 AnyActiveLearningAcquisitionFunction = qNegIntPosVar
+
+AnyMultiFidelityAcquisitionFunction = Union[qMFMES, qMFGibbon, qMFVariance]

--- a/bofire/data_models/strategies/predictives/multi_fidelity.py
+++ b/bofire/data_models/strategies/predictives/multi_fidelity.py
@@ -3,7 +3,7 @@ from typing import Literal
 from pydantic import Field, model_validator
 
 from bofire.data_models.acquisition_functions.api import (
-    AnyMultiObjectiveAcquisitionFunction,
+    AnyMultiFidelityAcquisitionFunction,
     qMFVariance,
 )
 from bofire.data_models.domain.api import Domain, Outputs
@@ -15,7 +15,7 @@ from bofire.data_models.surrogates.api import BotorchSurrogates, MultiTaskGPSurr
 class MultiFidelityStrategy(SoboStrategy):
     type: Literal["MultiFidelityStrategy"] = "MultiFidelityStrategy"
 
-    fidelity_acquisition_function: AnyMultiObjectiveAcquisitionFunction = Field(
+    fidelity_acquisition_function: AnyMultiFidelityAcquisitionFunction = Field(
         default_factory=lambda: qMFVariance(),
     )
 

--- a/bofire/strategies/predictives/multi_fidelity.py
+++ b/bofire/strategies/predictives/multi_fidelity.py
@@ -1,24 +1,125 @@
+import math
+from typing import Optional
+
 import numpy as np
 import pandas as pd
 import torch
 from botorch.acquisition import (
+    SampleReducingMCAcquisitionFunction,
     qMultiFidelityLowerBoundMaxValueEntropy,
     qMultiFidelityMaxValueEntropy,
 )
+from botorch.acquisition.objective import MCAcquisitionObjective, PosteriorTransform
+from botorch.acquisition.utils import project_to_target_fidelity
 from botorch.models.model import Model
+from botorch.sampling.base import MCSampler
 
+from bofire.data_models.acquisition_functions.api import qMFVariance
 from bofire.data_models.features.api import TaskInput
 from bofire.data_models.strategies.predictives.multi_fidelity import (
     MultiFidelityStrategy as DataModel,
 )
 from bofire.strategies.predictives.sobo import SoboStrategy
 from bofire.utils.naming_conventions import get_column_names
+from bofire.utils.torch_tools import tkwargs
+
+
+class qMultiFidelityVariance(SampleReducingMCAcquisitionFunction):
+    r"""MC-based Variance Bound.
+
+    Uses a reparameterization to extend UCB to qUCB for q > 1 (See Appendix A
+    of [Wilson2017reparam].) Since we only consider the variance, we get the following
+    expression.
+
+    `qVariance = E(max(|Y_tilde - mu|))`, where `Y_tilde ~ N(mu, beta pi/2 Sigma)`
+    and `f(X)` has distribution `N(mu, Sigma)`.
+
+
+    """
+
+    def __init__(
+        self,
+        model: Model,
+        beta: float,
+        fidelity_thresholds: torch.Tensor,
+        sampler: Optional[MCSampler] = None,
+        objective: Optional[MCAcquisitionObjective] = None,
+        posterior_transform: Optional[PosteriorTransform] = None,
+        X_pending: Optional[torch.Tensor] = None,
+    ) -> None:
+        r"""q-Upper Confidence Bound.
+
+        Args:
+            model: A fitted model.
+            beta: Controls tradeoff between mean and standard deviation in UCB.
+            sampler: The sampler used to draw base samples. See `MCAcquisitionFunction`
+                more details.
+            objective: The MCAcquisitionObjective under which the samples are
+                evaluated. Defaults to `IdentityMCObjective()`.
+            posterior_transform: A PosteriorTransform (optional).
+            X_pending: A `batch_shape x m x d`-dim Tensor of `m` design points that have
+                points that have been submitted for function evaluation but have not yet
+                been evaluated. Concatenated into X upon forward call. Copied and set to
+                have no gradient.
+        """
+        super().__init__(
+            model=model,
+            sampler=sampler,
+            objective=objective,
+            posterior_transform=posterior_transform,
+            X_pending=X_pending,
+        )
+        self.beta_prime = self._get_beta_prime(beta=beta)
+        self.fidelity_thresholds = fidelity_thresholds
+
+    def _get_beta_prime(self, beta: float) -> float:
+        return math.sqrt(beta * math.pi / 2)
+
+    def _sample_forward(self, obj: torch.Tensor) -> torch.Tensor:
+        r"""Evaluate qMultiFidelityVariance per sample on the candidate set `X`.
+
+        Args:
+            obj: A `sample_shape x batch_shape x q`-dim Tensor of MC objective values.
+
+        Returns:
+            A `sample_shape x batch_shape x q`-dim Tensor of acquisition values.
+        """
+        mean = obj.mean(dim=0)
+        return self.beta_prime * (obj - mean).abs()
+
+    def forward(self, X: torch.Tensor):
+        r"""Compute acquisition values for a batch of a design point with different fidelities.
+
+        Since the acquisition function depends on other fidelities, we need to
+        share information across a batch of samples across fidelities. We therefore
+        need to override the forward method to handle this.
+
+        Args:
+            X: A `batch_shape x q=1 x d`-dim Tensor. X must be ordered from lowest
+                to highest fidelity.
+
+        Returns:
+            A `batch_shape`-dim Tensor of acquisition values.
+        """
+        acqf_values = super().forward(X)
+        acqf_over_threshold = torch.zeros_like(acqf_values)
+
+        fidelity_threshold_scale = self.model.outcome_transform.stdvs.item()
+        fidelity_thresholds = self.fidelity_thresholds * fidelity_threshold_scale
+        above_threshold = acqf_values > fidelity_thresholds
+
+        if above_threshold.sum() == 0:
+            acqf_over_threshold[-1] = 1.0
+        else:
+            first_above_threshold = torch.argmax(above_threshold, dim=0)
+            acqf_over_threshold[first_above_threshold] = 1.0
+        return acqf_over_threshold
 
 
 def get_mf_acquisition_function(
     acquisition_function_name: str,
     model: Model,
-    candidate_set: torch.Tensor,
+    target_fidelities: dict[int, float],
     # objective: MCAcquisitionObjective,
     # X_observed: Tensor,
     # posterior_transform: Optional[PosteriorTransform] = None,
@@ -27,24 +128,49 @@ def get_mf_acquisition_function(
     # eta: Optional[Union[Tensor, float]] = 1e-3,
     # mc_samples: int = 512,
     # seed: Optional[int] = None,
+    *,
+    beta: Optional[float] = None,
+    fidelity_thresholds: Optional[torch.Tensor] = None,
+    candidate_set: Optional[torch.Tensor] = None,
 ):
     """Convenience function for initialiing multi-fidelity acquisition functions.
 
-    Mirrors the signature of botorch.acquisition.factory.get_acquisition_function()"""
+    Mirrors the signature of botorch.acquisition.factory.get_acquisition_function.
+    """
+
+    def project(X):
+        return project_to_target_fidelity(X=X, target_fidelities=target_fidelities)
+
+    if acquisition_function_name in ["qMFMES", "qMFGibbon"]:
+        if candidate_set is None:
+            raise ValueError(
+                "`candidate_set` must not be None for qMFMES and qMFGibbon."
+            )
+
     if acquisition_function_name == "qMFMES":
         return qMultiFidelityMaxValueEntropy(
             model=model,
-            candidate_set=candidate_set,
+            candidate_set=candidate_set,  # type: ignore
+            project=project,
         )
 
     elif acquisition_function_name == "qMFGibbon":
         return qMultiFidelityLowerBoundMaxValueEntropy(
             model=model,
-            candidate_set=candidate_set,
+            candidate_set=candidate_set,  # type: ignore
+            project=project,
         )
 
     elif acquisition_function_name == "qMFVariance":
-        return
+        if beta is None:
+            raise ValueError("`beta` must not be None for qMFVariance.")
+        if fidelity_thresholds is None:
+            raise ValueError("`fidelity_thresholds` must not be None for qMFVariance.")
+        return qMultiFidelityVariance(
+            model=model,
+            beta=beta,
+            fidelity_thresholds=fidelity_thresholds,
+        )
 
     raise NotImplementedError(
         f"Unknown acquisition function {acquisition_function_name}"
@@ -55,6 +181,7 @@ class MultiFidelityStrategy(SoboStrategy):
     def __init__(self, data_model: DataModel, **kwargs):
         super().__init__(data_model=data_model, **kwargs)
         self.task_feature_key = self.domain.inputs.get_keys(TaskInput)[0]
+        self.fidelity_acquisition_function = data_model.fidelity_acquisition_function
 
         # ft = data_model.fidelity_thresholds
         # M = len(self.domain.inputs.get_by_key(self.task_feature_key).fidelities)  # type: ignore
@@ -65,8 +192,13 @@ class MultiFidelityStrategy(SoboStrategy):
 
         This is a greedy optimization of the acquisition function. We first
         optimize the acqf for the target fidelity to generate a candidate x,
-        then select the lowest fidelity that has a variance exceeding a
-        threshold.
+        then select a target fidelity.
+
+        We do this procedure greedily in line with [Folch et al. 2023]. This has
+        the advantage of being simpler and faster, as we only need to evaluate
+        the fidelity acquisition function M times. It also allows more freedom
+        in the choice of design-space acquisition function, as well as enabling a
+        more flexible choice of surrogate models.
 
         Args:
             candidate_count (int): number of candidates to be generated
@@ -110,27 +242,56 @@ class MultiFidelityStrategy(SoboStrategy):
         sorted_fidelities = np.argsort(fidelity_input.fidelities)[::-1]
         target_fidelity_idx = sorted_fidelities[-1]
         target_fidelity = fidelity_input.fidelities[target_fidelity_idx]
+        num_fidelities = len(fidelity_input.fidelities)
         _, sd_cols = get_column_names(self.domain.outputs)
 
-        for fidelity_idx in sorted_fidelities:
-            if not fidelity_input.allowed[fidelity_idx]:
-                continue
+        fidelity_acqf = get_mf_acquisition_function(
+            acquisition_function_name=self.fidelity_acquisition_function.__class__.__name__,
+            model=self.model,
+            target_fidelities={target_fidelity_idx: float(target_fidelity)},
+            beta=(
+                self.fidelity_acquisition_function.beta
+                if isinstance(self.fidelity_acquisition_function, qMFVariance)
+                else 0.2
+            ),
+        )
 
-            m = fidelity_input.fidelities[fidelity_idx]
-            fidelity_name = fidelity_input.categories[fidelity_idx]
+        X_fidelity_batched = X.loc[X.index.repeat(num_fidelities)]
+        X_fidelity_batched[self.task_feature_key] = np.repeat(
+            fidelity_input.categories, len(X)
+        )
+        # TODO: check that this transform is correct
+        X_fidelity_batched = self.domain.inputs.transform(
+            experiments=X_fidelity_batched, specs=self.input_preprocessing_specs
+        )
+        X_fidelity_batched_tensor = torch.from_numpy(X_fidelity_batched.to_numpy()).to(
+            **tkwargs
+        )
+        acqf_values = fidelity_acqf(X_fidelity_batched_tensor)
 
-            fidelity_threshold_scale = self.model.outcome_transform.stdvs.item()
-            fidelity_threshold = self.fidelity_thresholds[m] * fidelity_threshold_scale
+        chosen_fidelity_idx = int(torch.argmax(acqf_values).item())
+        candidate = X_fidelity_batched.iloc[[chosen_fidelity_idx]]
+        return candidate
 
-            X_fid = X.assign(**{self.task_feature_key: fidelity_name})
-            transformed = self.domain.inputs.transform(
-                experiments=X_fid, specs=self.input_preprocessing_specs
-            )
-            pred = self.predict(transformed)
+        # for fidelity_idx in sorted_fidelities:
+        #     if not fidelity_input.allowed[fidelity_idx]:
+        #         continue
 
-            if (pred[sd_cols] > fidelity_threshold).all().all() or m == target_fidelity:
-                pred[self.task_feature_key] = fidelity_name
-                return pred
+        #     m = fidelity_input.fidelities[fidelity_idx]
+        #     fidelity_name = fidelity_input.categories[fidelity_idx]
+
+        #     fidelity_threshold_scale = self.model.outcome_transform.stdvs.item()
+        #     fidelity_threshold = self.fidelity_thresholds[m] * fidelity_threshold_scale
+
+        #     X_fid = X.assign(**{self.task_feature_key: fidelity_name})
+        #     transformed = self.domain.inputs.transform(
+        #         experiments=X_fid, specs=self.input_preprocessing_specs
+        #     )
+        #     pred = self.predict(transformed)
+
+        #     if (pred[sd_cols] > fidelity_threshold).all().all() or m == target_fidelity:
+        #         pred[self.task_feature_key] = fidelity_name
+        #         return pred
 
     def _verify_all_fidelities_observed(self) -> None:
         """Get all fidelities that have at least one observation.

--- a/tests/bofire/strategies/test_multi_fidelity.py
+++ b/tests/bofire/strategies/test_multi_fidelity.py
@@ -68,8 +68,8 @@ def test_mf_requires_all_fidelities_observed():
     "fidelity_acqf",
     (
         qMFVariance(fidelity_thresholds=0.1, beta=0.2),
-        qMFMES(),
-        qMFGibbon(),
+        qMFMES(fidelity_costs=[2.0, 1.0]),
+        qMFGibbon(fidelity_costs=[2.0, 1.0]),
     ),
 )
 def test_mf_fidelity_selection(fidelity_acqf):
@@ -115,8 +115,8 @@ def test_mf_fidelity_selection(fidelity_acqf):
     "fidelity_acqf",
     (
         qMFVariance(fidelity_thresholds=0.1, beta=0.2),
-        qMFMES(),
-        qMFGibbon(),
+        qMFMES(fidelity_costs=[2.0, 1.0]),
+        qMFGibbon(fidelity_costs=[2.0, 1.0]),
     ),
 )
 def test_mf_point_selection(fidelity_acqf):

--- a/tests/bofire/strategies/test_multi_fidelity.py
+++ b/tests/bofire/strategies/test_multi_fidelity.py
@@ -79,13 +79,14 @@ def test_mf_fidelity_selection():
     )
 
     experiments = benchmark.f(random_strategy.ask(4), return_complete=True)
+    experiments[benchmark.domain.outputs.get_keys()] *= 1000
     experiments[task_input.key] = ["task_1", "task_2", "task_2", "task_2"]
     experiments, withheld = experiments.iloc[:-1], experiments.iloc[-1:]
 
     strategy = MultiFidelityStrategy(
         data_model=MultiFidelityStrategyDataModel(
             domain=benchmark.domain,
-            fidelity_acquisition_function=qMFVariance(fidelity_thresholds=[0.1, 0.1]),
+            fidelity_acquisition_function=qMFVariance(fidelity_thresholds=0.1),
         )
     )
 

--- a/tutorials/advanced_examples/multifidelity_bo.ipynb
+++ b/tutorials/advanced_examples/multifidelity_bo.ipynb
@@ -181,6 +181,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "from bofire.data_models.acquisition_functions.api import qMFVariance\n",
     "from bofire.data_models.strategies.api import MultiFidelityStrategy\n",
     "\n",
     "\n",
@@ -190,7 +191,7 @@
     "mf_data_model = MultiFidelityStrategy(\n",
     "    domain=mf_benchmark.domain,\n",
     "    acquisition_function=qLogEI(),\n",
-    "    fidelity_thresholds=0.1,\n",
+    "    fidelity_acquisition_function=qMFVariance(fidelity_thresholds=0.1),\n",
     ")\n",
     "mf_data_model.surrogate_specs.surrogates[0].inputs"
    ]

--- a/tutorials/advanced_examples/multifidelity_bo.ipynb
+++ b/tutorials/advanced_examples/multifidelity_bo.ipynb
@@ -58,15 +58,15 @@
    "outputs": [],
    "source": [
     "SMOKE_TEST = os.environ.get(\"SMOKE_TEST\")\n",
-    "NUM_INIT_HF = 4\n",
-    "NUM_INIT_LF = 20\n",
+    "NUM_INIT_HF = 2\n",
+    "NUM_INIT_LF = 10\n",
     "if SMOKE_TEST:\n",
     "    num_runs = 5\n",
     "    num_iters = 2\n",
     "    verbose = False\n",
     "else:\n",
     "    num_runs = 5\n",
-    "    num_iters = 10\n",
+    "    num_iters = 20\n",
     "    verbose = True"
    ]
   },
@@ -132,11 +132,15 @@
     "            outputs=self._branin.domain.outputs,\n",
     "        )\n",
     "\n",
+    "        self.bias_scale = 0.2\n",
+    "\n",
     "    def _f(self, candidates: pd.DataFrame) -> pd.DataFrame:\n",
     "        candidates_no_task = candidates.drop(columns=[\"task\"])\n",
     "        f_branin = self._branin.f(candidates_no_task)\n",
     "        f_ackley = self._ackley.f(candidates_no_task)\n",
-    "        bias_scale = np.where(candidates[\"task\"] == \"task_hf\", 0.0, 0.15).reshape(-1, 1)\n",
+    "        bias_scale = np.where(\n",
+    "            candidates[\"task\"] == \"task_hf\", 0.0, self.bias_scale\n",
+    "        ).reshape(-1, 1)\n",
     "        bias_scale = pd.DataFrame(bias_scale, columns=self._domain.outputs.get_keys())\n",
     "        bias_scale[\"valid_y\"] = 0.0\n",
     "        return f_branin + bias_scale * f_ackley\n",
@@ -167,7 +171,7 @@
     "        experiments.index < NUM_INIT_LF, \"task_lf\", \"task_hf\"\n",
     "    )\n",
     "\n",
-    "    # then use the ml_benchmark to evaluate the low fidelity\n",
+    "    # then use the mf_benchmark to evaluate the low fidelity\n",
     "    return mf_benchmark.f(experiments, return_complete=True)\n",
     "\n",
     "\n",
@@ -205,6 +209,7 @@
    "source": [
     "from bofire.data_models.strategies.api import SoboStrategy, Strategy\n",
     "\n",
+    "\n",
     "surrogate_specs = BotorchSurrogates(\n",
     "    surrogates=[\n",
     "        MultiTaskGPSurrogate(\n",
@@ -241,12 +246,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "997918db",
+   "id": "10",
    "metadata": {},
    "outputs": [],
    "source": [
     "# helper function for running bayesian optimization loop\n",
-    "def run_bo_loop(strategy_data_model: Strategy, run_idx: int):\n",
+    "def run_bo_loop(\n",
+    "    strategy_data_model: Strategy, run_idx: int, last_itr_high_fidelity: bool = False\n",
+    "):\n",
     "    results = pd.DataFrame(columns=pd.MultiIndex.from_tuples([], names=(\"col\", \"run\")))\n",
     "    seed = 2048 * run_idx + 123\n",
     "    experiments = create_data_set(seed)\n",
@@ -257,14 +264,14 @@
     "    assert strategy.experiments is not None\n",
     "\n",
     "    pbar = tqdm(range(num_iters), desc=\"Optimizing\")\n",
-    "    for _ in pbar:\n",
+    "    for itr in pbar:\n",
     "        candidate = strategy.ask(1)\n",
+    "        if last_itr_high_fidelity and itr == num_iters - 1:\n",
+    "            candidate[\"task\"] = \"task_hf\"\n",
     "        y = mf_benchmark.f(candidate, return_complete=True)\n",
     "        strategy.tell(y)\n",
     "\n",
-    "        hf_experiments = strategy.experiments[\n",
-    "            strategy.experiments[\"task\"] == \"task_hf\"\n",
-    "        ]\n",
+    "        hf_experiments = strategy.experiments[strategy.experiments[\"task\"] == \"task_hf\"]\n",
     "        # note that both benchmarks have the same optimum\n",
     "        regret = hf_experiments[\"y\"].min() - mf_benchmark.get_optima()[\"y\"][0].item()\n",
     "\n",
@@ -277,7 +284,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "10",
+   "id": "11",
    "metadata": {
     "papermill": {
      "duration": null,
@@ -296,7 +303,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "11",
+   "id": "12",
    "metadata": {
     "papermill": {
      "duration": null,
@@ -312,14 +319,12 @@
     "tl_results = pd.DataFrame(columns=pd.MultiIndex.from_tuples([], names=(\"col\", \"run\")))\n",
     "for run_idx in range(num_runs):\n",
     "    results = run_bo_loop(tl_data_model, run_idx)\n",
-    "    tl_results = pd.concat((tl_results, results), axis=1)\n",
-    "\n",
-    "tl_results"
+    "    tl_results = pd.concat((tl_results, results), axis=1)"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "12",
+   "id": "13",
    "metadata": {
     "papermill": {
      "duration": null,
@@ -338,7 +343,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "13",
+   "id": "14",
    "metadata": {
     "papermill": {
      "duration": null,
@@ -354,14 +359,12 @@
     "mf_results = pd.DataFrame(columns=pd.MultiIndex.from_tuples([], names=(\"col\", \"run\")))\n",
     "for run_idx in range(num_runs):\n",
     "    results = run_bo_loop(mf_data_model, run_idx)\n",
-    "    mf_results = pd.concat((mf_results, results), axis=1)\n",
-    "\n",
-    "mf_results"
+    "    mf_results = pd.concat((mf_results, results), axis=1)"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "14",
+   "id": "15",
    "metadata": {
     "papermill": {
      "duration": null,
@@ -386,7 +389,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "15",
+   "id": "16",
    "metadata": {
     "papermill": {
      "duration": null,
@@ -441,7 +444,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6c34d2ac",
+   "id": "17",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -475,7 +478,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "16",
+   "id": "18",
    "metadata": {
     "papermill": {
      "duration": null,
@@ -495,7 +498,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "17",
+   "id": "19",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -504,7 +507,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ac5b934e",
+   "id": "20",
    "metadata": {},
    "source": [
     "### Information-based Multi-fidelity\n",
@@ -516,31 +519,32 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d3365143",
+   "id": "21",
    "metadata": {},
    "outputs": [],
    "source": [
     "from bofire.data_models.acquisition_functions.api import qMFMES\n",
     "\n",
+    "\n",
     "mf_mes_data_model = MultiFidelityStrategy(\n",
     "    domain=mf_benchmark.domain,\n",
     "    acquisition_function=qLogEI(),\n",
-    "    fidelity_acquisition_function=qMFMES(\n",
-    "        fidelity_costs=[1.0, 1.0]\n",
-    "    ),\n",
+    "    fidelity_acquisition_function=qMFMES(fidelity_costs=[3.0, 1.0]),\n",
     ")"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4b4a7064",
+   "id": "22",
    "metadata": {},
    "outputs": [],
    "source": [
-    "mf_mes_results = pd.DataFrame(columns=pd.MultiIndex.from_tuples([], names=(\"col\", \"run\")))\n",
+    "mf_mes_results = pd.DataFrame(\n",
+    "    columns=pd.MultiIndex.from_tuples([], names=(\"col\", \"run\"))\n",
+    ")\n",
     "for run_idx in range(num_runs):\n",
-    "    results = run_bo_loop(mf_mes_data_model, run_idx)\n",
+    "    results = run_bo_loop(mf_mes_data_model, run_idx, last_itr_high_fidelity=True)\n",
     "    mf_mes_results = pd.concat((mf_mes_results, results), axis=1)\n",
     "\n",
     "mf_mes_results"
@@ -549,12 +553,13 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9e27738c",
+   "id": "23",
    "metadata": {},
    "outputs": [],
    "source": [
     "fig, ax = plt.subplots(figsize=(4, 4))\n",
-    "cost_ratio = 3\n",
+    "fidelity_costs = mf_mes_data_model.fidelity_acquisition_function.fidelity_costs\n",
+    "cost_ratio = fidelity_costs[0] / fidelity_costs[1]\n",
     "\n",
     "plot_regret(\n",
     "    ax,\n",
@@ -585,14 +590,6 @@
     "\n",
     "plt.show()"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "bb77ee43",
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
@@ -611,7 +608,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.6"
+   "version": "3.10.11"
   },
   "papermill": {
    "default_parameters": {},

--- a/tutorials/advanced_examples/multifidelity_bo.ipynb
+++ b/tutorials/advanced_examples/multifidelity_bo.ipynb
@@ -65,7 +65,7 @@
     "    num_iters = 2\n",
     "    verbose = False\n",
     "else:\n",
-    "    num_runs = 10\n",
+    "    num_runs = 5\n",
     "    num_iters = 10\n",
     "    verbose = True"
    ]
@@ -203,8 +203,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from bofire.data_models.strategies.api import SoboStrategy\n",
-    "\n",
+    "from bofire.data_models.strategies.api import SoboStrategy, Strategy\n",
     "\n",
     "surrogate_specs = BotorchSurrogates(\n",
     "    surrogates=[\n",
@@ -237,6 +236,43 @@
    },
    "source": [
     "# Multi-fidelity Bayesian Optimisation"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "997918db",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# helper function for running bayesian optimization loop\n",
+    "def run_bo_loop(strategy_data_model: Strategy, run_idx: int):\n",
+    "    results = pd.DataFrame(columns=pd.MultiIndex.from_tuples([], names=(\"col\", \"run\")))\n",
+    "    seed = 2048 * run_idx + 123\n",
+    "    experiments = create_data_set(seed)\n",
+    "\n",
+    "    strategy = strategies.map(strategy_data_model)\n",
+    "    strategy.tell(experiments)\n",
+    "\n",
+    "    assert strategy.experiments is not None\n",
+    "\n",
+    "    pbar = tqdm(range(num_iters), desc=\"Optimizing\")\n",
+    "    for _ in pbar:\n",
+    "        candidate = strategy.ask(1)\n",
+    "        y = mf_benchmark.f(candidate, return_complete=True)\n",
+    "        strategy.tell(y)\n",
+    "\n",
+    "        hf_experiments = strategy.experiments[\n",
+    "            strategy.experiments[\"task\"] == \"task_hf\"\n",
+    "        ]\n",
+    "        # note that both benchmarks have the same optimum\n",
+    "        regret = hf_experiments[\"y\"].min() - mf_benchmark.get_optima()[\"y\"][0].item()\n",
+    "\n",
+    "        pbar.set_postfix({\"Regret\": f\"{regret:.4f}\"})\n",
+    "\n",
+    "    results[\"fidelity\", f\"{run_idx}\"] = strategy.experiments[\"task\"]\n",
+    "    results[\"y\", f\"{run_idx}\"] = strategy.experiments[\"y\"]\n",
+    "    return results"
    ]
   },
   {
@@ -274,30 +310,11 @@
    "outputs": [],
    "source": [
     "tl_results = pd.DataFrame(columns=pd.MultiIndex.from_tuples([], names=(\"col\", \"run\")))\n",
-    "for run in range(num_runs):\n",
-    "    seed = 2048 * run + 123\n",
-    "    experiments = create_data_set(seed)\n",
+    "for run_idx in range(num_runs):\n",
+    "    results = run_bo_loop(tl_data_model, run_idx)\n",
+    "    tl_results = pd.concat((tl_results, results), axis=1)\n",
     "\n",
-    "    tl_strategy = strategies.map(tl_data_model)\n",
-    "    tl_strategy.tell(experiments)\n",
-    "\n",
-    "    assert tl_strategy.experiments is not None\n",
-    "\n",
-    "    pbar = tqdm(range(num_iters), desc=\"Optimizing\")\n",
-    "    for _ in pbar:\n",
-    "        candidate = tl_strategy.ask(1)\n",
-    "        y = tl_benchmark.f(candidate, return_complete=True)\n",
-    "        tl_strategy.tell(y)\n",
-    "\n",
-    "        hf_experiments = tl_strategy.experiments[\n",
-    "            tl_strategy.experiments[\"task\"] == \"task_hf\"\n",
-    "        ]\n",
-    "        regret = hf_experiments[\"y\"].min() - tl_benchmark.get_optima()[\"y\"][0].item()\n",
-    "\n",
-    "        pbar.set_postfix({\"Regret\": f\"{regret:.4f}\"})\n",
-    "\n",
-    "    tl_results[\"fidelity\", f\"{run}\"] = tl_strategy.experiments[\"task\"]\n",
-    "    tl_results[\"y\", f\"{run}\"] = tl_strategy.experiments[\"y\"]"
+    "tl_results"
    ]
   },
   {
@@ -335,30 +352,11 @@
    "outputs": [],
    "source": [
     "mf_results = pd.DataFrame(columns=pd.MultiIndex.from_tuples([], names=(\"col\", \"run\")))\n",
-    "for run in range(num_runs):\n",
-    "    seed = 2048 * run + 123\n",
-    "    experiments = create_data_set(seed)\n",
+    "for run_idx in range(num_runs):\n",
+    "    results = run_bo_loop(mf_data_model, run_idx)\n",
+    "    mf_results = pd.concat((mf_results, results), axis=1)\n",
     "\n",
-    "    mf_strategy = strategies.map(mf_data_model)\n",
-    "    mf_strategy.tell(experiments)\n",
-    "\n",
-    "    assert mf_strategy.experiments is not None\n",
-    "\n",
-    "    pbar = tqdm(range(num_iters), desc=\"Optimizing\")\n",
-    "    for _ in pbar:\n",
-    "        candidate = mf_strategy.ask(1)\n",
-    "        y = mf_benchmark.f(candidate, return_complete=True)\n",
-    "        mf_strategy.tell(y)\n",
-    "\n",
-    "        hf_experiments = mf_strategy.experiments[\n",
-    "            mf_strategy.experiments[\"task\"] == \"task_hf\"\n",
-    "        ]\n",
-    "        regret = hf_experiments[\"y\"].min() - mf_benchmark.get_optima()[\"y\"][0].item()\n",
-    "\n",
-    "        pbar.set_postfix({\"Regret\": f\"{regret:.4f}\"})\n",
-    "\n",
-    "    mf_results[\"fidelity\", f\"{run}\"] = mf_strategy.experiments[\"task\"]\n",
-    "    mf_results[\"y\", f\"{run}\"] = mf_strategy.experiments[\"y\"]"
+    "mf_results"
    ]
   },
   {
@@ -437,9 +435,16 @@
     "        np.quantile(regret, 0.25, axis=0),\n",
     "        color=plot_kwargs.get(\"color\"),\n",
     "        alpha=0.2,\n",
-    "    )\n",
-    "\n",
-    "\n",
+    "    )"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6c34d2ac",
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "fig, axs = plt.subplots(ncols=2, figsize=(8, 4), sharey=True)\n",
     "cost_ratios = (1, 3)\n",
     "\n",
@@ -496,6 +501,96 @@
    "source": [
     "(mf_results[\"fidelity\"] == \"task_hf\")[-num_iters:].mean(axis=1)  # type: ignore"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ac5b934e",
+   "metadata": {},
+   "source": [
+    "### Information-based Multi-fidelity\n",
+    "\n",
+    "We can also use an information-theoretic approach to evaluate the different fidelities. \n",
+    "This approach selects the fidelity that maximizes the information gained about the global maximizer - see [Folch 2023] for more details."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d3365143",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from bofire.data_models.acquisition_functions.api import qMFMES\n",
+    "\n",
+    "mf_mes_data_model = MultiFidelityStrategy(\n",
+    "    domain=mf_benchmark.domain,\n",
+    "    acquisition_function=qLogEI(),\n",
+    "    fidelity_acquisition_function=qMFMES(),\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4b4a7064",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "mf_mes_results = pd.DataFrame(columns=pd.MultiIndex.from_tuples([], names=(\"col\", \"run\")))\n",
+    "for run_idx in range(num_runs):\n",
+    "    results = run_bo_loop(mf_mes_data_model, run_idx)\n",
+    "    mf_mes_results = pd.concat((mf_mes_results, results), axis=1)\n",
+    "\n",
+    "mf_mes_results"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9e27738c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig, ax = plt.subplots(figsize=(4, 4))\n",
+    "cost_ratios = 3\n",
+    "\n",
+    "plot_regret(\n",
+    "    ax,\n",
+    "    tl_results,\n",
+    "    fidelity_cost_ratio=cost_ratio,\n",
+    "    label=\"Transfer Learning\",\n",
+    "    color=\"blue\",\n",
+    ")\n",
+    "plot_regret(\n",
+    "    ax,\n",
+    "    mf_results,\n",
+    "    fidelity_cost_ratio=cost_ratio,\n",
+    "    label=\"Multi-fidelity (Variance)\",\n",
+    "    color=\"green\",\n",
+    ")\n",
+    "plot_regret(\n",
+    "    ax,\n",
+    "    mf_mes_results,\n",
+    "    fidelity_cost_ratio=cost_ratio,\n",
+    "    label=\"Multi-fidelity (MES)\",\n",
+    "    color=\"orange\",\n",
+    ")\n",
+    "\n",
+    "ax.set_xlabel(\"Time step\")\n",
+    "ax.set_title(f\"Fidelity cost ratio = {cost_ratio}\")\n",
+    "ax.legend()\n",
+    "ax.set_ylabel(\"Regret\")\n",
+    "\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bb77ee43",
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
@@ -514,7 +609,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.11"
+   "version": "3.11.6"
   },
   "papermill": {
    "default_parameters": {},

--- a/tutorials/advanced_examples/multifidelity_bo.ipynb
+++ b/tutorials/advanced_examples/multifidelity_bo.ipynb
@@ -59,7 +59,7 @@
    "source": [
     "SMOKE_TEST = os.environ.get(\"SMOKE_TEST\")\n",
     "NUM_INIT_HF = 4\n",
-    "NUM_INIT_LF = 10\n",
+    "NUM_INIT_LF = 20\n",
     "if SMOKE_TEST:\n",
     "    num_runs = 5\n",
     "    num_iters = 2\n",
@@ -380,7 +380,7 @@
     "BO performance.\n",
     "\n",
     "Specifically, although both strategies have a budget of 10 function queries, the MF \n",
-    "approach uses some of them on "
+    "approach uses some of them on the low fidelity to obtain information about the problem while exhausting less budget."
    ]
   },
   {
@@ -525,7 +525,9 @@
     "mf_mes_data_model = MultiFidelityStrategy(\n",
     "    domain=mf_benchmark.domain,\n",
     "    acquisition_function=qLogEI(),\n",
-    "    fidelity_acquisition_function=qMFMES(),\n",
+    "    fidelity_acquisition_function=qMFMES(\n",
+    "        fidelity_costs=[1.0, 1.0]\n",
+    "    ),\n",
     ")"
    ]
   },
@@ -552,7 +554,7 @@
    "outputs": [],
    "source": [
     "fig, ax = plt.subplots(figsize=(4, 4))\n",
-    "cost_ratios = 3\n",
+    "cost_ratio = 3\n",
     "\n",
     "plot_regret(\n",
     "    ax,\n",


### PR DESCRIPTION
This PR introduces an information based approach to multifidelity, using the Multifidelity Maximum Entropy Search method [Takeno 2020, Folch 2023].

This also converts the existing MultiFidelityStrategy to use a separate MultiFidelityAcquisitionFunction. This allows the acquisition function to be explicitly designed by the user. Also, by using BoTorch-style acquisition functions, we are able to generate batches of proposals by conditioning on pending experiments.

Leaving this as a draft because the information-based method doesn't seem to perform very well, which needs some investigation. I'm open to ideas!