### PR TITLE
Hotfix Acqf setup for fixed-features

### DIFF
--- a/bofire/strategies/predictives/botorch.py
+++ b/bofire/strategies/predictives/botorch.py
@@ -1,3 +1,4 @@
+import warnings
 from abc import abstractmethod
 from typing import Callable, Dict, List, Optional, Tuple, get_args
 
@@ -237,15 +238,18 @@ class BotorchStrategy(PredictiveStrategy):
             # we should only provide those experiments to the acqf builder in which all
             # input constraints are fulfilled, output constraints are handled directly
             # in botorch
-            clean_experiments = clean_experiments[
+            fulfilled_experiments = clean_experiments[
                 self.domain.is_fulfilled(clean_experiments)
             ].copy()
-            if len(clean_experiments) == 0:
-                raise ValueError(
+            if len(fulfilled_experiments) == 0:
+                warnings.warn(
                     "No valid and feasible experiments are available for setting up the acquisition function. Check your constraints.",
+                    RuntimeWarning,
                 )
-        else:
-            clean_experiments = clean_experiments.copy()
+            else:
+                clean_experiments = fulfilled_experiments
+        # else:
+        #     clean_experiments = clean_experiments.copy()
 
         transformed = self.domain.inputs.transform(
             clean_experiments,

--- a/tests/bofire/strategies/test_sobo.py
+++ b/tests/bofire/strategies/test_sobo.py
@@ -168,14 +168,23 @@ def test_get_acqf_input_tensors_infeasible(include_infeasible):
     )
     strategy._experiments = experiments
     if not include_infeasible:
-        with pytest.raises(
-            ValueError,
+        with pytest.warns(
+            RuntimeWarning,
             match="No valid and feasible experiments are available for setting up the acquisition function. Check your constraints.",
         ):
-            strategy.get_acqf_input_tensors()  # not include_infeasible should be default behavior
+            filtered_experiments, _ = strategy.get_acqf_input_tensors()
+            assert filtered_experiments.shape[0] == 10
     else:
-        X_train, X_pending = strategy.get_acqf_input_tensors()
+        X_train, _ = strategy.get_acqf_input_tensors()
         assert X_train.shape[0] == len(experiments)
+
+    if not include_infeasible:
+        for feat in benchmark.domain.inputs.get():
+            feat.bounds = (-6, 0)
+        strategy = SoboStrategy.make(domain=benchmark.domain)
+        strategy._experiments = experiments
+        filtered_experiments, _ = strategy.get_acqf_input_tensors()
+        assert filtered_experiments.shape[0] < 10
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to make BoFire better.

Help us to understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to BoFire here: https://github.com/experimental-desgin/bofire/blob/main/CONTRIBUTING.md
-->

## Motivation

This PR fixes the issue that when infeasibles are excluded in acqf setup but all are infeasibles an error is raised. Especially with fixed features that can happen often. For this reason, only a warning is now raised. In the future, we can have there a more fine-grained control.


### Have you read the [Contributing Guidelines on pull requests](https://github.com/experimental-design/bofire/blob/main/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

Unit tets.
