### PR TITLE
595 bug categorical doe unstable

### DIFF
--- a/bofire/strategies/doe/utils.py
+++ b/bofire/strategies/doe/utils.py
@@ -50,7 +50,7 @@ def represent_categories_as_by_their_states(
         )
 
         # enforce categoricals excluding each other
-        all_but_one_categoricals = categorical_one_hot_variabes
+        all_but_one_categoricals = categorical_one_hot_variabes[:-1]
 
     return list(inputs.get(excludes=[CategoricalInput])), all_but_one_categoricals  # type: ignore
 

--- a/bofire/strategies/doe/utils.py
+++ b/bofire/strategies/doe/utils.py
@@ -226,15 +226,12 @@ def interactions_terms(
     """
     inputs = continuous_inputs + categorical_inputs
     formula = ""
-    for i in range(len(inputs)):
-        for j in range(i):
-            a = inputs[i]
-            b = inputs[j]
-            if a != b and not (
-                (a.key in categorical_inputs.get_keys())
-                and (b.key in categorical_inputs.get_keys())
-            ):
-                formula += a.key + ":" + b.key + " + "
+    for c in combinations(range(len(inputs)), 2):
+        if not (
+            (inputs.get_keys()[c[0]] in categorical_inputs.get_keys())
+            and (inputs.get_keys()[c[1]] in categorical_inputs.get_keys())
+        ):
+            formula += inputs.get_keys()[c[0]] + ":" + inputs.get_keys()[c[1]] + " + "
     return formula
 
 

--- a/bofire/strategies/doe/utils.py
+++ b/bofire/strategies/doe/utils.py
@@ -41,6 +41,7 @@ CYIPOPT_AVAILABLE = importlib.util.find_spec("cyipopt") is not None
 def represent_categories_as_by_their_states(
     inputs: Inputs,
 ) -> Tuple[List[ContinuousInput], List[CategoricalInput]]:
+    all_but_one_categoricals = []
     if len(inputs.get([CategoricalInput])) > 0:
         inputs = copy(inputs)
         categorical_inputs = list(inputs.get([CategoricalInput]))
@@ -49,7 +50,7 @@ def represent_categories_as_by_their_states(
         )
 
         # enforce categoricals excluding each other
-        all_but_one_categoricals = categorical_one_hot_variabes[:-1]
+        all_but_one_categoricals = categorical_one_hot_variabes
 
     return list(inputs.get(excludes=[CategoricalInput])), all_but_one_categoricals  # type: ignore
 

--- a/bofire/strategies/doe/utils_categorical_discrete.py
+++ b/bofire/strategies/doe/utils_categorical_discrete.py
@@ -37,7 +37,9 @@ def map_discrete_to_continuous(
     """
 
     def generate_value_key(input: DiscreteInput, d: float):
-        return f"aux_{input.key}_{str(d).replace('.', '_')}"
+        return (
+            f"aux_{input.key}_{str(d).replace('.', '__decpt__').replace('-','__neg__')}"
+        )
 
     # Create a new list of inputs
     new_inputs = []

--- a/bofire/strategies/doe/utils_categorical_discrete.py
+++ b/bofire/strategies/doe/utils_categorical_discrete.py
@@ -7,7 +7,6 @@ import pandas as pd
 from bofire.data_models.constraints.api import (
     LinearEqualityConstraint,
     LinearInequalityConstraint,
-    NChooseKConstraint,
 )
 from bofire.data_models.domain.api import Constraints, Domain, Inputs
 from bofire.data_models.features.api import (
@@ -144,14 +143,6 @@ def map_categorical_to_continuous(
                 features=[i.key for i in new_auxiliary_inputs_for_input],
                 coefficients=[1] * len(new_auxiliary_inputs_for_input),
                 rhs=1,
-            )
-        )
-        new_constraints.append(
-            NChooseKConstraint(
-                features=[i.key for i in new_auxiliary_inputs_for_input],
-                min_count=0,
-                max_count=1,
-                none_also_valid=True,
             )
         )
 

--- a/bofire/strategies/doe_strategy.py
+++ b/bofire/strategies/doe_strategy.py
@@ -114,29 +114,31 @@ class DoEStrategy(Strategy):
                     mapped_aux_categorical_inputs=mapped_aux_categorical_inputs,
                 )
             )
