### PR TITLE
Fix/628

### DIFF
--- a/bofire/data_models/strategies/predictives/botorch.py
+++ b/bofire/data_models/strategies/predictives/botorch.py
@@ -39,7 +39,7 @@ class BotorchStrategy(PredictiveStrategy):
     include_infeasible_exps_in_acqf_calc: bool = Field(
         default=False,
         description="Whether infeasible experiments should be included in the set "
-                    "of experiments used to compute the acquisition function.",
+        "of experiments used to compute the acquisition function.",
     )
 
     @model_validator(mode="after")

--- a/bofire/data_models/strategies/predictives/botorch.py
+++ b/bofire/data_models/strategies/predictives/botorch.py
@@ -36,6 +36,11 @@ class BotorchStrategy(PredictiveStrategy):
     # hyperopt params
     frequency_hyperopt: Annotated[int, Field(ge=0)] = 0  # 0 indicates no hyperopt
     folds: int = 5
+    include_infeasible_exps_in_acqf_calc: bool = Field(
+        default=False,
+        description="Whether infeasible experiments should be included in the set "
+                    "of experiments used to compute the acquisition function.",
+    )
 
     @model_validator(mode="after")
     def validate_domain_for_optimizer(self):

--- a/bofire/strategies/predictives/active_learning.py
+++ b/bofire/strategies/predictives/active_learning.py
@@ -88,6 +88,7 @@ class ActiveLearningStrategy(BotorchStrategy):
         folds: int | None = None,
         acquisition_function: AnyActiveLearningAcquisitionFunction | None = None,
         seed: int | None = None,
+        include_infeasible_exps_in_acqf_calc: bool | None = False,
     ):
         """
         Creates an ActiveLearningStrategy instance. ActiveLearningStrategy that uses an acquisition function which focuses on
@@ -103,6 +104,8 @@ class ActiveLearningStrategy(BotorchStrategy):
                 folds: Number of folds for cross-validation in hyperparameter optimization.
                 acquisition_function: Acquisition function to use.
                 seed: Seed for the random number generator.
+                include_infeasible_exps_in_acqf_calc: Whether infeasible experiments should be included in the set
+                    of experiments used to compute the acquisition function.
             Returns:
                 ActiveLearningStrategy: An instance of the ActiveLearningStrategy class.
         """

--- a/bofire/strategies/predictives/botorch.py
+++ b/bofire/strategies/predictives/botorch.py
@@ -51,6 +51,9 @@ class BotorchStrategy(PredictiveStrategy):
         self.frequency_hyperopt = data_model.frequency_hyperopt
         self.folds = data_model.folds
         self.surrogates = None
+        self.include_infeasible_exps_in_acqf_calc = (
+            data_model.include_infeasible_exps_in_acqf_calc
+        )
 
         torch.manual_seed(self.seed)
 
@@ -213,12 +216,8 @@ class BotorchStrategy(PredictiveStrategy):
             return True
         return False
 
-    def get_acqf_input_tensors(self, include_infeasible: bool = False):
+    def get_acqf_input_tensors(self):
         """
-
-        Args:
-            include_infeasible (bool, optional): If True, infeasible experiments (violation of bounds and constraints)
-            are also included in the data for the acquisition function. Defaults to False.
 
         Returns:
             X_train (Tensor): Tensor of shape (n, d) with n training points and d input dimensions.
@@ -235,7 +234,7 @@ class BotorchStrategy(PredictiveStrategy):
             keep="first",
             inplace=False,
         )
-        if not include_infeasible:
+        if not self.include_infeasible_exps_in_acqf_calc:
             # we should only provide those experiments to the acqf builder in which all
             # input constraints are fulfilled, output constraints are handled directly
             # in botorch

--- a/bofire/strategies/predictives/mobo.py
+++ b/bofire/strategies/predictives/mobo.py
@@ -148,6 +148,7 @@ class MoboStrategy(BotorchStrategy):
         frequency_hyperopt: int | None = None,
         folds: int | None = None,
         seed: int | None = None,
+        include_infeasible_exps_in_acqf_calc: bool | None = False,
     ):
         """
         Creates an instance of a multi-objective strategy based on expected hypervolume improvement.
@@ -168,6 +169,8 @@ class MoboStrategy(BotorchStrategy):
             frequency_hyperopt: Frequency at which to perform hyperparameter optimization.
             folds: Number of folds for cross-validation for hyperparameter optimization.
             seed: Random seed for reproducibility.
+            include_infeasible_exps_in_acqf_calc: Whether infeasible experiments should be included in the set
+                of experiments used to compute the acquisition function.
         Returns:
             An instance of the strategy configured with the specified parameters.
         """

--- a/bofire/strategies/predictives/multi_fidelity.py
+++ b/bofire/strategies/predictives/multi_fidelity.py
@@ -132,6 +132,7 @@ class MultiFidelityStrategy(SoboStrategy):
         frequency_hyperopt: int | None = None,
         folds: int | None = None,
         seed: int | None = None,
+        include_infeasible_exps_in_acqf_calc: bool | None = False,
     ) -> Self:
         """
         Create a new instance of the multi-fidelity optimization strategy with the given parameters. This strategy
