### PR TITLE
Dtype not specified in `ActiveLearningStrategy`

### DIFF
--- a/bofire/strategies/predictives/active_learning.py
+++ b/bofire/strategies/predictives/active_learning.py
@@ -11,6 +11,7 @@ from bofire.data_models.strategies.predictives.active_learning import (
     ActiveLearningStrategy as DataModel,
 )
 from bofire.strategies.predictives.botorch import BotorchStrategy
+from bofire.utils.torch_tools import tkwargs
 
 
 class ActiveLearningStrategy(BotorchStrategy):
@@ -33,7 +34,7 @@ class ActiveLearningStrategy(BotorchStrategy):
         random_model = RandomStrategy(domain=self.domain)
         sampler = strategies.map(random_model)
         mc_samples = sampler.ask(candidate_count=self.acquisition_function.n_mc_samples)
-        mc_samples = torch.tensor(mc_samples.values)
+        mc_samples = torch.tensor(mc_samples.values).to(**tkwargs)
 
         _, X_pending = self.get_acqf_input_tensors()
 


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to make BoFire better.

Help us to understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to BoFire here: https://github.com/experimental-desgin/bofire/blob/main/CONTRIBUTING.md
-->

## Motivation

Dtype was not specified for `mc_samples` in active learning strategy.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/experimental-design/bofire/blob/main/CONTRIBUTING.md#pull-requests)?

Y

## Test Plan

No need for additional tests.
