### PR TITLE
fix typo MBO_LENGTHCALE_PRIOR -> MBO_LENGTHSCALE_PRIOR

### DIFF
--- a/bofire/data_models/priors/api.py
+++ b/bofire/data_models/priors/api.py
@@ -40,7 +40,7 @@ THREESIX_SCALE_PRIOR = partial(GammaPrior, concentration=2.0, rate=0.15)
 # By default BoTorch places a highly informative prior on the kernel lengthscales,
 # which easily leads to overfitting. Here we set a broader prior distribution for the
 # lengthscale. The priors for the noise and signal variance are set more tightly.
-MBO_LENGTHCALE_PRIOR = partial(GammaPrior, concentration=2.0, rate=0.2)
+MBO_LENGTHSCALE_PRIOR = partial(GammaPrior, concentration=2.0, rate=0.2)
 MBO_NOISE_PRIOR = partial(GammaPrior, concentration=2.0, rate=4.0)
 MBO_OUTPUTSCALE_PRIOR = partial(GammaPrior, concentration=2.0, rate=4.0)
 

--- a/bofire/data_models/surrogates/mixed_single_task_gp.py
+++ b/bofire/data_models/surrogates/mixed_single_task_gp.py
@@ -20,7 +20,7 @@ from bofire.data_models.kernels.api import (
 from bofire.data_models.priors.api import (
     HVARFNER_LENGTHSCALE_PRIOR,
     HVARFNER_NOISE_PRIOR,
-    MBO_LENGTHCALE_PRIOR,
+    MBO_LENGTHSCALE_PRIOR,
     MBO_NOISE_PRIOR,
     MBO_OUTPUTSCALE_PRIOR,
     THREESIX_LENGTHSCALE_PRIOR,
@@ -57,7 +57,7 @@ class MixedSingleTaskGPHyperconfig(Hyperconfig):
         if hyperparameters.prior == "mbo":
             noise_prior, lengthscale_prior, _ = (
                 MBO_NOISE_PRIOR(),
-                MBO_LENGTHCALE_PRIOR(),
+                MBO_LENGTHSCALE_PRIOR(),
                 MBO_OUTPUTSCALE_PRIOR(),
             )
         elif hyperparameters.prior == "threesix":

--- a/bofire/data_models/surrogates/multi_task_gp.py
+++ b/bofire/data_models/surrogates/multi_task_gp.py
@@ -13,7 +13,7 @@ from bofire.data_models.features.api import (
 )
 from bofire.data_models.kernels.api import AnyKernel, MaternKernel, RBFKernel
 from bofire.data_models.priors.api import (
-    MBO_LENGTHCALE_PRIOR,
+    MBO_LENGTHSCALE_PRIOR,
     MBO_NOISE_PRIOR,
     THREESIX_LENGTHSCALE_PRIOR,
     THREESIX_NOISE_PRIOR,
@@ -53,7 +53,10 @@ class MultiTaskGPHyperconfig(Hyperconfig):
             return MaternKernel(nu=1.5, lengthscale_prior=lengthscale_prior, ard=ard)
 
         if hyperparameters.prior == "mbo":
-            noise_prior, lengthscale_prior = (MBO_NOISE_PRIOR(), MBO_LENGTHCALE_PRIOR())
+            noise_prior, lengthscale_prior = (
+                MBO_NOISE_PRIOR(),
+                MBO_LENGTHSCALE_PRIOR(),
+            )
         else:
             noise_prior, lengthscale_prior = (
                 THREESIX_NOISE_PRIOR(),

--- a/bofire/data_models/surrogates/shape.py
+++ b/bofire/data_models/surrogates/shape.py
@@ -12,7 +12,7 @@ from bofire.data_models.features.api import (
 )
 from bofire.data_models.kernels.api import MaternKernel, RBFKernel, WassersteinKernel
 from bofire.data_models.priors.api import (
-    MBO_LENGTHCALE_PRIOR,
+    MBO_LENGTHSCALE_PRIOR,
     MBO_NOISE_PRIOR,
     MBO_OUTPUTSCALE_PRIOR,
     THREESIX_LENGTHSCALE_PRIOR,
@@ -53,7 +53,7 @@ class PiecewiseLinearGPSurrogateHyperconfig(Hyperconfig):
         if hyperparameters.prior == "mbo":
             noise_prior, lengthscale_prior, outputscale_prior = (
                 MBO_NOISE_PRIOR(),
-                MBO_LENGTHCALE_PRIOR(),
+                MBO_LENGTHSCALE_PRIOR(),
                 MBO_OUTPUTSCALE_PRIOR(),
             )
         else:

--- a/bofire/data_models/surrogates/single_task_gp.py
+++ b/bofire/data_models/surrogates/single_task_gp.py
@@ -19,7 +19,7 @@ from bofire.data_models.kernels.api import (
 from bofire.data_models.priors.api import (
     HVARFNER_LENGTHSCALE_PRIOR,
     HVARFNER_NOISE_PRIOR,
-    MBO_LENGTHCALE_PRIOR,
+    MBO_LENGTHSCALE_PRIOR,
     MBO_NOISE_PRIOR,
     MBO_OUTPUTSCALE_PRIOR,
     THREESIX_LENGTHSCALE_PRIOR,
@@ -86,7 +86,7 @@ class SingleTaskGPHyperconfig(Hyperconfig):
         if hyperparameters.prior == "mbo":
             noise_prior, lengthscale_prior, outputscale_prior = (
                 MBO_NOISE_PRIOR(),
-                MBO_LENGTHCALE_PRIOR(),
+                MBO_LENGTHSCALE_PRIOR(),
                 MBO_OUTPUTSCALE_PRIOR(),
             )
         elif hyperparameters.prior == "threesix":

--- a/tests/bofire/surrogates/test_gps.py
+++ b/tests/bofire/surrogates/test_gps.py
@@ -39,7 +39,7 @@ from bofire.data_models.molfeatures.api import MordredDescriptors
 from bofire.data_models.priors.api import (
     HVARFNER_LENGTHSCALE_PRIOR,
     HVARFNER_NOISE_PRIOR,
-    MBO_LENGTHCALE_PRIOR,
+    MBO_LENGTHSCALE_PRIOR,
     MBO_NOISE_PRIOR,
     MBO_OUTPUTSCALE_PRIOR,
     ROBUSTGP_LENGTHSCALE_CONSTRAINT,
@@ -290,7 +290,7 @@ def test_SingleTaskGPHyperconfig():
         assert surrogate_data.noise_prior == MBO_NOISE_PRIOR()
         if candidate.scalekernel == "True":
             assert surrogate_data.kernel.outputscale_prior == MBO_OUTPUTSCALE_PRIOR()
-        assert base_kernel.lengthscale_prior == MBO_LENGTHCALE_PRIOR()
+        assert base_kernel.lengthscale_prior == MBO_LENGTHSCALE_PRIOR()
     elif candidate.prior == "threesix":
         assert surrogate_data.noise_prior == THREESIX_NOISE_PRIOR()
         if candidate.scalekernel == "True":
@@ -435,7 +435,8 @@ def test_MixedSingleTaskGPHyperconfig():
     if candidate.prior == "mbo":
         assert surrogate_data.noise_prior == MBO_NOISE_PRIOR()
         assert (
-            surrogate_data.continuous_kernel.lengthscale_prior == MBO_LENGTHCALE_PRIOR()
+            surrogate_data.continuous_kernel.lengthscale_prior
+            == MBO_LENGTHSCALE_PRIOR()
         )
     if candidate.prior == "threesix":
         assert surrogate_data.noise_prior == THREESIX_NOISE_PRIOR()
@@ -784,7 +785,7 @@ def test_RobustSingleTaskGPHyperconfig():
             assert surrogate_data.kernel.outputscale_prior == MBO_OUTPUTSCALE_PRIOR()
             assert (
                 surrogate_data.kernel.base_kernel.lengthscale_prior
-                == MBO_LENGTHCALE_PRIOR()
+                == MBO_LENGTHSCALE_PRIOR()
             )
         elif candidate.prior == "threesix":
             assert surrogate_data.noise_prior == THREESIX_NOISE_PRIOR()

--- a/tests/bofire/surrogates/test_multitask_gps.py
+++ b/tests/bofire/surrogates/test_multitask_gps.py
@@ -19,7 +19,7 @@ from bofire.data_models.features.api import (
 from bofire.data_models.kernels.api import MaternKernel, RBFKernel
 from bofire.data_models.priors.api import (
     LKJ_PRIOR,
-    MBO_LENGTHCALE_PRIOR,
+    MBO_LENGTHSCALE_PRIOR,
     MBO_NOISE_PRIOR,
     THREESIX_LENGTHSCALE_PRIOR,
     THREESIX_NOISE_PRIOR,
@@ -62,7 +62,7 @@ def test_MultiTaskGPHyperconfig():
         assert isinstance(surrogate_data.kernel, RBFKernel)
     if candidate.prior == "mbo":
         assert surrogate_data.noise_prior == MBO_NOISE_PRIOR()
-        assert surrogate_data.kernel.lengthscale_prior == MBO_LENGTHCALE_PRIOR()
+        assert surrogate_data.kernel.lengthscale_prior == MBO_LENGTHSCALE_PRIOR()
     else:
         assert surrogate_data.noise_prior == THREESIX_NOISE_PRIOR()
         assert surrogate_data.kernel.lengthscale_prior == THREESIX_LENGTHSCALE_PRIOR()

--- a/tests/bofire/surrogates/test_shape.py
+++ b/tests/bofire/surrogates/test_shape.py
@@ -14,7 +14,7 @@ from bofire.data_models.kernels.api import RBFKernel as RBFKernelDataModel
 
 # , RBFKernel, ScaleKernel
 from bofire.data_models.priors.api import (
-    MBO_LENGTHCALE_PRIOR,
+    MBO_LENGTHSCALE_PRIOR,
     MBO_NOISE_PRIOR,
     THREESIX_LENGTHSCALE_PRIOR,
     THREESIX_NOISE_PRIOR,
@@ -155,7 +155,8 @@ def test_PiecewiseLinearGPHyperconfig():
     if candidate.prior == "mbo":
         assert surrogate_data.noise_prior == MBO_NOISE_PRIOR()
         assert (
-            surrogate_data.continuous_kernel.lengthscale_prior == MBO_LENGTHCALE_PRIOR()
+            surrogate_data.continuous_kernel.lengthscale_prior
+            == MBO_LENGTHSCALE_PRIOR()
         )
     else:
         assert surrogate_data.noise_prior == THREESIX_NOISE_PRIOR()


### PR DESCRIPTION
## Motivation

There was a typo in MBO_LENGTHSCALE_PRIOR, I corrected  all occurences.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/experimental-design/bofire/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Ran testing framework.
