### PR TITLE
Add AdditiveSaasModel to BotorchSurrogates

### DIFF
--- a/bofire/data_models/surrogates/botorch_surrogates.py
+++ b/bofire/data_models/surrogates/botorch_surrogates.py
@@ -14,6 +14,7 @@ from bofire.data_models.surrogates.fully_bayesian import (
     FullyBayesianSingleTaskGPSurrogate,
 )
 from bofire.data_models.surrogates.linear import LinearSurrogate
+from bofire.data_models.surrogates.map_saas import AdditiveMapSaasSingleTaskGPSurrogate
 from bofire.data_models.surrogates.mixed_single_task_gp import (
     MixedSingleTaskGPSurrogate,
 )
@@ -47,6 +48,7 @@ AnyBotorchSurrogate = Union[
     CategoricalDeterministicSurrogate,
     MultiTaskGPSurrogate,
     PiecewiseLinearGPSurrogate,
+    AdditiveMapSaasSingleTaskGPSurrogate,
 ]
 
 


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to make BoFire better.

Help us to understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to BoFire here: https://github.com/experimental-desgin/bofire/blob/main/CONTRIBUTING.md
-->

## Motivation

This PR adds the missing additive saas model to the botorch surrogates list so that it can be used in optis.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/experimental-design/bofire/blob/main/CONTRIBUTING.md#pull-requests)?

Y.
## Test Plan

Not needed.
