### PR TITLE
Fix stochastic test failing

### DIFF
--- a/bofire/strategies/doe/utils.py
+++ b/bofire/strategies/doe/utils.py
@@ -281,7 +281,11 @@ def n_zero_eigvals(
         rhs_only=True,
         inputs=domain.inputs,
     )
-    N = len(model_formula) + 3
+    # Need enough samples so the information matrix rank is determined by
+    # structural constraints (e.g. equality constraints), not by sampling luck.
+    # Discrete inputs with few levels are especially prone to degenerate samples
+    # at small N.
+    N = 5 * len(model_formula) + 3
 
     sampler = RandomStrategy(data_model=RandomStrategyDataModel(domain=domain))
     X = sampler.ask(N)


### PR DESCRIPTION
## Motivation

Need enough samples so the information matrix rank is determined by
structural constraints (e.g. equality constraints), not by sampling luck.
Discrete inputs with few levels are especially prone to degenerate samples
at small N.

Give more headroom so the random samples are diverse enough. There's no deep theoretical reason for exactly 5x — it's a practical choice to reduce the probability of degenerate samples while keeping the computation cheap.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/experimental-design/bofire/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Fixed stochastic test failing.
