### PR TITLE
Strategy selector in documentation

### DIFF
--- a/docs/javascripts/selectortabs.js
+++ b/docs/javascripts/selectortabs.js
@@ -1,0 +1,92 @@
+const selectorTabStrategies = {
+    // map from tab labels to group names
+    "single-objective": "objective",
+    "multi-objective": "objective",
+    "single-task": "tasks",
+    "multi-task": "tasks",
+    "multi-fidelity": "tasks",
+    "simple-domain": "domain",
+    "many-categorical-features": "domain",
+}
+
+let strategies = {
+    "objective": "single-objective",
+    "tasks": "single-task",
+    "domain": "simple-domain",
+}
+
+const getStrategyCode = () => {
+    const objective = strategies["objective"];
+    const tasks = strategies["tasks"];
+    const domain = strategies["domain"];
+
+    let strategyDataModel = ""
+    if (objective == "single-objective") {
+        if (tasks == "single-task") {
+            if (domain == "simple-domain") {
+                strategyDataModel = "SoboStrategy"
+            } else if (domain == "many-categorical-features") {
+                strategyDataModel = "EntingStrategy"
+            }
+        } else if (tasks == "multi-task") {
+            strategyDataModel = "SoboStrategy"
+        } else if (tasks == "multi-fidelity") {
+            strategyDataModel = "MultiFidelityStrategy"
+            // we define multi fidelity as a multi-task where you can query the other fidelities
+        }
+    } else if (objective == "multi-objective") {
+        if (tasks == "single-task" && domain == "simple-domain") {
+            strategyDataModel = "MoboStrategy"
+        }
+    }
+
+    return hljs.highlight(
+`# import the data model
+from bofire.data_models.strategies.api import ${strategyDataModel}
+import bofire.strategies.api as strategies
+
+surrogate_data_model = BotorchSurrogates(surrogates=[
+    MultiTaskGPSurrogate(
+        inputs=domain.inputs,
+        outputs=domain.outputs,
+    )
+])
+
+strategy_data_model = ${strategyDataModel}(
+    domain=domain
+    surrogate=surrogate_data_model
+)
+strategy = strategies.map(strategy_data_model)
+`, { language : "python"}
+    )
+}
+
+const updateStrategyCodeBlock = () => {
+    const codeBlock = document.getElementById("stategyTemplate")
+    codeBlock.innerHTML = getStrategyCode().value
+}
+
+const tabSync = () => {
+    const tabs = document.querySelectorAll(".tabbed-set > input")
+    for (const tab of tabs) {
+      tab.addEventListener("click", () => {
+        const current = document.querySelector(`label[for=${tab.id}]`)
+        console.log(tab.id)
+        const pos = current.getBoundingClientRect().top
+        // const labels = document.querySelectorAll('.tabbed-set > label, .tabbed-alternate > .tabbed-labels > label')
+        
+        const updatedGroup = selectorTabStrategies[tab.id]
+        strategies[updatedGroup] = tab.id
+        updateStrategyCodeBlock()
+
+        // Preserve scroll position
+        const delta = (current.getBoundingClientRect().top) - pos
+        window.scrollBy(0, delta)
+      })
+    }
+  }
+
+document$.subscribe(function() {
+    console.log(document.title)
+    tabSync()
+})

--- a/docs/userguide_strategies.md
+++ b/docs/userguide_strategies.md
@@ -1,0 +1,19 @@
+# Strategies
+
+
+=== "Single Objective"
+
+=== "Multi Objective"
+
+===! "Single Task"
+
+=== "Multi Task"
+
+=== "Multi Fidelity"
+
+===! "Simple Domain"
+
+=== "Many categorical features"
+
+
+<pre><code id="stategyTemplate"> </ code><pre>

--- a/docs/userguide_strategies.md
+++ b/docs/userguide_strategies.md
@@ -1,15 +1,29 @@
 # Strategies
 
+<!-- 
+    https://github.com/sgbaird/honegumi 
+    https://github.com/facebook/Ax/issues/1479
+-->
+
+In BoFire, a `Strategy` provides an interface for proposing new experiments. 
+Below, we provide a tool for suggesting the most appropriate strategy for your
+Bayesian optimization problem. Our tool is inspired by [honegumi](https://github.com/sgbaird/honegumi).
+
+<div class="tab-marker" id="objective-marker"> </div>
 
 === "Single Objective"
 
 === "Multi Objective"
+
+<div class="tab-marker" id="tasks-marker"> </div>
 
 ===! "Single Task"
 
 === "Multi Task"
 
 === "Multi Fidelity"
+
+<div class="tab-marker" id="domain-marker"> </div>
 
 ===! "Simple Domain"
 

--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -9,6 +9,7 @@ nav:
   - Notebook page: getting_started.ipynb
   - Examples: examples.md
   - Data Models vs Functional Components: data_models_functionals.md
+  - Strategies: userguide_strategies.md
   - Surrogate Models: userguide_surrogates.md
   - API Reference:
     - Domain: ref-domain.md
@@ -60,10 +61,18 @@ markdown_extensions:
   - pymdownx.details
   - pymdownx.highlight
   - pymdownx.inlinehilite
+  - pymdownx.tabbed:
+      alternate_style: true
+      slugify: !!python/object/apply:pymdownx.slugs.slugify {kwds: {case: lower}}
   - admonition
 
+extra_css:
+  - https://cdn.jsdelivr.net/gh/highlightjs/cdn-release@11.11.1/build/styles/default.min.css
+
 extra_javascript:
+  - https://cdn.jsdelivr.net/gh/highlightjs/cdn-release@latest/build/highlight.min.js
   - javascripts/mathjax.js
+  - javascripts/selectortabs.js
   - https://unpkg.com/mathjax@3/es5/tex-mml-chtml.js
 
 extra:


### PR DESCRIPTION
## Motivation

Currently, there is no _Strategy_ page in the documentation, despite this being the main way that users will interact with BoFire. Additionally, the _Surrogates_ page can be quite overwhelming, with many options to choose from.

I propose we take inspiration from the excellent tool https://honegumi.readthedocs.io/en/latest/, which I found when trying to recreate the 'Install PyTorch' table on https://pytorch.org/. This PR has a rough implementation of this table, with a couple of example screenshots below:

![image](https://github.com/user-attachments/assets/51d50adf-f33c-4495-9104-729345308252)

Clicking on the "multi-task" link changes the code block appropriately:

![image](https://github.com/user-attachments/assets/772dfe1c-61ed-4c0d-a140-8f41373b6fbf)


### Have you read the [Contributing Guidelines on pull requests](https://github.com/experimental-design/bofire/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

The docs do not have associated tests. I will check on different devices/platforms that the interface works as intended.
