### PR TITLE
bounds can be tuple

### DIFF
--- a/bofire/data_models/types.py
+++ b/bofire/data_models/types.py
@@ -1,5 +1,5 @@
 from collections.abc import Sequence
-from typing import Annotated, Dict, List, Union
+from typing import Annotated, Dict, List, Tuple, Union
 
 from pydantic import AfterValidator, Field, PositiveInt
 
@@ -92,7 +92,7 @@ Descriptors = Annotated[
 ]
 
 Bounds = Annotated[
-    List[float],
+    Union[List[float], Tuple[float, float]],
     Field(min_length=2, max_length=2),
     AfterValidator(validate_monotonically_increasing),
 ]


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to make BoFire better.

Help us to understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to BoFire here: https://github.com/experimental-desgin/bofire/blob/main/CONTRIBUTING.md
-->

## Motivation

Static type checkers will not complain if bounds are defined as tuples with two elements. With this change, lists and tuples can be used without complaints of static type checkers.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/experimental-design/bofire/blob/main/CONTRIBUTING.md#pull-requests)?

Y

## Test Plan

Should not have an impact on the runtime behaviour. Just a change of a type annotation.
