### PR TITLE
Tests/reduce disk space

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -29,13 +29,8 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
-      - name: Set up uv
-        uses: astral-sh/setup-uv@v2
-        with:
-          enable-cache: true
-
       - name: Install Dependencies
-        run: uv pip install "." pytest --system
+        run: pip install "." pytest
 
       - name: Run data model tests
         run: pytest tests/bofire/data_models
@@ -54,13 +49,10 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
-      - name: Set up uv
-        uses: astral-sh/setup-uv@v2
-        with:
-          enable-cache: true
-
       - name: Install Dependencies
-        run: uv pip install ".[optimization, tests]" --system
+        run: |
+          pip install torch --index-url https://download.pytorch.org/whl/cpu
+          pip install ".[optimization, tests]"
 
       - name: Run tests
         shell: bash -l {0}


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to make BoFire better.

Help us to understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to BoFire here: https://github.com/experimental-desgin/bofire/blob/main/CONTRIBUTING.md
-->

Our tests in the pipeline run out of disc space. Check what packages are not necessary. Torch with CUDA is a candiate to be replaced by CPU-Torch.

Further, I cleaned a little up by removing uv from the workflow which is not really needed there and by removing the xgb option from workflow installations that does not exist anymore.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/experimental-design/bofire/blob/main/CONTRIBUTING.md#pull-requests)?

Y

## Test Plan

not applicable
