### PR TITLE
Ordinal encoding for surrogates for mixed alternating optimization

### DIFF
--- a/bofire/data_models/domain/features.py
+++ b/bofire/data_models/domain/features.py
@@ -475,7 +475,7 @@ class Inputs(_BaseFeatures[AnyInput]):
 
         num_values = num_cats + num_discretes
 
-        return functools.reduce(operator.mul, num_values)
+        return functools.reduce(operator.mul, num_values, 1)
 
     # transformation related methods
     def _get_transform_info(

--- a/bofire/data_models/domain/features.py
+++ b/bofire/data_models/domain/features.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
+import functools
 import itertools
+import operator
 import re
 import warnings
 from collections.abc import Iterator, Sequence
@@ -435,6 +437,45 @@ class Inputs(_BaseFeatures[AnyInput]):
         list_of_lists = list_of_lists + list_of_lists_2
 
         return list(itertools.product(*list_of_lists))
+
+    def get_num_categorical_combinations(
+        self,
+        include: Union[Type, List[Type]] = Input,
+        exclude: Union[Type, List[Type]] = None,  # type: ignore
+    ) -> int:
+        """Get the total number of unique categorical combinations.
+
+        This is used before generating all of the categorical combinations, which may
+        cause memory issues if there are too many.
+
+        Args:
+            include (Feature, optional): Features to be included. Defaults to Input.
+            exclude (Feature, optional): Features to be excluded, e.g. subclasses
+                of the included features. Defaults to None.
+
+        Returns:
+            int: Returns the number of unique combinations of discrete and categorical
+                features.
+
+        """
+        features = [
+            f
+            for f in self.get(includes=include, excludes=exclude)
+            if (isinstance(f, CategoricalInput) and not f.is_fixed())
+        ]
+        num_cats = [len(f.get_allowed_categories()) for f in features]
+
+        discretes = [
+            f
+            for f in self.get(includes=include, excludes=exclude)
+            if (isinstance(f, DiscreteInput) and not f.is_fixed())
+        ]
+
+        num_discretes = [len(d.values) for d in discretes]
+
+        num_values = num_cats + num_discretes
+
+        return functools.reduce(operator.mul, num_values)
 
     # transformation related methods
     def _get_transform_info(

--- a/bofire/data_models/strategies/predictives/acqf_optimization.py
+++ b/bofire/data_models/strategies/predictives/acqf_optimization.py
@@ -8,13 +8,9 @@ from bofire.data_models.base import BaseModel
 from bofire.data_models.constraints import api as constraints
 from bofire.data_models.constraints.api import InterpointConstraint
 from bofire.data_models.domain.domain import Domain
-from bofire.data_models.enum import CategoricalEncodingEnum, CategoricalMethodEnum
-from bofire.data_models.features.api import CategoricalDescriptorInput, ContinuousInput
+from bofire.data_models.features.api import ContinuousInput
 from bofire.data_models.strategies.shortest_path import has_local_search_region
-from bofire.data_models.surrogates.api import (
-    BotorchSurrogates,
-    MixedSingleTaskGPSurrogate,
-)
+from bofire.data_models.surrogates.api import BotorchSurrogates
 from bofire.data_models.types import IntPowerOfTwo
 
 
@@ -109,11 +105,6 @@ class BotorchOptimizer(AcquisitionOptimizer):
     # for a discussion on the use of sequential, have a look here
     # https://github.com/pytorch/botorch/discussions/2810
 
-    # encoding params
-    descriptor_method: CategoricalMethodEnum = CategoricalMethodEnum.EXHAUSTIVE
-    categorical_method: CategoricalMethodEnum = CategoricalMethodEnum.EXHAUSTIVE
-    discrete_method: CategoricalMethodEnum = CategoricalMethodEnum.EXHAUSTIVE
-
     # local search region params
     local_search_config: Optional[AnyLocalSearchConfig] = None
 
@@ -169,32 +160,36 @@ class BotorchOptimizer(AcquisitionOptimizer):
         validate_interpoint_constraints(domain)
 
     def validate_surrogate_specs(self, surrogate_specs: BotorchSurrogates):
+        pass
+        # FIXME: I don't think any of these checks are required - should we delete this
+        # method?
+
         # we also have to check here that the categorical method is compatible with the chosen models
         # categorical_method = (
         #   values["categorical_method"] if "categorical_method" in values else None
         # )
 
-        if self.categorical_method == CategoricalMethodEnum.FREE:
-            for m in surrogate_specs.surrogates:
-                if isinstance(m, MixedSingleTaskGPSurrogate):
-                    raise ValueError(
-                        "Categorical method FREE not compatible with a a MixedSingleTaskGPModel.",
-                    )
-        # we also check that if a categorical with descriptor method is used as one hot encoded the same method is
-        # used for the descriptor as for the categoricals
-        for m in surrogate_specs.surrogates:
-            keys = m.inputs.get_keys(CategoricalDescriptorInput)
-            for k in keys:
-                input_proc_specs = (
-                    m.input_preprocessing_specs[k]
-                    if k in m.input_preprocessing_specs
-                    else None
-                )
-                if input_proc_specs == CategoricalEncodingEnum.ONE_HOT:
-                    if self.categorical_method != self.descriptor_method:
-                        raise ValueError(
-                            "One-hot encoded CategoricalDescriptorInput features has to be treated with the same method as categoricals.",
-                        )
+        # if self.categorical_method == CategoricalMethodEnum.FREE:
+        #     for m in surrogate_specs.surrogates:
+        #         if isinstance(m, MixedSingleTaskGPSurrogate):
+        #             raise ValueError(
+        #                 "Categorical method FREE not compatible with a a MixedSingleTaskGPModel.",
+        #             )
+        # # we also check that if a categorical with descriptor method is used as one hot encoded the same method is
+        # # used for the descriptor as for the categoricals
+        # for m in surrogate_specs.surrogates:
+        #     keys = m.inputs.get_keys(CategoricalDescriptorInput)
+        #     for k in keys:
+        #         input_proc_specs = (
+        #             m.input_preprocessing_specs[k]
+        #             if k in m.input_preprocessing_specs
+        #             else None
+        #         )
+        #         if input_proc_specs == CategoricalEncodingEnum.ONE_HOT:
+        #             if self.categorical_method != self.descriptor_method:
+        #                 raise ValueError(
+        #                     "One-hot encoded CategoricalDescriptorInput features has to be treated with the same method as categoricals.",
+        #                 )
 
 
 class GeneticAlgorithmOptimizer(AcquisitionOptimizer):

--- a/bofire/data_models/surrogates/botorch.py
+++ b/bofire/data_models/surrogates/botorch.py
@@ -25,14 +25,14 @@ class BotorchSurrogate(Surrogate):
         descriptor_keys = inputs.get_keys(CategoricalDescriptorInput, exact=True)
         molecular_keys = inputs.get_keys(MolecularInput, exact=True)
         for key in categorical_keys:
-            if (
-                v.get(key, CategoricalEncodingEnum.ONE_HOT)
-                != CategoricalEncodingEnum.ONE_HOT
-            ):
-                raise ValueError(
-                    "Botorch based models have to use one hot encodings for categoricals",
-                )
-            v[key] = CategoricalEncodingEnum.ONE_HOT
+            # if (
+            #     v.get(key, CategoricalEncodingEnum.ONE_HOT)
+            #     != CategoricalEncodingEnum.ONE_HOT
+            # ):
+            #     raise ValueError(
+            #         "Botorch based models have to use one hot encodings for categoricals",
+            #     )
+            v.setdefault(key, CategoricalEncodingEnum.ONE_HOT)
         # TODO: include descriptors into probabilistic reparam via OneHotToDescriptor input transform
         for key in descriptor_keys:
             if v.get(key, CategoricalEncodingEnum.DESCRIPTOR) not in [
@@ -42,8 +42,7 @@ class BotorchSurrogate(Surrogate):
                 raise ValueError(
                     "Botorch based models have to use one hot encodings or descriptor encodings for categoricals.",
                 )
-            if v.get(key) is None:
-                v[key] = CategoricalEncodingEnum.DESCRIPTOR
+            v.setdefault(key, CategoricalEncodingEnum.DESCRIPTOR)
         for key in inputs.get_keys(NumericalInput):
             if v.get(key) is not None:
                 raise ValueError(

--- a/bofire/data_models/surrogates/mixed_single_task_gp.py
+++ b/bofire/data_models/surrogates/mixed_single_task_gp.py
@@ -108,11 +108,14 @@ class MixedSingleTaskGPSurrogate(TrainableBotorchSurrogate):
     @classmethod
     def validate_categoricals(cls, v, values):
         """Checks that at least one one-hot encoded categorical feature is present."""
-        return v
-        # TODO: do we need to validate categoricals?
-        if CategoricalEncodingEnum.ONE_HOT not in v.values():
+        supported_encodings = {
+            CategoricalEncodingEnum.ONE_HOT,
+            CategoricalEncodingEnum.ORDINAL,
+        }
+        if not supported_encodings.intersection(v.values()):
             raise ValueError(
-                "MixedSingleTaskGPSurrogate can only be used if at least one one-hot encoded categorical feature is present.",
+                "MixedSingleTaskGPSurrogate can only be used if at least one one-hot "
+                "or ordinal encoded categorical feature is present.",
             )
         return v
 

--- a/bofire/data_models/surrogates/mixed_single_task_gp.py
+++ b/bofire/data_models/surrogates/mixed_single_task_gp.py
@@ -108,6 +108,8 @@ class MixedSingleTaskGPSurrogate(TrainableBotorchSurrogate):
     @classmethod
     def validate_categoricals(cls, v, values):
         """Checks that at least one one-hot encoded categorical feature is present."""
+        return v
+        # TODO: do we need to validate categoricals?
         if CategoricalEncodingEnum.ONE_HOT not in v.values():
             raise ValueError(
                 "MixedSingleTaskGPSurrogate can only be used if at least one one-hot encoded categorical feature is present.",

--- a/bofire/surrogates/mixed_single_task_gp.py
+++ b/bofire/surrogates/mixed_single_task_gp.py
@@ -93,9 +93,9 @@ class MixedSingleTaskGPSurrogate(BotorchSurrogate, TrainableSurrogate):
         )
         tfs = {}
         if scaler is not None:
-            tfs["tf1"] = scaler
+            tfs["scaler"] = scaler
         if o2n is not None:
-            tfs["tf2"] = o2n
+            tfs["o2n"] = o2n
 
         tf = ChainedInputTransform(**tfs) if tfs else None
 

--- a/bofire/surrogates/mixed_single_task_gp.py
+++ b/bofire/surrogates/mixed_single_task_gp.py
@@ -5,7 +5,7 @@ import botorch
 import pandas as pd
 import torch
 from botorch.fit import fit_gpytorch_mll
-from botorch.models.transforms.input import ChainedInputTransform, OneHotToNumeric
+from botorch.models.transforms.input import ChainedInputTransform
 from botorch.models.transforms.outcome import Standardize
 from gpytorch.mlls import ExactMarginalLogLikelihood
 
@@ -64,31 +64,39 @@ class MixedSingleTaskGPSurrogate(BotorchSurrogate, TrainableSurrogate):
         categorical_feature_keys = get_categorical_feature_keys(
             self.input_preprocessing_specs,
         )
-        # these are the categorical dimensions after applying the OneHotToNumeric transform
+        o2n = None
+        # TODO: apply OneHotToNumeric to approriate dimensions
+        # # these are the categorical dimensions after applying the OneHotToNumeric transform
         cat_dims = list(
             range(len(ord_dims), len(ord_dims) + len(categorical_feature_keys)),
         )
 
-        features2idx, _ = self.inputs._get_transform_info(
-            self.input_preprocessing_specs,
-        )
+        # features2idx, _ = self.inputs._get_transform_info(
+        #     self.input_preprocessing_specs,
+        # )
 
-        # these are the categorical features within the the OneHotToNumeric transform
-        categorical_features = {
-            features2idx[feat][0]: len(features2idx[feat])
-            for feat in categorical_feature_keys
-        }
+        # # these are the categorical features within the the OneHotToNumeric transform
+        # categorical_features = {
+        #     features2idx[feat][0]: len(features2idx[feat])
+        #     for feat in categorical_feature_keys
+        # }
 
-        o2n = OneHotToNumeric(
-            dim=tX.shape[1],
-            categorical_features=categorical_features,
-            transform_on_train=False,
-        )
-        tf = ChainedInputTransform(tf1=scaler, tf2=o2n) if scaler is not None else o2n
+        # o2n = OneHotToNumeric(
+        #     dim=tX.shape[1],
+        #     categorical_features=categorical_features,
+        #     transform_on_train=False,
+        # )
+        tfs = {}
+        if scaler is not None:
+            tfs["tf1"] = scaler
+        if o2n is not None:
+            tfs["tf2"] = o2n
+
+        tf = ChainedInputTransform(**tfs) if tfs else None
 
         # fit the model
         self.model = botorch.models.MixedSingleTaskGP(
-            train_X=o2n.transform(tX),
+            train_X=o2n.transform(tX) if o2n is not None else tX,
             train_Y=tY,
             cat_dims=cat_dims,
             # cont_kernel_factory=self.continuous_kernel.to_gpytorch,

--- a/tests/bofire/surrogates/test_gps.py
+++ b/tests/bofire/surrogates/test_gps.py
@@ -527,7 +527,9 @@ def test_MixedSingleTaskGPModel(kernel, scaler, output_scaler):
         ).all()
         assert isinstance(model.model.input_transform.tf2, OneHotToNumeric)
     else:
-        assert isinstance(model.model.input_transform, OneHotToNumeric)
+        assert isinstance(model.model.input_transform, ChainedInputTransform)
+        assert "tf1" not in model.model.input_transform
+        assert isinstance(model.model.input_transform.tf2, OneHotToNumeric)
     assert model.is_compatibilized is False
     # reload the model from dump and check for equality in predictions
     model2 = MixedSingleTaskGPSurrogate(


### PR DESCRIPTION
## Motivation

This PR removes the requirement that Botorch surrogates must have a one-hot encoding. This should make BoFire more flexible. This PR also introduces mixed alternating optimization (https://github.com/pytorch/botorch/pull/2866), which requires inputs to have an integer encoding.

See issue #579. I would also recommend addressing #459 in this PR, since we are changing the MixedSingleTaskGP model anyway.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/experimental-design/bofire/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

- Test the new mixed optimizer in line with `test_optimizer.py`
- Test the MixedSingleTaskGP model, compare that the predictions are equivalent regardless of input encoding.