@@ -159,5 +160,7 @@ class MultiFidelityStrategy(SoboStrategy):
             frequency_hyperopt: The frequency of hyperparameter optimization.
             folds: The number of folds for cross-validation.
             seed: The random seed to use.
+            include_infeasible_exps_in_acqf_calc: Whether infeasible experiments should be included in the set
+                of experiments used to compute the acquisition function.
         """
         return cast(Self, make_strategy(cls, DataModel, locals()))

--- a/bofire/strategies/predictives/qparego.py
+++ b/bofire/strategies/predictives/qparego.py
@@ -165,6 +165,7 @@ class QparegoStrategy(BotorchStrategy):
         frequency_hyperopt: int | None = None,
         folds: int | None = None,
         seed: int | None = None,
+        include_infeasible_exps_in_acqf_calc: bool | None = False,
     ) -> Self:
         """
         Creates an instance of the multi-objective strategy ParEGO using the provided configuration parameters.
@@ -187,6 +188,8 @@ class QparegoStrategy(BotorchStrategy):
             frequency_hyperopt: Frequency of hyperparameter optimization.
             folds: Number of folds for cross-validation for hyperparameter optimization.
             seed: Random seed for reproducibility.
+            include_infeasible_exps_in_acqf_calc: Whether infeasible experiments should be included in the set
+                of experiments used to compute the acquisition function.
         Returns:
             An instance of the strategy configured with the provided parameters.
         """

--- a/bofire/strategies/predictives/sobo.py
+++ b/bofire/strategies/predictives/sobo.py
@@ -296,6 +296,7 @@ class AdditiveSoboStrategy(SoboStrategy):
         frequency_hyperopt: int | None = None,
         folds: int | None = None,
         seed: int | None = None,
+        include_infeasible_exps_in_acqf_calc: bool | None = False,
     ):
         """
         Creates a Bayesian optimization strategy that adds multiple objectives.
@@ -312,6 +313,8 @@ class AdditiveSoboStrategy(SoboStrategy):
             frequency_hyperopt: The frequency of hyperparameter optimization.
             folds: The number of folds for cross-validation for hyperparameter optimization.
             seed: The random seed to use.
+            include_infeasible_exps_in_acqf_calc: Whether infeasible experiments should be included in the set
+                of experiments used to compute the acquisition function.
         """
         return make_strategy(cls, AdditiveDataModel, locals())
 
@@ -358,6 +361,7 @@ class MultiplicativeSoboStrategy(SoboStrategy):
         frequency_hyperopt: int | None = None,
         folds: int | None = None,
         seed: int | None = None,
+        include_infeasible_exps_in_acqf_calc: bool | None = False,
     ) -> Self:
         """
         Creates Bayesian optimization strategy that multiplies multiple objectives. The weights of
@@ -373,6 +377,8 @@ class MultiplicativeSoboStrategy(SoboStrategy):
             frequency_hyperopt: The frequency of hyperparameter optimization.
             folds: The number of folds for cross-validation for hyperparameter optimization.
             seed: The random seed to use.
+            include_infeasible_exps_in_acqf_calc: Whether infeasible experiments should be included in the set
+                of experiments used to compute the acquisition function.
         """
         return cast(Self, make_strategy(cls, MultiplicativeDataModel, locals()))
 
@@ -423,6 +429,7 @@ class MultiplicativeAdditiveSoboStrategy(SoboStrategy):
         frequency_hyperopt: int | None = None,
         folds: int | None = None,
         seed: int | None = None,
+        include_infeasible_exps_in_acqf_calc: bool | None = False,
     ) -> Self:
         """
         Creates a Bayesian optimization strategy that mixes additions and multiplions of multiple objectives.
@@ -442,6 +449,8 @@ class MultiplicativeAdditiveSoboStrategy(SoboStrategy):
             frequency_hyperopt: The frequency of hyperparameter optimization.
             folds: The number of folds for cross-validation for hyperparameter optimization.
             seed: The random seed to use.
+            include_infeasible_exps_in_acqf_calc: Whether infeasible experiments should be included in the set
+                of experiments used to compute the acquisition function.
         """
         return cast(Self, make_strategy(cls, MultiplicativeAdditiveDataModel, locals()))
 
@@ -550,6 +559,7 @@ class CustomSoboStrategy(SoboStrategy):
         frequency_hyperopt: int | None = None,
         folds: int | None = None,
         seed: int | None = None,
+        include_infeasible_exps_in_acqf_calc: bool | None = False,
     ):
         """
         The `CustomSoboStrategy` can be used to design custom objectives or objective combinations for optimizations.
@@ -569,5 +579,7 @@ class CustomSoboStrategy(SoboStrategy):
             frequency_hyperopt: The frequency of hyperparameter optimization.
             folds: The number of folds for cross-validation.
             seed: The random seed to use.
