### PR TITLE
Hvarfner Priors for MixedSingleTaskGP

### DIFF
--- a/bofire/data_models/surrogates/mixed_single_task_gp.py
+++ b/bofire/data_models/surrogates/mixed_single_task_gp.py
@@ -18,6 +18,8 @@ from bofire.data_models.kernels.api import (
     RBFKernel,
 )
 from bofire.data_models.priors.api import (
+    HVARFNER_LENGTHSCALE_PRIOR,
+    HVARFNER_NOISE_PRIOR,
     MBO_LENGTHCALE_PRIOR,
     MBO_NOISE_PRIOR,
     MBO_OUTPUTSCALE_PRIOR,
@@ -38,7 +40,7 @@ class MixedSingleTaskGPHyperconfig(Hyperconfig):
                 key="continuous_kernel",
                 categories=["rbf", "matern_1.5", "matern_2.5"],
             ),
-            CategoricalInput(key="prior", categories=["mbo", "botorch"]),
+            CategoricalInput(key="prior", categories=["mbo", "threesix", "hvarfner"]),
             CategoricalInput(key="ard", categories=["True", "False"]),
         ],
     )
@@ -58,12 +60,18 @@ class MixedSingleTaskGPHyperconfig(Hyperconfig):
                 MBO_LENGTHCALE_PRIOR(),
                 MBO_OUTPUTSCALE_PRIOR(),
             )
-        else:
+        elif hyperparameters.prior == "threesix":
             noise_prior, lengthscale_prior, _ = (
                 THREESIX_NOISE_PRIOR(),
                 THREESIX_LENGTHSCALE_PRIOR(),
                 THREESIX_SCALE_PRIOR(),
             )
+        else:
+            noise_prior, lengthscale_prior = (
+                HVARFNER_NOISE_PRIOR(),
+                HVARFNER_LENGTHSCALE_PRIOR(),
+            )
+
         surrogate_data.noise_prior = noise_prior
         if hyperparameters.continuous_kernel == "rbf":
             surrogate_data.continuous_kernel = RBFKernel(
@@ -93,13 +101,13 @@ class MixedSingleTaskGPSurrogate(TrainableBotorchSurrogate):
     type: Literal["MixedSingleTaskGPSurrogate"] = "MixedSingleTaskGPSurrogate"
     continuous_kernel: AnyContinuousKernel = Field(
         default_factory=lambda: MaternKernel(
-            ard=True, nu=2.5, lengthscale_prior=THREESIX_LENGTHSCALE_PRIOR()
+            ard=True, nu=2.5, lengthscale_prior=HVARFNER_LENGTHSCALE_PRIOR()
         )
     )
     categorical_kernel: AnyCategoricalKernel = Field(
         default_factory=lambda: HammingDistanceKernel(ard=True),
     )
-    noise_prior: AnyPrior = Field(default_factory=lambda: THREESIX_NOISE_PRIOR())
+    noise_prior: AnyPrior = Field(default_factory=lambda: HVARFNER_NOISE_PRIOR())
     hyperconfig: Optional[MixedSingleTaskGPHyperconfig] = Field(
         default_factory=lambda: MixedSingleTaskGPHyperconfig(),
     )

--- a/tests/bofire/surrogates/test_gps.py
+++ b/tests/bofire/surrogates/test_gps.py
@@ -427,16 +427,22 @@ def test_MixedSingleTaskGPHyperconfig():
         assert surrogate_data.continuous_kernel.nu == 2.5
     else:
         assert isinstance(surrogate_data.continuous_kernel, RBFKernel)
-    if candidate.prior == "mbo":
+    if candidate.prior == "mobo":
         assert surrogate_data.noise_prior == MBO_NOISE_PRIOR()
         assert (
             surrogate_data.continuous_kernel.lengthscale_prior == MBO_LENGTHCALE_PRIOR()
         )
-    else:
+    if candidate.prior == "threesix":
         assert surrogate_data.noise_prior == THREESIX_NOISE_PRIOR()
         assert (
             surrogate_data.continuous_kernel.lengthscale_prior
             == THREESIX_LENGTHSCALE_PRIOR()
+        )
+    if candidate.prior == "hvarfner":
+        assert surrogate_data.noise_prior == HVARFNER_NOISE_PRIOR()
+        assert (
+            surrogate_data.continuous_kernel.lengthscale_prior
+            == HVARFNER_LENGTHSCALE_PRIOR()
         )
 
 


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to make BoFire better.

Help us to understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to BoFire here: https://github.com/experimental-desgin/bofire/blob/main/CONTRIBUTING.md
-->

## Motivation

This PR introduces Hvarfner priors as default for the mixed single task gp (as it is in botorch) and also as a option for hyperopt.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/experimental-design/bofire/blob/main/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

Unit tests.
