### PR TITLE
fix broken link in tutorials README.md

### DIFF
--- a/tutorials/README.md
+++ b/tutorials/README.md
@@ -4,7 +4,7 @@ The notebooks in this folder demonstrate the usage of bofire. The are organized 
 
 ### Getting Started
 
-`getting_started.ipynb` contains the python code of the getting started section of the  [GH pages getting started](https://experimental-design.github.io/bofire/start)
+`getting_started.ipynb` contains the python code of the getting started section of the  [GH pages getting started](https://experimental-design.github.io/bofire/getting_started/)
 
 ### Basic Examples
 


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to make BoFire better.

Help us to understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to BoFire here: https://github.com/experimental-desgin/bofire/blob/main/CONTRIBUTING.md
-->

Just a really minor thing - a link was broken. But I put it to review to follow the rules
