### PR TITLE
Update cheminfo dependency to mordredcommunity

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,7 @@ entmoot = [
     "pyomo<=6.9.4",
     "entmoot>=2.0.6",
 ] # we pin the pyomo version here due to compatibility issues
-cheminfo = ["rdkit>=2023.3.2", "scikit-learn>=1.0.0", "mordred>=1.2.0"]
+cheminfo = ["rdkit>=2023.3.2", "scikit-learn>=1.0.0", "mordredcommunity>=2.0.1"]
 tests = ["pytest", "pytest-cov", "papermill"]
 docs = ["jupyter", "jupyter-cache", "matplotlib", "seaborn"]
 all = [


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to make BoFire better.

Help us to understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to BoFire here: https://github.com/experimental-desgin/bofire/blob/main/CONTRIBUTING.md
-->

## Motivation

The `cheminfo` optional dependency uses `mordred`, which is no longer maintained.
This PR changes it to [`mordredcommunity`](https://github.com/JacksonBurns/mordred-community), which is a community-maintained fork of `mordred` with bug fixes and explicit compatibility with your Python versions (3.10+).

### Have you read the [Contributing Guidelines on pull requests](https://github.com/experimental-design/bofire/blob/main/CONTRIBUTING.md#pull-requests)?

:+1:

## Test Plan

`mordredcommunity` is drop-in compatible, even to the level of `import mordred` - the CI should pass without issue
