### PR TITLE
number_of_categorical_combinations

### DIFF
--- a/tests/bofire/data_models/domain/test_inputs.py
+++ b/tests/bofire/data_models/domain/test_inputs.py
@@ -58,6 +58,24 @@ RDKIT_AVAILABLE = importlib.util.find_spec("rdkit") is not None
                         key="f1",
                         categories=["c11", "c12"],
                     ),
+                    DiscreteInput(
+                        key="f2",
+                        values=[1, 2],
+                    ),
+                ],
+            ),
+            [
+                [("f1", "c11"), ("f1", "c12")],
+                [("f2", 1), ("f2", 2)],
+            ],
+        ),
+        (
+            Inputs(
+                features=[
+                    CategoricalInput(
+                        key="f1",
+                        categories=["c11", "c12"],
+                    ),
                     CategoricalInput(
                         key="f2",
                         categories=["c21", "c22", "c23"],
@@ -79,6 +97,7 @@ RDKIT_AVAILABLE = importlib.util.find_spec("rdkit") is not None
 def test_inputs_get_categorical_combinations(inputs, data):
     expected = list(itertools.product(*data))
     assert inputs.get_categorical_combinations() == expected
+    assert inputs.get_number_of_categorical_combinations() == len(expected)
 
 
 def test_inputs_is_fulfilled():
@@ -190,6 +209,9 @@ def test_categorical_combinations_of_domain_filtered(inputs, data, include, excl
         inputs.get_categorical_combinations(include=include, exclude=exclude)
         == expected
     )
+    assert inputs.get_number_of_categorical_combinations(
+        include=include, exclude=exclude
+    ) == len(expected)
 
 
 # test features container


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to make BoFire better.

Help us to understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to BoFire here: https://github.com/experimental-desgin/bofire/blob/main/CONTRIBUTING.md
-->

## Motivation

This PR adds the option to compute the number of categorical combinations, this is needed for the new functionality regarding the alternating optimizer which will follow soon. The method was originally implemented by @TobyBoyne  in https://github.com/experimental-design/bofire/pull/603. I now made a seperate PR out of it, and will integrate the rest later.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/experimental-design/bofire/blob/main/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

Unit tests.