-            # if only categoricals in domain
-            if len(self.domain.inputs) == len(
-                self.domain.inputs.get([CategoricalInput])
-            ):
-                return design_categoricals.iloc[
-                    fixed_experiments_count:, :
-                ].reset_index(
-                    drop=True,
+            # if no discrete in domain
+            if len(self.domain.inputs.get([DiscreteInput])) == 0:
+                return (
+                    design_categoricals.join(design_no_categoricals)
+                    .iloc[fixed_experiments_count:, :]
+                    .reset_index(
+                        drop=True,
+                    )
                 )
-            design_projected = project_candidates_into_domain(
-                domain=self.domain,
-                candidates=design_no_categoricals,
-                mapping_discrete_input_to_discrete_aux=mapping_discrete_input_to_discrete_aux,
-                keys_continuous_inputs=[
-                    continuous_input.key for continuous_input in mapped_continous_inputs
-                ],
-                scip_params=self._data_model.scip_params,
-            )
-            design = filter_out_discrete_auxilliary_vars(
-                design_projected,
-                aux_vars_for_discrete=aux_vars_for_discrete,
-            )
-            design = pd.concat([design, design_categoricals], axis=1)
+            else:
+                design_projected = project_candidates_into_domain(
+                    domain=self.domain,
+                    candidates=design_no_categoricals,
+                    mapping_discrete_input_to_discrete_aux=mapping_discrete_input_to_discrete_aux,
+                    keys_continuous_inputs=[
+                        continuous_input.key
+                        for continuous_input in mapped_continous_inputs
+                    ],
+                    scip_params=self._data_model.scip_params,
+                )
+                design = filter_out_discrete_auxilliary_vars(
+                    design_projected,
+                    aux_vars_for_discrete=aux_vars_for_discrete,
+                )
+                design = pd.concat([design, design_categoricals], axis=1)
         if self._return_fixed_candidates:
             fixed_experiments_count = 0
         return design.iloc[fixed_experiments_count:, :].reset_index(

--- a/tests/bofire/strategies/doe/test_utils.py
+++ b/tests/bofire/strategies/doe/test_utils.py
@@ -47,7 +47,7 @@ def get_formula_from_string_recursion_limit():
     model = model[:-3]
     model = get_formula_from_string(model_type=model)
 
-    terms = ["1"] + [f"x{i}" for i in range(350)]
+    terms = [f"x{i}" for i in range(350)]
     terms.append("1")
 
     for i in range(351):

--- a/tests/bofire/strategies/doe/test_utils.py
+++ b/tests/bofire/strategies/doe/test_utils.py
@@ -47,7 +47,7 @@ def get_formula_from_string_recursion_limit():
     model = model[:-3]
     model = get_formula_from_string(model_type=model)
 
-    terms = [f"x{i}" for i in range(350)]
+    terms = ["1"] + [f"x{i}" for i in range(350)]
     terms.append("1")
 
     for i in range(351):
@@ -773,4 +773,4 @@ def test_formula_discrete_handled_like_continuous():
 
 
 if __name__ == "__main__":
-    test_formula_discrete_handled_like_continuous()
+    get_formula_from_string_recursion_limit()

--- a/tests/bofire/strategies/doe/test_utils_categorical_discrete.py
+++ b/tests/bofire/strategies/doe/test_utils_categorical_discrete.py
@@ -24,7 +24,7 @@ def test_domain_relaxation():
     domain = Domain(
         inputs=Inputs(
             features=[
-                DiscreteInput(key="x1", values=[0.3, 5]),
+                DiscreteInput(key="x1", values=[-0.3, 5]),
                 DiscreteInput(key="x2", values=[0.7, 10]),
                 ContinuousInput(key="x3", bounds=[10, 11]),
                 ContinuousInput(key="x4", bounds=[5, 11]),
@@ -71,29 +71,29 @@ def test_domain_relaxation():
 
     assert len(mapped_continous_inputs) == 2
 
-    assert "aux_x1_0_3" in mapping_discrete_input_to_discrete_aux["x1"]
-    assert "aux_x1_5_0" in mapping_discrete_input_to_discrete_aux["x1"]
+    assert "aux_x1___neg__0__decpt__3" in mapping_discrete_input_to_discrete_aux["x1"]
+    assert "aux_x1_5__decpt__0" in mapping_discrete_input_to_discrete_aux["x1"]
 
-    assert "aux_x2_0_7" in mapping_discrete_input_to_discrete_aux["x2"]
-    assert "aux_x2_10_0" in mapping_discrete_input_to_discrete_aux["x2"]
+    assert "aux_x2_0__decpt__7" in mapping_discrete_input_to_discrete_aux["x2"]
+    assert "aux_x2_10__decpt__0" in mapping_discrete_input_to_discrete_aux["x2"]
 
     assert LinearEqualityConstraint(
-        features=["aux_x1_0_3", "aux_x1_5_0"],
+        features=["aux_x1___neg__0__decpt__3", "aux_x1_5__decpt__0"],
         coefficients=[1] * 2,
         rhs=1,
     ) in relaxed_domain.constraints.get([LinearEqualityConstraint])
     assert LinearEqualityConstraint(
-        features=["aux_x2_0_7", "aux_x2_10_0"],
+        features=["aux_x2_0__decpt__7", "aux_x2_10__decpt__0"],
         coefficients=[1] * 2,
         rhs=1,
     ) in relaxed_domain.constraints.get([LinearEqualityConstraint])
     assert LinearEqualityConstraint(
-        features=["x1", "aux_x1_0_3", "aux_x1_5_0"],
-        coefficients=[1.0] + [-0.3, -5.0],
+        features=["x1", "aux_x1___neg__0__decpt__3", "aux_x1_5__decpt__0"],
+        coefficients=[1.0] + [0.3, -5.0],
         rhs=0.0,
     ) in relaxed_domain.constraints.get([LinearEqualityConstraint])
     assert LinearEqualityConstraint(
-        features=["x2", "aux_x2_0_7", "aux_x2_10_0"],
+        features=["x2", "aux_x2_0__decpt__7", "aux_x2_10__decpt__0"],
         coefficients=[1.0] + [-0.7, -10.0],
         rhs=0.0,
     ) in relaxed_domain.constraints.get([LinearEqualityConstraint])
@@ -128,10 +128,10 @@ def test_domain_relaxation():
                     "x2",
                     "x3",
                     "x4",
-                    "aux_x1_0_3",
-                    "aux_x1_5_0",
-                    "aux_x2_0_7",
-                    "aux_x2_10_0",
+                    "aux_x1___neg__0__decpt__3",
+                    "aux_x1_5__decpt__0",
+                    "aux_x2_0__decpt__7",
+                    "aux_x2_10__decpt__0",
                 ]
             ],
             df_sample[
@@ -140,10 +140,10 @@ def test_domain_relaxation():
                     "x2",
                     "x3",
                     "x4",
-                    "aux_x1_0_3",
-                    "aux_x1_5_0",
-                    "aux_x2_0_7",
-                    "aux_x2_10_0",
+                    "aux_x1___neg__0__decpt__3",
+                    "aux_x1_5__decpt__0",
+                    "aux_x2_0__decpt__7",
+                    "aux_x2_10__decpt__0",
                 ]
             ],
             check_dtype=False,

--- a/tests/bofire/strategies/doe/test_utils_categorical_discrete.py
+++ b/tests/bofire/strategies/doe/test_utils_categorical_discrete.py
@@ -60,7 +60,7 @@ def test_domain_relaxation():
     assert len(relaxed_domain.inputs.get([ContinuousInput])) == 11
     assert len(relaxed_domain.constraints.get([LinearInequalityConstraint])) == 1
     assert len(relaxed_domain.constraints.get([LinearEqualityConstraint])) == 6
-    assert len(relaxed_domain.constraints.get([NChooseKConstraint])) == 1
+    assert len(relaxed_domain.constraints.get([NChooseKConstraint])) == 0
 
     assert len(mappings_categorical_var_key_to_aux_var_key_state_pairs) == 1
     assert len(mapping_discrete_input_to_discrete_aux) == 2

--- a/tests/bofire/strategies/doe/test_utils_categorical_discrete.py
+++ b/tests/bofire/strategies/doe/test_utils_categorical_discrete.py
@@ -110,7 +110,6 @@ def test_domain_relaxation():
     df_sample = relaxed_domain.inputs.sample(10)
     assert len(df_sample) == 10
     assert len(df_sample.columns) == 11
-    print(df_sample)
 
     df_no_categorical, df_categorical = (
         filter_out_categorical_and_categorical_auxilliary_vars(

--- a/tests/bofire/strategies/test_doe.py
+++ b/tests/bofire/strategies/test_doe.py
@@ -527,7 +527,6 @@ def test_free_discrete_doe():
     strategy = DoEStrategy(data_model=data_model)
     n_exp = strategy.get_required_number_of_experiments()
     candidates = strategy.ask(candidate_count=n_exp, raise_validation_error=True)
-    print(candidates)
     assert candidates.shape == (n_exp, 3)
     # check only lb and ub are values in candidates
     for col in all_inputs:
@@ -586,7 +585,6 @@ def test_discrete_and_categorical_doe_w_constraints():
     strategy = DoEStrategy(data_model=data_model)
     n_exp = strategy.get_required_number_of_experiments()
     candidates = strategy.ask(candidate_count=n_exp, raise_validation_error=True)
-    print(candidates)
     assert candidates.shape == (n_exp, 7)
 
 

--- a/tests/bofire/strategies/test_doe.py
+++ b/tests/bofire/strategies/test_doe.py
@@ -886,4 +886,4 @@ def one_cont_3_cat():
 
 
 if __name__ == "__main__":
-    test_discrete_and_categorical_doe_w_constraints_num_of_experiments()
+    test_partially_fixed_experiments()

--- a/tests/bofire/strategies/test_doe.py
+++ b/tests/bofire/strategies/test_doe.py
@@ -624,8 +624,8 @@ def test_discrete_and_categorical_doe_w_constraints_num_of_experiments():
     excepted_model_string = {
         "linear": "1 + a + b + aux_c_meep",
         "linear-and-quadratic": "1 + a + b + aux_c_meep + a ** 2 + b ** 2",
-        "linear-and-interactions": "1 + a + b + aux_c_meep + b:a + aux_c_meep:a + aux_c_meep:b",
-        "fully-quadratic": "1 + a + b + aux_c_meep + a ** 2 + b ** 2 + b:a + aux_c_meep:a + aux_c_meep:b",
+        "linear-and-interactions": "1 + a + b + aux_c_meep + a:aux_c_meep + a:b + aux_c_meep:b",
+        "fully-quadratic": "1 + a + b + aux_c_meep + a ** 2 + b ** 2 + a:aux_c_meep + a:b + aux_c_meep:b",
     }
 
     for model_type in [
@@ -684,8 +684,8 @@ def test_discrete_and_categorical_doe_w_constraints_num_of_experiments():
     excepted_model_string = {
         "linear": "1 + a + b + aux_c_meep + aux_c_moop",
         "linear-and-quadratic": "1 + a + b + aux_c_meep + aux_c_moop + a ** 2 + b ** 2",
-        "linear-and-interactions": "1 + a + b + aux_c_meep + aux_c_moop + b:a + aux_c_meep:a + aux_c_meep:b + aux_c_moop:a + aux_c_moop:b",
-        "fully-quadratic": "1 + a + b + aux_c_meep + aux_c_moop + a ** 2 + b ** 2 + b:a + aux_c_meep:a + aux_c_meep:b + aux_c_moop:a + aux_c_moop:b",
+        "linear-and-interactions": "1 + a + b + aux_c_meep + aux_c_moop + a:aux_c_meep + a:aux_c_moop + a:b + aux_c_meep:b + aux_c_moop:b",
+        "fully-quadratic": "1 + a + b + aux_c_meep + aux_c_moop + a ** 2 + b ** 2 + a:aux_c_meep + a:aux_c_moop + a:b + aux_c_meep:b + aux_c_moop:b",
     }
 
     for model_type in [

--- a/tests/bofire/strategies/test_doe.py
+++ b/tests/bofire/strategies/test_doe.py
@@ -509,8 +509,8 @@ def test_free_discrete_doe():
     torch.cuda.manual_seed(0)
 
     all_inputs = [
-        DiscreteInput(key="a_discrete", values=[0.1, 0.2, 0.3, 1.6, 2], rtol=1e-3),
-        DiscreteInput(key="b_discrete", values=[0.0, 0.2, 0.3, 1.6, 10], rtol=1e-3),
+        DiscreteInput(key="a_discrete", values=[-0.1, 0.2, 0.3, 1.6, 2], rtol=1e-3),
+        DiscreteInput(key="b_discrete", values=[-0.1, 0.0, 0.2, 0.3, 1.6], rtol=1e-3),
         DiscreteInput(key="c_discrete", values=[0.0, 5, 8, 10], rtol=1e-3),
     ]
     domain = Domain.from_lists(
@@ -527,6 +527,7 @@ def test_free_discrete_doe():
     strategy = DoEStrategy(data_model=data_model)
     n_exp = strategy.get_required_number_of_experiments()
     candidates = strategy.ask(candidate_count=n_exp, raise_validation_error=True)
+    print(candidates)
     assert candidates.shape == (n_exp, 3)
     # check only lb and ub are values in candidates
     for col in all_inputs:
@@ -548,7 +549,9 @@ def test_discrete_and_categorical_doe_w_constraints():
     ]
     all_inputs = [
         DiscreteInput(key="a_discrete", values=[0.1, 0.2, 0.3, 1.6, 2], rtol=1e-3),
-        DiscreteInput(key="b_discrete", values=[0.0, 0.2, 0.3, 1.6, 10], rtol=1e-3),
+        DiscreteInput(
+            key="b_discrete", values=[-1.0, 0.0, 0.2, 0.3, 1.6, 10], rtol=1e-3
+        ),
         DiscreteInput(key="c_discrete", values=[0.0, 5, 8, 10], rtol=1e-3),
         CategoricalInput(key="flatulent_butterfly", categories=["pff", "pf", "pffpff"]),
         CategoricalInput(key="farting_turtle", categories=["meep", "moop"]),
@@ -583,6 +586,7 @@ def test_discrete_and_categorical_doe_w_constraints():
     strategy = DoEStrategy(data_model=data_model)
     n_exp = strategy.get_required_number_of_experiments()
     candidates = strategy.ask(candidate_count=n_exp, raise_validation_error=True)
+    print(candidates)
     assert candidates.shape == (n_exp, 7)
 
 
@@ -862,4 +866,4 @@ def one_cont_3_cat():
 
 
 if __name__ == "__main__":
-    one_cont_3_cat()
+    test_free_discrete_doe()

--- a/tests/bofire/strategies/test_doe.py
+++ b/tests/bofire/strategies/test_doe.py
@@ -886,4 +886,6 @@ def one_cont_3_cat():
 
 
 if __name__ == "__main__":
-    test_partially_fixed_experiments()
+    test_discrete_and_categorical_doe_w_constraints_num_of_experiments()
+    test_purely_categorical_doe()
+    one_cont_3_cat()


### PR DESCRIPTION


<!--
Thank you for sending the PR! We appreciate you spending the time to make BoFire better.

Help us to understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to BoFire here: https://github.com/experimental-desgin/bofire/blob/main/CONTRIBUTING.md
-->

## Motivation

[edit Behrang]
The actual problem was a segmentation fault. This has been fixed by checking that smart rounding is only applied if discrete inputs exist. Further, this PR contains additional fixes that were found during debugging.

- A faulty n-choose-k constraint avoided categoricals to be optimized. This has been removed. However, this constraint made sure that the number of experiments was correct. The actual reason for the wrong number of experiments was a wrong formulaic formula. This formula has been fixed.
- Underscores and minus signs in formula strings made problems. Has been fixed by using unambiguous strings instead.
- In the creation of the formula string we have to separate numerical and categoricals because we cannot calculate with categorical.

[/edit]

### Have you read the [Contributing Guidelines on pull requests](https://github.com/experimental-design/bofire/blob/main/CONTRIBUTING.md#pull-requests)?

[edit Behrang]
Yes
[/edit]

## Test Plan

[edit Behrang]
Unit tests have been extended.
[/edit]