### PR TITLE
562 pydantic deprecation warnings

### DIFF
--- a/bofire/benchmarks/single.py
+++ b/bofire/benchmarks/single.py
@@ -43,7 +43,7 @@ class Ackley(Benchmark):
 
     """
 
-    # @validator("validate_categoricals")
+    # @field_validator("validate_categoricals")
     # def validate_categoricals(cls, v, num_categoricals):
     #     if v and num_categoricals ==1:
     #         raise ValueError("num_categories  must be specified if categorical=True")

--- a/bofire/data_models/features/continuous.py
+++ b/bofire/data_models/features/continuous.py
@@ -27,7 +27,9 @@ class ContinuousInput(NumericalInput):
 
     bounds: Bounds
     local_relative_bounds: Optional[
-        Annotated[List[Annotated[float, Field(gt=0)]], Field(min_items=2, max_items=2)]  # type: ignore
+        Annotated[
+            List[Annotated[float, Field(gt=0)]], Field(min_length=2, max_length=2)
+        ]  # type: ignore
     ] = None
     stepsize: Optional[PositiveFloat] = None
 

--- a/bofire/data_models/priors/normal.py
+++ b/bofire/data_models/priors/normal.py
@@ -1,6 +1,6 @@
+import math
 from typing import Literal
 
-import numpy as np
 from pydantic import PositiveFloat
 
 from bofire.data_models.priors.prior import Prior
@@ -43,7 +43,7 @@ class DimensionalityScaledLogNormalPrior(Prior):
     type: Literal["DimensionalityScaledLogNormalPrior"] = (
         "DimensionalityScaledLogNormalPrior"
     )
-    loc: PositiveFloat = np.sqrt(2)
+    loc: PositiveFloat = math.sqrt(2)
     loc_scaling: PositiveFloat = 0.5
-    scale: PositiveFloat = np.sqrt(3)
+    scale: PositiveFloat = math.sqrt(3)
     scale_scaling: float = 0.0

--- a/bofire/data_models/surrogates/mixed_tanimoto_gp.py
+++ b/bofire/data_models/surrogates/mixed_tanimoto_gp.py
@@ -1,6 +1,6 @@
 from typing import Literal, Type
 
-from pydantic import Field, validator
+from pydantic import Field, field_validator
 
 # from bofire.data_models.enum import MolecularEncodingEnum
 from bofire.data_models.features.api import AnyOutput, ContinuousOutput
@@ -56,7 +56,7 @@ class MixedTanimotoGPSurrogate(TrainableBotorchSurrogate):
         """
         return isinstance(my_type, type(ContinuousOutput))
 
