### PR TITLE
Use Seed Sequences for random number generation

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -68,7 +68,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ '3.10', '3.12' ]
+        python-version: [ '3.11', '3.12' ]
     steps:
       - name: Check out repo
         uses: actions/checkout@v4

--- a/bofire/strategies/random.py
+++ b/bofire/strategies/random.py
@@ -291,41 +291,18 @@ class RandomStrategy(Strategy):
             combined_eqs = unfixed_eqs + unfixed_interpoints  # type: ignore
 
             # now use the hit and run sampler
-            # this try except is needed as in the main branch of botorch the keyword argument
-            # `thinning` was changed to `n_thinning`, which is not yet in the latest release
-            # so we need to catch the TypeError and use the old keyword argument. As soon as the
-            # new release is out, we can remove this try except block.
-            # TODO: remove this try except block when the new release of botorch is out
-            try:
-                candidates = sample_q_batches_from_polytope(  # type: ignore
-                    n=1,
-                    q=n,
-                    bounds=bounds.to(**tkwargs),
-                    inequality_constraints=(
-                        unfixed_ineqs if len(unfixed_ineqs) > 0 else None  # type: ignore
-                    ),
-                    equality_constraints=combined_eqs
-                    if len(combined_eqs) > 0
-                    else None,
-                    n_burnin=n_burnin,
-                    thinning=n_thinning,  # type: ignore
-                    seed=seed,
-                ).squeeze(dim=0)
-            except TypeError:
-                candidates = sample_q_batches_from_polytope(
-                    n=1,
-                    q=n,
-                    bounds=bounds.to(**tkwargs),
-                    inequality_constraints=(
-                        unfixed_ineqs if len(unfixed_ineqs) > 0 else None  # type: ignore
-                    ),
-                    equality_constraints=combined_eqs
-                    if len(combined_eqs) > 0
-                    else None,
-                    n_burnin=n_burnin,
-                    n_thinning=n_thinning,
-                    seed=seed,
-                ).squeeze(dim=0)
+            candidates = sample_q_batches_from_polytope(
+                n=1,
+                q=n,
+                bounds=bounds.to(**tkwargs),
+                inequality_constraints=(
+                    unfixed_ineqs if len(unfixed_ineqs) > 0 else None  # type: ignore
+                ),
+                equality_constraints=combined_eqs if len(combined_eqs) > 0 else None,
+                n_burnin=n_burnin,
+                n_thinning=n_thinning,
+                seed=seed,
+            ).squeeze(dim=0)
 
             # check that the random generated candidates are not always the same
             if (candidates.unique(dim=0).shape[0] != n) and (n > 1):

--- a/bofire/strategies/random.py
+++ b/bofire/strategies/random.py
@@ -127,7 +127,7 @@ class RandomStrategy(Strategy):
             if candidate_count <= len(unused):
                 sampled_combinations = [
                     unused[i]
-                    for i in self.rng.choice(
+                    for i in np.random.default_rng(self._get_seed()).choice(
                         len(unused),
                         size=candidate_count,
                         replace=False,

--- a/bofire/strategies/strategy.py
+++ b/bofire/strategies/strategy.py
@@ -33,7 +33,7 @@ class Strategy(ABC):
             if data_model.seed is not None
             else np.random.default_rng().integers(1000)
         )
-        self.rng = np.random.default_rng(self.seed)
+        self.seed_seq = np.random.SeedSequence(self.seed)
         self._experiments = None
         self._candidates = None
 
@@ -45,7 +45,8 @@ class Strategy(ABC):
             int: random seed.
 
         """
-        return int(self.rng.integers(1, 100000))
+        (spawned_seed_seq,) = self.seed_seq.spawn(1)
+        return spawned_seed_seq.generate_state(1).item()
 
     @classmethod
     def from_spec(cls, data_model: DataModel) -> "Strategy":

--- a/bofire/strategies/strategy.py
+++ b/bofire/strategies/strategy.py
@@ -24,16 +24,12 @@ class Strategy(ABC):
     ):
         self.domain = data_model.domain
         # if data_model.seed is None (no explicit seed provided by the user),
-        # we draw a random seed from the default random number generator
-        # This is done to ensure reproducibility of the strategy,
+        # we use the randomly generated entropy from the seed sequence.
+        # This is done to ensure reproducibility of the strategy:
         # even if the user does not provide a seed one can extract the used seed
         # from the strategy object via `strategy.seed`.
-        self.seed = (
-            data_model.seed
-            if data_model.seed is not None
-            else np.random.default_rng().integers(1000)
-        )
-        self.seed_seq = np.random.SeedSequence(self.seed)
+        self.seed_seq = np.random.SeedSequence(data_model.seed)
+        self.seed = self.seed_seq.entropy
         self._experiments = None
         self._candidates = None
 

--- a/bofire/strategies/strategy.py
+++ b/bofire/strategies/strategy.py
@@ -28,7 +28,11 @@ class Strategy(ABC):
         # This is done to ensure reproducibility of the strategy,
         # even if the user does not provide a seed one can extract the used seed
         # from the strategy object via `strategy.seed`.
-        self.seed = data_model.seed or np.random.default_rng().integers(1000)
+        self.seed = (
+            data_model.seed
+            if data_model.seed is not None
+            else np.random.default_rng().integers(1000)
+        )
         self.rng = np.random.default_rng(self.seed)
         self._experiments = None
         self._candidates = None

--- a/tests/bofire/strategies/test_multi_fidelity.py
+++ b/tests/bofire/strategies/test_multi_fidelity.py
@@ -82,7 +82,7 @@ def test_mf_fidelity_selection():
     strategy = MultiFidelityStrategy(
         data_model=MultiFidelityStrategyDataModel(
             domain=benchmark.domain,
-            fidelity_thresholds=0.1,
+            fidelity_thresholds=0.2,
         )
     )
 


### PR DESCRIPTION
## Motivation

Currently, when generating random numbers, the `RandomStrategy` uses a `np.random.Generator` object to sample a random seed. The best practice for generating sequences of seeds is [`np.random.SeedSequence`](https://numpy.org/doc/2.2/reference/random/bit_generators/generated/numpy.random.SeedSequence.html). This PR now uses this in `Strategy`.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/experimental-design/bofire/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

All tests pass for `tests/bofire/strategies/test_random.py`.