### PR TITLE
Bump image for doc pipelines

### DIFF
--- a/.github/workflows/docs-build.yaml
+++ b/.github/workflows/docs-build.yaml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     concurrency:
       group: ${{ github.workflow }}-${{ github.ref }}
     steps:

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   deploy:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     concurrency:
       group: ${{ github.workflow }}-${{ github.ref }}
     steps:


### PR DESCRIPTION
In the doc pipelines, we are still using Ubuntu 20.04, which is not anymore supported by github, here we change to `ubuntu-latest`.