### PR TITLE
Working Stepsize Implementation

### DIFF
--- a/bofire/strategies/predictives/predictive.py
+++ b/bofire/strategies/predictives/predictive.py
@@ -184,6 +184,21 @@ class PredictiveStrategy(Strategy):
         self._fit(self.experiments)
         self.is_fitted = True
 
+    def _postprocess_candidates(self, candidates: pd.DataFrame) -> pd.DataFrame:
+        """Postprocess the candidates.
+
+        Here we append the predictions to the candidates.
+
+        Args:
+            candidates (Tensor): Tensor of candidates returned from `optimize_acqf`.
+
+        Returns:
+            pd.DataFrame: Dataframe with candidates.
+
+        """
+        preds = self.predict(candidates)
+        return pd.concat((candidates, preds), axis=1)
+
     @abstractmethod
     def _fit(self, experiments: pd.DataFrame):
         """Abstract method where the actual prediction are occurring."""

--- a/bofire/strategies/strategy.py
+++ b/bofire/strategies/strategy.py
@@ -6,6 +6,7 @@ import numpy as np
 import pandas as pd
 from pydantic import PositiveInt
 
+from bofire.data_models.features.api import ContinuousInput
 from bofire.data_models.strategies.api import Strategy as DataModel
 from bofire.strategies.data_models.candidate import Candidate
 from bofire.strategies.data_models.values import InputValue
@@ -127,6 +128,8 @@ class Strategy(ABC):
 
         candidates = self._ask(candidate_count=candidate_count)
 
+        candidates = self.postprocess_candidates(candidates)
+
         self.domain.validate_candidates(
             candidates=candidates,
             only_inputs=True,
@@ -143,6 +146,42 @@ class Strategy(ABC):
         if add_pending:
             self.add_candidates(candidates)
 
+        return candidates
+
+    def postprocess_candidates(self, candidates: pd.DataFrame) -> pd.DataFrame:
+        """Method to allow for postprocessing of candidates.
+
+        By default this methods applies the stepsize of continuous features if applicable.
+
+        Args:
+            candidates (pd.DataFrame): DataFrame with candidates.
+
+        Returns:
+            pd.DataFrame: DataFrame with postprocessed candidates.
+
+        """
+        keys_in_constraints = []
+        for c in self.domain.constraints.get():
+            keys_in_constraints.extend(c.features())  # type: ignore
+        for feature in self.domain.inputs.get(ContinuousInput):
+            assert isinstance(feature, ContinuousInput)
+            if feature.key not in keys_in_constraints:
+                candidates[feature.key] = feature.round(candidates[feature.key])
+
+        # perform strategy specific postprocessing
+        candidates = self._postprocess_candidates(candidates)
+        return candidates
+
+    def _postprocess_candidates(self, candidates: pd.DataFrame) -> pd.DataFrame:
+        """Method to allow for strategy specific postprocessing of candidates.
+
+        Args:
+            candidates (pd.DataFrame): DataFrame with candidates.
+
+        Returns:
+            pd.DataFrame: DataFrame with postprocessed candidates.
+
+        """
         return candidates
 
     @abstractmethod

--- a/tests/bofire/data_models/features/test_continuous.py
+++ b/tests/bofire/data_models/features/test_continuous.py
@@ -11,22 +11,26 @@ from bofire.data_models.features.api import ContinuousDescriptorInput, Continuou
 
 
 def test_continuous_input_invalid_stepsize():
-    with pytest.raises(ValueError):
-        ContinuousInput(key="a", bounds=(1, 1), stepsize=0)
-    with pytest.raises(ValueError):
-        ContinuousInput(key="a", bounds=(0, 5), stepsize=0.3)
-    with pytest.raises(ValueError):
-        ContinuousInput(key="a", bounds=(0, 1), stepsize=1)
+    with pytest.raises(
+        ValueError, match="Stepsize cannot be provided for a fixed continuous input."
+    ):
+        ContinuousInput(key="a", bounds=(0, 0), stepsize=0.3)
+    with pytest.raises(ValueError, match="Stepsize is too big for provided range."):
+        ContinuousInput(key="a", bounds=(0, 1), stepsize=1.2)
 
 
 def test_continuous_input_round():
     feature = ContinuousInput(key="a", bounds=(0, 5))
-    values = pd.Series([1.0, 1.3, 0.55])
+    values = pd.Series([1.0, 1.3, 0.55, 4.9])
     assert_series_equal(values, feature.round(values))
     feature = ContinuousInput(key="a", bounds=(0, 5), stepsize=0.25)
-    assert_series_equal(pd.Series([1.0, 1.25, 0.5]), feature.round(values))
+    assert_series_equal(pd.Series([1.0, 1.25, 0.5, 5]), feature.round(values))
     feature = ContinuousInput(key="a", bounds=(0, 5), stepsize=0.1)
-    assert_series_equal(pd.Series([1.0, 1.3, 0.5]), feature.round(values))
+    assert_series_equal(pd.Series([1.0, 1.3, 0.5, 4.9]), feature.round(values))
+    # for not matching interval
+    values = pd.Series([0.4, 2.06])
+    feature = ContinuousInput(key="a", bounds=(0, 2.1), stepsize=0.5)
+    assert_series_equal(pd.Series([0.5, 2.1]), feature.round(values))
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to make BoFire better.

Help us to understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to BoFire here: https://github.com/experimental-desgin/bofire/blob/main/CONTRIBUTING.md
-->

## Motivation

Currently, one can provide a `stepsize` for a continuous input feature but it is not exploited. Here we make the first steps towards a working stepsize implementation. In case that a continuous input is not part of a constraint, it is rounded after candidate generation to the closest allowed value. For predictive strategies, the predictions are then calculated for the rounded value. 

It is a draft as it will be incorporated after the refactoring of the acqf optimization is included. 

cc: @LukasHebing 


### Have you read the [Contributing Guidelines on pull requests](https://github.com/experimental-design/bofire/blob/main/CONTRIBUTING.md#pull-requests)?

Y

## Test Plan

Unit tests.
