### PR TITLE
Add fallback version for setuptools_scm

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -94,6 +94,7 @@ find = {}
 [tool.setuptools_scm]
 local_scheme = "node-and-date"
 write_to = "./bofire/version.py"
+fallback_version = "0.0.0.dev0+unknown"
 
 [tool.ruff]
 target-version = "py39"


### PR DESCRIPTION
## Motivation

Adds fallback_version = "0.0.0.dev0+unknown" to the [tool.setuptools_scm] section in [pyproject.toml](vscode-file://vscode-app/c:/Users/chrihaas/AppData/Local/Programs/Microsoft%20VS%20Code/bdd88df003/resources/app/out/vs/code/electron-browser/workbench/workbench.html).

Problem:
When building BoFire from a source archive without git metadata (e.g., GitHub's "Download ZIP", release tarballs, or vendored copies), setuptools_scm fails to determine the version and the build errors out.

Solution:
The fallback_version option provides a safe default when git metadata is unavailable, allowing the package to build successfully.

Format choice:

- 0.0.0.dev0+unknown follows PEP 440 semantic versioning
- Parseable by standard tools (packaging.version.parse())
- The +unknown local identifier clearly indicates the source

### Have you read the [Contributing Guidelines on pull requests](https://github.com/experimental-design/bofire/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

None
