### PR TITLE
Bugfix in Hyperopt Functionality of SingleTaskGPSurrogate

### DIFF
--- a/bofire/data_models/surrogates/single_task_gp.py
+++ b/bofire/data_models/surrogates/single_task_gp.py
@@ -95,7 +95,7 @@ class SingleTaskGPHyperconfig(Hyperconfig):
         else:
             raise ValueError(f"Kernel {hyperparameters.kernel} not known.")
 
-        if hyperparameters.scalekernel:
+        if hyperparameters.scalekernel == "True":
             surrogate_data.kernel = ScaleKernel(
                 base_kernel=base_kernel, outputscale_prior=outputscale_prior
             )

--- a/tests/bofire/runners/test_hyperoptimize.py
+++ b/tests/bofire/runners/test_hyperoptimize.py
@@ -54,13 +54,17 @@ def test_hyperoptimize(strategy: str):
         [e.name for e in RegressionMetricsEnum]
         + surrogate_data.hyperconfig.domain.inputs.get_keys(),
     )
-    assert hasattr(opt_data.kernel, "base_kernel")
-    assert opt_data.kernel.base_kernel.ard == (metrics.iloc[0]["ard"] == "True")
-    if metrics.iloc[0].kernel == "matern_1.5":
-        assert isinstance(opt_data.kernel.base_kernel, MaternKernel)
-        assert opt_data.kernel.base_kernel.nu == 1.5
-    elif metrics.iloc[0].kernel == "matern_2.5":
-        assert isinstance(opt_data.kernel.base_kernel, MaternKernel)
-        assert opt_data.kernel.base_kernel.nu == 2.5
+    if hasattr(opt_data.kernel, "base_kernel"):
+        assert metrics.iloc[0]["scalekernel"] == "True"
+        base_kernel = opt_data.kernel.base_kernel
     else:
-        assert isinstance(opt_data.kernel.base_kernel, RBFKernel)
+        base_kernel = opt_data.kernel
+    assert base_kernel.ard == (metrics.iloc[0]["ard"] == "True")
+    if metrics.iloc[0].kernel == "matern_1.5":
+        assert isinstance(base_kernel, MaternKernel)
+        assert base_kernel.nu == 1.5
+    elif metrics.iloc[0].kernel == "matern_2.5":
+        assert isinstance(base_kernel, MaternKernel)
+        assert base_kernel.nu == 2.5
+    else:
+        assert isinstance(base_kernel, RBFKernel)

--- a/tests/bofire/surrogates/test_gps.py
+++ b/tests/bofire/surrogates/test_gps.py
@@ -263,37 +263,39 @@ def test_SingleTaskGPHyperconfig():
     )
     candidate = surrogate_data.hyperconfig.inputs.sample(1).loc[0]
     surrogate_data.update_hyperparameters(candidate)
-    if hasattr(surrogate_data.kernel, "base_kernel"):
-        assert surrogate_data.kernel.base_kernel.ard == (candidate["ard"] == "True")
-        if candidate.kernel == "matern_1.5":
-            assert isinstance(surrogate_data.kernel.base_kernel, MaternKernel)
-            assert surrogate_data.kernel.base_kernel.nu == 1.5
-        elif candidate.kernel == "matern_2.5":
-            assert isinstance(surrogate_data.kernel.base_kernel, MaternKernel)
-            assert surrogate_data.kernel.base_kernel.nu == 2.5
-        else:
-            assert isinstance(surrogate_data.kernel.base_kernel, RBFKernel)
-        if candidate.prior == "mbo":
-            assert surrogate_data.noise_prior == MBO_NOISE_PRIOR()
+    # if hasattr(surrogate_data.kernel, "base_kernel"):
+    base_kernel = (
+        surrogate_data.kernel.base_kernel
+        if hasattr(surrogate_data.kernel, "base_kernel")
+        else surrogate_data.kernel
+    )
+    if candidate.scalekernel == "True":
+        assert hasattr(surrogate_data.kernel, "base_kernel")
+    else:
+        assert not hasattr(surrogate_data.kernel, "base_kernel")
+    if candidate.kernel == "matern_1.5":
+        assert isinstance(base_kernel, MaternKernel)
+        assert base_kernel.nu == 1.5
+    elif candidate.kernel == "matern_2.5":
+        assert isinstance(base_kernel, MaternKernel)
+        assert base_kernel.nu == 2.5
+    else:
+        assert isinstance(base_kernel, RBFKernel)
+    if candidate.prior == "mbo":
+        assert surrogate_data.noise_prior == MBO_NOISE_PRIOR()
+        if candidate.scalekernel == "True":
             assert surrogate_data.kernel.outputscale_prior == MBO_OUTPUTSCALE_PRIOR()
-            assert (
-                surrogate_data.kernel.base_kernel.lengthscale_prior
-                == MBO_LENGTHCALE_PRIOR()
-            )
-        elif candidate.prior == "threesix":
-            assert surrogate_data.noise_prior == THREESIX_NOISE_PRIOR()
+        assert base_kernel.lengthscale_prior == MBO_LENGTHCALE_PRIOR()
+    elif candidate.prior == "threesix":
+        assert surrogate_data.noise_prior == THREESIX_NOISE_PRIOR()
+        if candidate.scalekernel == "True":
             assert surrogate_data.kernel.outputscale_prior == THREESIX_SCALE_PRIOR()
-            assert (
-                surrogate_data.kernel.base_kernel.lengthscale_prior
-                == THREESIX_LENGTHSCALE_PRIOR()
-            )
-        else:
-            assert surrogate_data.noise_prior == HVARFNER_NOISE_PRIOR()
+        assert base_kernel.lengthscale_prior == THREESIX_LENGTHSCALE_PRIOR()
+    else:
+        assert surrogate_data.noise_prior == HVARFNER_NOISE_PRIOR()
+        if candidate.scalekernel == "True":
             assert surrogate_data.kernel.outputscale_prior == THREESIX_SCALE_PRIOR()
-            assert (
-                surrogate_data.kernel.base_kernel.lengthscale_prior
-                == HVARFNER_LENGTHSCALE_PRIOR()
-            )
+        assert base_kernel.lengthscale_prior == HVARFNER_LENGTHSCALE_PRIOR()
 
 
 def test_SingleTaskGPModel_feature_subsets():


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to make BoFire better.

Help us to understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to BoFire here: https://github.com/experimental-desgin/bofire/blob/main/CONTRIBUTING.md
-->

## Motivation

There is a bug in the hyperconfig ot the SingleTaskGPSurrogate. `True` and `"True"` was mixed up (took me a few hours to figure out :D). As consequence a scale kernel was never applied. This PR fixes it and also updates the tests accordingly. 


### Have you read the [Contributing Guidelines on pull requests](https://github.com/experimental-design/bofire/blob/main/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

Unit tests