-    @validator("input_preprocessing_specs")
+    @field_validator("input_preprocessing_specs")
     def validate_moleculars(cls, v, values):
         """Checks that at least one of fingerprints, fragments, or fingerprintsfragments features are present."""
         if not any(

--- a/bofire/data_models/surrogates/tanimoto_gp.py
+++ b/bofire/data_models/surrogates/tanimoto_gp.py
@@ -1,6 +1,6 @@
 from typing import Literal, Type
 
-from pydantic import Field, validator
+from pydantic import Field, field_validator
 
 from bofire.data_models.features.api import AnyOutput, ContinuousOutput
 from bofire.data_models.kernels.api import AnyKernel, ScaleKernel
@@ -44,7 +44,7 @@ class TanimotoGPSurrogate(TrainableBotorchSurrogate):
         return isinstance(my_type, type(ContinuousOutput))
 
     # TanimotoGP will be used when at least one of fingerprints, fragments, or fingerprintsfragments are present
-    @validator("input_preprocessing_specs")
+    @field_validator("input_preprocessing_specs")
     def validate_moleculars(cls, v, values):
         """Checks that at least one of fingerprints, fragments, or fingerprintsfragments features are present."""
         if not any(

--- a/bofire/surrogates/diagnostics.py
+++ b/bofire/surrogates/diagnostics.py
@@ -4,7 +4,7 @@ from typing import Dict, List, Optional, Tuple, Union
 
 import numpy as np
 import pandas as pd
-from pydantic import Field, field_validator, model_validator, validator
+from pydantic import Field, field_validator, model_validator
 from scipy.integrate import simpson
 from scipy.stats import fisher_exact, kendalltau, norm, pearsonr, spearmanr
 from sklearn.metrics import (
@@ -625,7 +625,7 @@ class CvResults(BaseModel):
 
     # TODO[pydantic]: We couldn't refactor the `validator`, please replace it by `field_validator` manually.
     # Check https://docs.pydantic.dev/dev-v2/migration/#changes-to-validators for more information.
-    @validator("results")
+    @field_validator("results")
     def validate_results(cls, v, values):
         if len(v) <= 1:
             raise ValueError("`results` sequence has to contain at least two elements.")

--- a/tests/bofire/data_models/domain/test_domain.py
+++ b/tests/bofire/data_models/domain/test_domain.py
@@ -4,7 +4,7 @@ import numpy as np
 import pandas as pd
 import pytest
 from pandas.testing import assert_frame_equal, assert_series_equal
-from pydantic.error_wrappers import ValidationError
+from pydantic import ValidationError
 from pytest import fixture
 
 from bofire.data_models.api import Outputs

--- a/tests/bofire/data_models/domain/test_features.py
+++ b/tests/bofire/data_models/domain/test_features.py
@@ -1,7 +1,7 @@
 from collections.abc import Sequence
 
 import pytest
-from pydantic.error_wrappers import ValidationError
+from pydantic import ValidationError
 
 import tests.bofire.data_models.specs.api as specs
 from bofire.data_models.domain.api import Features, Inputs, Outputs

--- a/tests/bofire/data_models/serialization/test_serialization.py
+++ b/tests/bofire/data_models/serialization/test_serialization.py
@@ -40,7 +40,7 @@ def test_objective_should_be_serializable(objective_spec: Spec):
 def test_feature_should_be_serializable(feature_spec: Spec):
     spec = feature_spec.typed_spec()
     obj = feature_spec.cls(**spec)
-    assert obj.dict() == spec
+    assert obj.model_dump() == spec
 
 
 def test_domain_should_be_serializable(domain_spec: Spec):

--- a/tests/bofire/data_models/specs/priors.py
+++ b/tests/bofire/data_models/specs/priors.py
@@ -1,6 +1,6 @@
 import random
 
-from pydantic.error_wrappers import ValidationError
+from pydantic import ValidationError
 
 import bofire.data_models.priors.api as priors
 from tests.bofire.data_models.specs.specs import Specs

--- a/tests/bofire/data_models/specs/strategies.py
+++ b/tests/bofire/data_models/specs/strategies.py
@@ -315,7 +315,7 @@ for use_cyipopt in [True, False, None]:
     specs.add_valid(
         strategies.DoEStrategy,
         lambda use_cyipopt=use_cyipopt: {
-            "domain": domain.valid().obj().dict(),
+            "domain": domain.valid().obj().model_dump(),
             "verbose": False,
             "ipopt_options": {"max_iter": 200, "print_level": 0},
             "criterion": strategies.SpaceFillingCriterion(

--- a/tests/bofire/data_models/test_base.py
+++ b/tests/bofire/data_models/test_base.py
@@ -1,5 +1,5 @@
 import pytest
-from pydantic.error_wrappers import ValidationError
+from pydantic import ValidationError
 
 from bofire.data_models.base import BaseModel
 

--- a/tests/bofire/priors/test_mapper.py
+++ b/tests/bofire/priors/test_mapper.py
@@ -25,7 +25,7 @@ from bofire.data_models.priors.api import (
 def test_map(prior, expected_prior):
     gprior = priors.map(prior)
     assert isinstance(gprior, expected_prior)
-    for key, value in prior.dict().items():
+    for key, value in prior.model_dump().items():
         if key == "type":
             continue
         assert value == getattr(gprior, key)

--- a/tests/bofire/strategies/test_strategy.py
+++ b/tests/bofire/strategies/test_strategy.py
@@ -6,7 +6,7 @@ import pandas as pd
 import pytest
 from _pytest.fixtures import fixture
 from pandas.testing import assert_frame_equal
-from pydantic.error_wrappers import ValidationError
+from pydantic import ValidationError
 
 from bofire.data_models.constraints.api import (
     LinearEqualityConstraint,
@@ -254,7 +254,7 @@ def test_strategy_no_variance():
     with pytest.raises(ValueError):
         strategy.tell(experiments)
     # introduce variance but in an invalid experiment
-    experiments.loc[0, "valid_of1"] = 0
+    experiments.loc[0, "valid_of1"] = False
     experiments.loc[0, "b"] = 0.7
     with pytest.raises(ValueError):
         strategy.tell(experiments)

--- a/tests/bofire/surrogates/test_shape.py
+++ b/tests/bofire/surrogates/test_shape.py
@@ -3,7 +3,7 @@ import torch
 from gpytorch.kernels import MaternKernel, ProductKernel, ScaleKernel
 from gpytorch.priors import GammaPrior, LogNormalPrior
 from pandas.testing import assert_frame_equal
-from torch.testing import assert_allclose
+from torch.testing import assert_close
 
 import bofire.surrogates.api as surrogates
 import tests.bofire.data_models.specs.api as specs
@@ -27,11 +27,11 @@ def test_PiecewiseLinearGPSurrogate():
     surrogate_data = specs.surrogates.valid(PiecewiseLinearGPSurrogate).obj()
     surrogate = surrogates.map(surrogate_data)
     assert isinstance(surrogate, surrogates.PiecewiseLinearGPSurrogate)
-    assert_allclose(
+    assert_close(
         surrogate.transform.tf1.idx_x,
         torch.tensor([4, 5], dtype=torch.int64),
     )
-    assert_allclose(
+    assert_close(
         surrogate.transform.tf1.idx_y,
         torch.tensor([0, 1, 2, 3], dtype=torch.int64),
     )

--- a/tests/bofire/surrogates/test_surrogates.py
+++ b/tests/bofire/surrogates/test_surrogates.py
@@ -3,7 +3,7 @@ from typing import Literal, Type
 import numpy as np
 import pandas as pd
 import pytest
-from pydantic.error_wrappers import ValidationError
+from pydantic import ValidationError
 
 from bofire.data_models.domain.api import Inputs, Outputs
 from bofire.data_models.features.api import AnyOutput, ContinuousInput, ContinuousOutput


### PR DESCRIPTION
## Motivation

#562 

Looked at the Pydantic warnings mentioned by @DavidWalz and fixed the following:

```
PydanticDeprecatedSince20: `min_items` is deprecated and will be removed, use `min_length` instead.
Deprecated in Pydantic V2.0 to be removed in V3.0. See Pydantic V2 Migration Guide at https://errors.pydantic.dev/2.11/migration/

PydanticDeprecatedSince20: `max_items` is deprecated and will be removed, use `max_length` instead. 
Deprecated in Pydantic V2.0 to be removed in V3.0. See Pydantic V2 Migration Guide at https://errors.pydantic.dev/2.11/migration/
  
PydanticDeprecatedSince20: Pydantic V1 style `@validator` validators are deprecated. You should migrate to Pydantic V2 style `@field_validator` validators, see the migration guide for more details.
Deprecated in Pydantic V2.0 to be removed in V3.0. See Pydantic V2 Migration Guide at https://errors.pydantic.dev/2.11/migration/
```

I also fixed the following warnings:
- `PydanticJsonSchemaWarning: Default value 1.4142135623730951 is not JSON serializable; excluding default from JSON schema [non-serializable-default]
    warnings.warn(message, PydanticJsonSchemaWarning)
`
- A warning related to torch_all_close()
- Some more pandas related warnings.


I did not fix the following:
`PydanticDeprecatedSince20: json_encoders is deprecated. See https://docs.pydantic.dev/2.11/concepts/serialization/#custom-serializers for alternatives. 
Deprecated in Pydantic V2.0 to be removed in V3.0. See Pydantic V2 Migration Guide at https://errors.pydantic.dev/2.11/migration/`

From my understanding we would need to rewrite the json_encoders in [https://github.com/experimental-design/bofire/blob/main/bofire/data_models/base.py](url). But I think Pydantic V2 does not allow this to be global and type specific anymore. We would need to write `@field_serializer()` for each field and subclass if I'm correct. So not sure how and if we should proceed with this, what do you think @jduerholt 


### Have you read the [Contributing Guidelines on pull requests](https://github.com/experimental-design/bofire/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Ran the existing tests
