### PR TITLE
suggestions to NChooseK repair function

### DIFF
--- a/bofire/data_models/domain/features.py
+++ b/bofire/data_models/domain/features.py
@@ -696,7 +696,7 @@ class Inputs(_BaseFeatures[AnyInput]):
             experiments (Optional[pd.DataFrame], optional): Dataframe with input features.
                 If provided the real feature bounds are returned based on both the opt.
                 feature bounds and the extreme points in the dataframe. Defaults to None,
-            reference_experiment (Optional[pd.Serues], optional): If a reference experiment provided,
+            reference_experiment (Optional[pd.Series], optional): If a reference experiment provided,
             then the local bounds based on a local search region are provided as reference to the
                 reference experiment. Currently only supported for continuous inputs.
                 For more details, it is referred to https://www.merl.com/publications/docs/TR2023-057.pdf. Defaults to None.

--- a/bofire/strategies/utils.py
+++ b/bofire/strategies/utils.py
@@ -613,21 +613,31 @@ class LinearProjection(PymooRepair):
                 if n_zero == 0:
                     return ub
 
-                # sort each row, and set the smallest n_zero elements to zero
-                ub[np.argsort(x) < n_zero] = 0
+                # Get indices of the lowest n_zero values per row
+                low_indices = np.argsort(x, axis=1)[:, :n_zero]
+
+                # set the lowest indices of each row to zero
+                rows = np.arange(x.shape[0])[:, None]
+                ub[rows, low_indices] = 0
+
                 return ub
 
             @staticmethod
             def _lb_correction(
                 lb: np.ndarray, x: np.ndarray, n_non_zero: int, min_delta: float
             ) -> np.ndarray:
-                """correct upper bounds: set the upper bound of the smallest n_zero elements in each row to zero"""
+                """correct lower bounds: set the lower bound of the largest n_non_zero elements in each row to min_delta"""
                 if n_non_zero == 0:
                     return lb
 
-                # sort each row, and set the largest n_non_zero elements to min_delta
-                d = x.shape[1]
-                lb[np.argsort(x) >= d - n_non_zero] = min_delta
+                # Get indices of largest n_non_zero values for each row
+                top_indices = np.argsort(x, axis=1)[:, -n_non_zero:]
+
+                # Set all values in lb to 0 initially
+                lb.fill(0)
+                rows = np.arange(x.shape[0])[:, None]
+                lb[rows, top_indices] = min_delta
+
                 return lb
 
             def __call__(self, x: np.ndarray) -> List[Tuple[np.ndarray, np.ndarray]]:


### PR DESCRIPTION

## Motivation

@LukasHebing I was looking at the LinearProjection and how it handles the repair with NChooseKConstraints and found results that were not intuitive to me.

In a nutshell, I consider a NChooseKConstraint over 6 inputs, with a min_count=2 and a max_count=3.
I consider the following candidate x:
`[[3.60200e-03 0.00000e+00 1.24000e-04 1.48000e-04 3.16161e-01]]`
`np.argsort(x): [[1 2 3 0 4]]`

With the following lower and upper bounds before repair:
`lb before repair [[0. 0. 0. 0. 0.]]`
`ub before repair [[0.46000001 0.47       0.28       5.         5.        ]]`

After the repair the bounds and candidate becomes:
```
lb after repair [[0.    0.    0.001 0.    0.001]]
ub after repair [[0.   0.47 0.28 0.   5.  ]]
repaired candidate
[array([-4.78402306e-28,  0.00000000e+00,  1.00000000e-03, -1.96578431e-29,
        3.16161000e-01])]
```
In my opinion something goes wrong here. I would expect the biggest components in the candidate to remain, so indices 0 and 4 in this case, with the min_value (1e-3) attributed to the one highest after that.
Basically I would expect the following to happen:

```
lower bound before repair [[0. 0. 0. 0. 0.]] upper bound before repair [[0.46000001 0.47       0.28       5.         5.        ]]
lower bound after repair [[0.001 0.    0.    0.    0.001]] upper bound after repair [[0.46000001 0.         0.         5.         5.        ]]
repaired candidate
[[ 3.60200000e-03  0.00000000e+00 -1.64712484e-29  1.48000000e-04
   3.16161000e-01]]
```

Do you agree with this, or am I missing some understanding here?

I made a suggestion to adjust the `_ub_correction` and `_lb_correction functions` that should give us the correct behavior. So far it is tested on up to two NChooseKConstraints but with disjoint subsets of the features. Not sure if it will also work if that is not the case, but also not sure if we would really want users to do this. Thoughts @jduerholt?

### Have you read the [Contributing Guidelines on pull requests](https://github.com/experimental-design/bofire/blob/main/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

Already incorporated a unit test with one NChooseKConstraint and ContinuousInputs. Will add more after some discussion if this is the right way to go.