### PR TITLE
docs used deprecated pydantic

### DIFF
--- a/docs/data_models_functionals.md
+++ b/docs/data_models_functionals.md
@@ -11,9 +11,9 @@ import bofire.data_models.domain.api as dm_domain
 import bofire.data_models.features.api as dm_features
 import bofire.data_models.strategies.api as dm_strategies
 
-in1 = dm_features.ContinuousInput(key="in1", bounds=(0.0,1.0))
-in2 = dm_features.ContinuousInput(key="in2", bounds=(0.0,2.0))
-in3 = dm_features.ContinuousInput(key="in3", bounds=(0.0,3.0))
+in1 = dm_features.ContinuousInput(key="in1", bounds=[0.0,1.0])
+in2 = dm_features.ContinuousInput(key="in2", bounds=[0.0,2.0])
+in3 = dm_features.ContinuousInput(key="in3", bounds=[0.0,3.0])
 
 out1 = dm_features.ContinuousOutput(key="out1")
 
@@ -33,14 +33,13 @@ data_model = dm_strategies.RandomStrategy(domain=domain)
 Such a data model can be (de)serialized as follows:
 
 ```python
-import json
-from pydantic import parse_obj_as
+from pydantic import TypeAdapter
 from bofire.data_models.strategies.api import AnyStrategy
 
 serialized = data_model.model_dump_json()
-data = json.loads(serialized)
-# alternative: data = data_model.dict()
-data_model_ = parse_obj_as(AnyStrategy, data)
+
+data_model_ = TypeAdapter(AnyStrategy).validate_json(serialized)
+
 assert data_model_ == data_model
 ```
 The data model of a strategy contains its hyperparameters.


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to make BoFire better.

Help us to understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to BoFire here: https://github.com/experimental-desgin/bofire/blob/main/CONTRIBUTING.md
-->

## Motivation

Update to pydantic 2 in the docs. Remove deprecation

### Have you read the [Contributing Guidelines on pull requests](https://github.com/experimental-design/bofire/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Docs