+            include_infeasible_exps_in_acqf_calc: Whether infeasible experiments should be included in the set
+                of experiments used to compute the acquisition function.
         """
         return make_strategy(cls, CustomDataModel, locals())

--- a/bofire/strategies/predictives/sobo.py
+++ b/bofire/strategies/predictives/sobo.py
@@ -192,6 +192,7 @@ class SoboStrategy(BotorchStrategy):
         frequency_hyperopt: int | None = None,
         folds: int | None = None,
         seed: int | None = None,
+        include_infeasible_exps_in_acqf_calc: bool | None = False,
     ) -> Self:
         """
         Creates a single objective Bayesian optimization strategy.
@@ -206,6 +207,8 @@ class SoboStrategy(BotorchStrategy):
             frequency_hyperopt: The frequency of hyperparameter optimization.
             folds: The number of folds for cross-validation.
             seed: The random seed to use.
+            include_infeasible_exps_in_acqf_calc: Whether infeasible experiments should be included in the set
+                of experiments used to compute the acquisition function.
         """
         return cast(Self, make_strategy(cls, SoboDataModel, locals()))
 

--- a/tests/bofire/data_models/specs/strategies.py
+++ b/tests/bofire/data_models/specs/strategies.py
@@ -60,6 +60,7 @@ strategy_commons = {
     "frequency_check": 1,
     "frequency_hyperopt": 0,
     "folds": 5,
+    "include_infeasible_exps_in_acqf_calc": False,
 }
 
 

--- a/tests/bofire/strategies/test_sobo.py
+++ b/tests/bofire/strategies/test_sobo.py
@@ -164,7 +164,9 @@ def test_get_acqf_input_tensors_infeasible(include_infeasible):
     for feat in benchmark.domain.inputs.get():
         feat.bounds = (100, 200)
 
-    strategy = SoboStrategy.make(domain=benchmark.domain, include_infeasible_exps_in_acqf_calc=include_infeasible)
+    strategy = SoboStrategy.make(
+        domain=benchmark.domain, include_infeasible_exps_in_acqf_calc=include_infeasible
+    )
     strategy._experiments = experiments
     if not include_infeasible:
         with pytest.raises(

--- a/tests/bofire/strategies/test_sobo.py
+++ b/tests/bofire/strategies/test_sobo.py
@@ -164,7 +164,7 @@ def test_get_acqf_input_tensors_infeasible(include_infeasible):
     for feat in benchmark.domain.inputs.get():
         feat.bounds = (100, 200)
 
-    strategy = SoboStrategy.make(domain=benchmark.domain)
+    strategy = SoboStrategy.make(domain=benchmark.domain, include_infeasible_exps_in_acqf_calc=include_infeasible)
     strategy._experiments = experiments
     if not include_infeasible:
         with pytest.raises(
@@ -173,7 +173,7 @@ def test_get_acqf_input_tensors_infeasible(include_infeasible):
         ):
             strategy.get_acqf_input_tensors()  # not include_infeasible should be default behavior
     else:
-        X_train, X_pending = strategy.get_acqf_input_tensors(include_infeasible=True)
+        X_train, X_pending = strategy.get_acqf_input_tensors()
         assert X_train.shape[0] == len(experiments)
 
 

--- a/tests/bofire/strategies/test_sobo.py
+++ b/tests/bofire/strategies/test_sobo.py
@@ -154,7 +154,8 @@ def test_SOBO_init_qUCB():
     assert acqf.beta_prime == math.sqrt(beta * math.pi / 2)
 
 
-def test_get_acqf_input_tensors_infeasible():
+@pytest.mark.parametrize("include_infeasible", (True, False))
+def test_get_acqf_input_tensors_infeasible(include_infeasible):
     benchmark = Himmelblau()
     experiments = benchmark.f(
         benchmark.domain.inputs.sample(10),
@@ -165,11 +166,15 @@ def test_get_acqf_input_tensors_infeasible():
 
     strategy = SoboStrategy.make(domain=benchmark.domain)
     strategy._experiments = experiments
-    with pytest.raises(
-        ValueError,
-        match="No valid and feasible experiments are available for setting up the acquisition function. Check your constraints.",
-    ):
-        strategy.get_acqf_input_tensors()
+    if not include_infeasible:
+        with pytest.raises(
+            ValueError,
+            match="No valid and feasible experiments are available for setting up the acquisition function. Check your constraints.",
+        ):
+            strategy.get_acqf_input_tensors()  # not include_infeasible should be default behavior
+    else:
+        X_train, X_pending = strategy.get_acqf_input_tensors(include_infeasible=True)
+        assert X_train.shape[0] == len(experiments)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
This PR addresses #628.

It adds a field to the data-model of the `BotorchStrategy`: `include_infeasible_exps_in_acqf_calc`

- This flag changes the behavior of the `get_acqf_input_tensors` function: Filtering out infeasible experiments (violation of constraints or bounds) will only be done, if the field is set to False.

- The default value is False, so the function will work as before, if nothing is changed.

- All `make` methods from the strategy classes, inheriting from `BotorchStrategy` are adapted to show this option in the kwargs