### PR TITLE
Expose `sequential` to data model

### DIFF
--- a/bofire/data_models/strategies/predictives/acqf_optimization.py
+++ b/bofire/data_models/strategies/predictives/acqf_optimization.py
@@ -105,6 +105,9 @@ class BotorchOptimizer(AcquisitionOptimizer):
     n_raw_samples: IntPowerOfTwo = 1024
     maxiter: PositiveInt = 2000
     batch_limit: Optional[PositiveInt] = Field(default=None, validate_default=True)
+    sequential: bool = False
+    # for a discussion on the use of sequential, have a look here
+    # https://github.com/pytorch/botorch/discussions/2810
 
     # encoding params
     descriptor_method: CategoricalMethodEnum = CategoricalMethodEnum.EXHAUSTIVE

--- a/bofire/strategies/predictives/acqf_optimization.py
+++ b/bofire/strategies/predictives/acqf_optimization.py
@@ -295,6 +295,7 @@ class BotorchOptimizer(AcquisitionOptimizer):
         self.n_raw_samples = data_model.n_raw_samples
         self.maxiter = data_model.maxiter
         self.batch_limit = data_model.batch_limit
+        self.sequential = data_model.sequential
 
         # just for completeness here, we should drop the support for FREE and only go over ones that are also
         # allowed, for more speedy optimization we can user other solvers
@@ -343,6 +344,7 @@ class BotorchOptimizer(AcquisitionOptimizer):
             nonlinear_constraints=nonlinears,  # type: ignore
             fixed_features=fixed_features,
             fixed_features_list=fixed_features_list,
+            sequential=self.sequential,
         )
 
         candidates = self._candidates_tensor_to_dataframe(
@@ -364,6 +366,7 @@ class BotorchOptimizer(AcquisitionOptimizer):
                 nonlinear_constraints=nonlinears,  # type: ignore
                 fixed_features=fixed_features,
                 fixed_features_list=fixed_features_list,
+                sequential=self.sequential,
             )
             if self.local_search_config.is_local_step(
                 local_acqf_val.item(),
@@ -398,6 +401,7 @@ class BotorchOptimizer(AcquisitionOptimizer):
         nonlinear_constraints: List[Callable[[Tensor], float]],
         fixed_features: Optional[Dict[int, float]],
         fixed_features_list: Optional[List[Dict[int, float]]],
+        sequential: bool,
     ) -> Tuple[Tensor, Tensor]:
         if len(acqfs) > 1:
             candidates, acqf_vals = optimize_acqf_list(
@@ -466,6 +470,7 @@ class BotorchOptimizer(AcquisitionOptimizer):
                 return_best_only=True,
                 options=self._get_optimizer_options(domain),  # type: ignore
                 ic_generator=ic_generator,
+                sequential=sequential,
                 **ic_gen_kwargs,
             )
         return candidates, acqf_vals


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to make BoFire better.

Help us to understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to BoFire here: https://github.com/experimental-desgin/bofire/blob/main/CONTRIBUTING.md
-->

## Motivation

Following discussion https://github.com/pytorch/botorch/discussions/2810, this PR adds the possibility to explicitly toggle between sequential and parallel batch candidate generation for the botorch optimizer. It applies only to the case where `optimize_acqf` is used, all other cases are sequential in itself.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/experimental-design/bofire/blob/main/CONTRIBUTING.md#pull-requests)?

Y.

## Test Plan

Not necessary for this PR.
