### PR TITLE
weightedmean implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,13 +12,13 @@ and this project adheres to [Pragmatic Versioning](https://github.com/experiment
 - Explicit Interaction features (like `x_1 * x_2`) for botorch based surrogates via the engineered features mechanism.
 - Support for custom formulas including discrete and categorical features in the DoE module.
 - Support for pandas 3.0
-- Optional normalization (`normalize_by_weight_sum`) for `WeightedSumFeature` and `MolecularWeightedSumFeature`, enabling weighted-mean behavior.
+- `WeightedMeanFeature` and `MolecularWeightedMeanFeature` engineered features for weighted-mean behavior.
 
 ### Changed
 
 - **Breaking**: For all botorch surrogate that are trainable, the `scaler` keyword used on defining how to scale the inputs before entering the actual model/kernel, do not expect anymore an enum but instance of a `Scaler` class like `Normalize` or `Standardize`. Via this, it can be controlled on which features the scaler should operate.
 - Static type checking was migrated from `pyright` to `ty`.
-- Refactored weighted engineered-feature surrogate mapping to share implementation across descriptor and molecular weighted-sum features.
+- Refactored weighted engineered-feature surrogate mapping to share implementation across weighted sum/mean and molecular weighted sum/mean.
 
 ### Fixed
 

--- a/bofire/data_models/features/api.py
+++ b/bofire/data_models/features/api.py
@@ -11,9 +11,11 @@ from bofire.data_models.features.engineered_feature import (
     CloneFeature,
     EngineeredFeature,
     MeanFeature,
+    MolecularWeightedMeanFeature,
     MolecularWeightedSumFeature,
     ProductFeature,
     SumFeature,
+    WeightedMeanFeature,
     WeightedSumFeature,
 )
 from bofire.data_models.features.feature import Feature, Input, Output
@@ -45,7 +47,9 @@ AnyFeature = Union[
     TaskInput,
     SumFeature,
     MeanFeature,
+    WeightedMeanFeature,
     WeightedSumFeature,
+    MolecularWeightedMeanFeature,
     MolecularWeightedSumFeature,
     ContinuousMolecularInput,
     ProductFeature,
@@ -68,7 +72,9 @@ AnyOutput = Union[ContinuousOutput, CategoricalOutput]
 AnyEngineeredFeature = Union[
     SumFeature,
     MeanFeature,
+    WeightedMeanFeature,
     WeightedSumFeature,
+    MolecularWeightedMeanFeature,
     MolecularWeightedSumFeature,
     ProductFeature,
     CloneFeature,

--- a/bofire/data_models/features/engineered_feature.py
+++ b/bofire/data_models/features/engineered_feature.py
@@ -88,15 +88,12 @@ class WeightedSumFeature(EngineeredFeature):
     Args:
         features: The features to be used to compute the weighted sum.
         descriptors: The descriptors to be used to compute the weighted sum.
-        normalize_by_weight_sum: If True, normalize by the sum of feature
-            values and compute a weighted mean instead of a weighted sum.
         keep_features: Whether to keep the original features after
             creating the engineered feature in surrogate creation.
     """
 
     type: Literal["WeightedSumFeature"] = "WeightedSumFeature"
     descriptors: Descriptors
-    normalize_by_weight_sum: bool = False
     order_id: ClassVar[int] = 2
 
     @property
@@ -117,6 +114,21 @@ class WeightedSumFeature(EngineeredFeature):
                 )
 
 
+class WeightedMeanFeature(WeightedSumFeature):
+    """Weighted mean feature, which computes the mean over the specified
+    descriptors weighted by the involved feature values.
+
+    Args:
+        features: The features to be used to compute the weighted mean.
+        descriptors: The descriptors to be used to compute the weighted mean.
+        keep_features: Whether to keep the original features after
+            creating the engineered feature in surrogate creation.
+    """
+
+    type: Literal["WeightedMeanFeature"] = "WeightedMeanFeature"
+    order_id: ClassVar[int] = 6
+
+
 class MolecularWeightedSumFeature(EngineeredFeature):
     """Molecular weighted sum feature, which computes the sum over the specified
     molecular descriptors weighted by the involved feature values.
@@ -124,15 +136,12 @@ class MolecularWeightedSumFeature(EngineeredFeature):
     Args:
         features: The molecular features to be used to compute the weighted sum.
         molfeatures: The molecular feature descriptor specification.
-        normalize_by_weight_sum: If True, normalize by the sum of feature
-            values and compute a weighted mean instead of a weighted sum.
         keep_features: Whether to keep the original features after
             creating the engineered feature in surrogate creation.
     """
 
     type: Literal["MolecularWeightedSumFeature"] = "MolecularWeightedSumFeature"
     molfeatures: AnyMolFeatures
-    normalize_by_weight_sum: bool = False
     order_id: ClassVar[int] = 3
 
     @property
@@ -147,6 +156,21 @@ class MolecularWeightedSumFeature(EngineeredFeature):
                 raise ValueError(
                     f"Feature '{feature_key}' is not a ContinuousMolecularInput",
                 )
+
+
+class MolecularWeightedMeanFeature(MolecularWeightedSumFeature):
+    """Molecular weighted mean feature, which computes the mean over the specified
+    molecular descriptors weighted by the involved feature values.
+
+    Args:
+        features: The molecular features to be used to compute the weighted mean.
+        molfeatures: The molecular feature descriptor specification.
+        keep_features: Whether to keep the original features after
+            creating the engineered feature in surrogate creation.
+    """
+
+    type: Literal["MolecularWeightedMeanFeature"] = "MolecularWeightedMeanFeature"
+    order_id: ClassVar[int] = 7
 
 
 class ProductFeature(EngineeredFeature):

--- a/bofire/surrogates/engineered_features.py
+++ b/bofire/surrogates/engineered_features.py
@@ -10,9 +10,11 @@ from bofire.data_models.features.api import (
     CloneFeature,
     EngineeredFeature,
     MeanFeature,
+    MolecularWeightedMeanFeature,
     MolecularWeightedSumFeature,
     ProductFeature,
     SumFeature,
+    WeightedMeanFeature,
     WeightedSumFeature,
 )
 from bofire.data_models.types import InputTransformSpecs
@@ -32,8 +34,7 @@ def _weighted_features(
             min=torch.finfo(weights.dtype).eps,
         )
         weighted_sum = weighted_sum / weight_sum
-    result = weighted_sum.unsqueeze(-2)
-    return result.expand(*result.shape[:-2], 1, -1)
+    return weighted_sum.unsqueeze(-2)
 
 
 def _map_reduction_feature(
@@ -59,19 +60,14 @@ def _map_reduction_feature(
     )
 
 
-map_sum_feature = partial(_map_reduction_feature, reducer=torch.sum)
-map_product_feature = partial(_map_reduction_feature, reducer=torch.prod)
-map_mean_feature = partial(_map_reduction_feature, reducer=torch.mean)
-
-
-def map_weighted_sum_feature(
+def _map_weighted_feature(
     inputs: Inputs,
     transform_specs: InputTransformSpecs,
     feature: WeightedSumFeature,
+    normalize: bool,
 ) -> AppendFeatures:
     features2idx, _ = inputs._get_transform_info(transform_specs)
     indices = [features2idx[key][0] for key in feature.features]
-
     descriptors = torch.tensor(
         [
             inputs.get_by_key(key)
@@ -81,22 +77,25 @@ def map_weighted_sum_feature(
         ],
         dtype=torch.double,
     )
-
     return AppendFeatures(
         f=_weighted_features,
         fkwargs={
             "indices": indices,
             "descriptors": descriptors,
-            "normalize": feature.normalize_by_weight_sum,
+            "normalize": normalize,
         },
         transform_on_train=True,
     )
 
 
-def _get_molecular_descriptors(
+def _map_molecular_weighted_feature(
     inputs: Inputs,
+    transform_specs: InputTransformSpecs,
     feature: MolecularWeightedSumFeature,
-) -> torch.Tensor:
+    normalize: bool,
+) -> AppendFeatures:
+    features2idx, _ = inputs._get_transform_info(transform_specs)
+    indices = [features2idx[key][0] for key in feature.features]
     molecules = [
         inputs.get_by_key(key).molecule  # ty: ignore[unresolved-attribute]
         for key in feature.features
@@ -104,23 +103,13 @@ def _get_molecular_descriptors(
     # filter out highly-correlated descriptors before computing descriptor values
     feature.molfeatures.remove_correlated_descriptors(molecules)
     descriptors_df = feature.molfeatures.get_descriptor_values(pd.Series(molecules))
-    return torch.tensor(descriptors_df.values, dtype=torch.double)
-
-
-def map_molecular_weighted_sum_feature(
-    inputs: Inputs,
-    transform_specs: InputTransformSpecs,
-    feature: MolecularWeightedSumFeature,
-) -> AppendFeatures:
-    features2idx, _ = inputs._get_transform_info(transform_specs)
-    indices = [features2idx[key][0] for key in feature.features]
-    descriptors = _get_molecular_descriptors(inputs=inputs, feature=feature)
+    descriptors = torch.tensor(descriptors_df.values, dtype=torch.double)
     return AppendFeatures(
         f=_weighted_features,
         fkwargs={
             "indices": indices,
             "descriptors": descriptors,
-            "normalize": feature.normalize_by_weight_sum,
+            "normalize": normalize,
         },
         transform_on_train=True,
     )
@@ -144,11 +133,27 @@ def map_clone_feature(
     )
 
 
+# Mapper bindings
+map_sum_feature = partial(_map_reduction_feature, reducer=torch.sum)
+map_product_feature = partial(_map_reduction_feature, reducer=torch.prod)
+map_mean_feature = partial(_map_reduction_feature, reducer=torch.mean)
+map_weighted_sum_feature = partial(_map_weighted_feature, normalize=False)
+map_weighted_mean_feature = partial(_map_weighted_feature, normalize=True)
+map_molecular_weighted_sum_feature = partial(
+    _map_molecular_weighted_feature, normalize=False
+)
+map_molecular_weighted_mean_feature = partial(
+    _map_molecular_weighted_feature, normalize=True
+)
+
+
 AGGREGATE_MAP = {
     SumFeature: map_sum_feature,
     ProductFeature: map_product_feature,
     MeanFeature: map_mean_feature,
+    WeightedMeanFeature: map_weighted_mean_feature,
     WeightedSumFeature: map_weighted_sum_feature,
+    MolecularWeightedMeanFeature: map_molecular_weighted_mean_feature,
     MolecularWeightedSumFeature: map_molecular_weighted_sum_feature,
     CloneFeature: map_clone_feature,
 }

--- a/tests/bofire/data_models/features/test_engineered_feature.py
+++ b/tests/bofire/data_models/features/test_engineered_feature.py
@@ -5,8 +5,10 @@ from bofire.data_models.features.api import (
     ContinuousDescriptorInput,
     ContinuousInput,
     ContinuousMolecularInput,
+    MolecularWeightedMeanFeature,
     MolecularWeightedSumFeature,
     SumFeature,
+    WeightedMeanFeature,
     WeightedSumFeature,
 )
 from bofire.data_models.molfeatures.api import MordredDescriptors
@@ -66,12 +68,9 @@ def test_weighted_sum_feature_validation():
         weighted_sum_feature.validate_features(inputs)
 
 
-def test_weighted_sum_feature_validation_with_normalization_flag():
-    weighted_sum_feature = WeightedSumFeature(
-        key="w_sum1",
-        features=["feat1", "feat2"],
-        descriptors=["desc1", "desc2"],
-        normalize_by_weight_sum=True,
+def test_weighted_mean_feature_validation():
+    weighted_mean_feature = WeightedMeanFeature(
+        key="w_mean1", features=["feat1", "feat2"], descriptors=["desc1", "desc2"]
     )
     inputs = Inputs(
         features=[
@@ -87,7 +86,7 @@ def test_weighted_sum_feature_validation_with_normalization_flag():
     with pytest.raises(
         ValueError, match="Feature 'feat2' is not a ContinuousDescriptorInput"
     ):
-        weighted_sum_feature.validate_features(inputs)
+        weighted_mean_feature.validate_features(inputs)
 
     inputs = Inputs(
         features=[
@@ -106,12 +105,38 @@ def test_weighted_sum_feature_validation_with_normalization_flag():
         ]
     )
     with pytest.raises(ValueError, match="Not all descriptors"):
-        weighted_sum_feature.validate_features(inputs)
+        weighted_mean_feature.validate_features(inputs)
 
 
 def test_molecular_weighted_sum_feature_validation():
     mol_feature = MolecularWeightedSumFeature(
         key="mw_sum1",
+        features=["m1", "m2"],
+        molfeatures=MordredDescriptors(descriptors=["NssCH2", "ATSC2d"]),
+    )
+    inputs = Inputs(
+        features=[
+            ContinuousMolecularInput(key="m1", bounds=(0, 1), molecule="C"),
+            ContinuousInput(key="m2", bounds=(0, 1)),
+        ]
+    )
+    with pytest.raises(
+        ValueError, match="Feature 'm2' is not a ContinuousMolecularInput"
+    ):
+        mol_feature.validate_features(inputs)
+
+    inputs = Inputs(
+        features=[
+            ContinuousMolecularInput(key="m1", bounds=(0, 1), molecule="C"),
+            ContinuousMolecularInput(key="m2", bounds=(0, 1), molecule="CC"),
+        ]
+    )
+    mol_feature.validate_features(inputs)
+
+
+def test_molecular_weighted_mean_feature_validation():
+    mol_feature = MolecularWeightedMeanFeature(
+        key="mw_mean1",
         features=["m1", "m2"],
         molfeatures=MordredDescriptors(descriptors=["NssCH2", "ATSC2d"]),
     )

--- a/tests/bofire/data_models/specs/engineered_features.py
+++ b/tests/bofire/data_models/specs/engineered_features.py
@@ -1,5 +1,5 @@
 from bofire.data_models.domain.api import EngineeredFeatures
-from bofire.data_models.features.api import MeanFeature, SumFeature, WeightedSumFeature
+from bofire.data_models.features.api import MeanFeature, SumFeature, WeightedMeanFeature
 from tests.bofire.data_models.specs.specs import Specs
 
 
@@ -11,11 +11,10 @@ specs.add_valid(
         "features": [
             SumFeature(key="sum1", features=["a", "b"]).model_dump(),
             MeanFeature(key="mean1", features=["a", "b"]).model_dump(),
-            WeightedSumFeature(
-                key="weighted_sum_normalized1",
+            WeightedMeanFeature(
+                key="weighted_mean1",
                 features=["a", "b"],
                 descriptors=["alpha", "beta"],
-                normalize_by_weight_sum=True,
             ).model_dump(),
         ],
     },

--- a/tests/bofire/data_models/specs/features.py
+++ b/tests/bofire/data_models/specs/features.py
@@ -59,18 +59,16 @@ specs.add_valid(
         "key": str(uuid.uuid4()),
         "features": ["a", "b", "c"],
         "descriptors": ["alpha", "beta"],
-        "normalize_by_weight_sum": False,
         "keep_features": True,
     },
 )
 
 specs.add_valid(
-    features.WeightedSumFeature,
+    features.WeightedMeanFeature,
     lambda: {
         "key": str(uuid.uuid4()),
         "features": ["a", "b", "c"],
         "descriptors": ["alpha", "beta"],
-        "normalize_by_weight_sum": True,
         "keep_features": True,
     },
 )
@@ -84,13 +82,12 @@ specs.add_valid(
             descriptors=["NssCH2", "ATSC2d"],
             ignore_3D=True,
         ).model_dump(),
-        "normalize_by_weight_sum": False,
         "keep_features": True,
     },
 )
 
 specs.add_valid(
-    features.MolecularWeightedSumFeature,
+    features.MolecularWeightedMeanFeature,
     lambda: {
         "key": str(uuid.uuid4()),
         "features": ["a", "b", "c"],
@@ -98,7 +95,6 @@ specs.add_valid(
             descriptors=["NssCH2", "ATSC2d"],
             ignore_3D=True,
         ).model_dump(),
-        "normalize_by_weight_sum": True,
         "keep_features": True,
     },
 )

--- a/tests/bofire/surrogates/test_engineered_features.py
+++ b/tests/bofire/surrogates/test_engineered_features.py
@@ -11,18 +11,22 @@ from bofire.data_models.features.api import (
     ContinuousInput,
     ContinuousMolecularInput,
     MeanFeature,
+    MolecularWeightedMeanFeature,
     MolecularWeightedSumFeature,
     ProductFeature,
     SumFeature,
+    WeightedMeanFeature,
     WeightedSumFeature,
 )
 from bofire.data_models.molfeatures.api import MordredDescriptors
 from bofire.surrogates.engineered_features import (
     map_clone_feature,
     map_mean_feature,
+    map_molecular_weighted_mean_feature,
     map_molecular_weighted_sum_feature,
     map_product_feature,
     map_sum_feature,
+    map_weighted_mean_feature,
     map_weighted_sum_feature,
 )
 from bofire.utils.torch_tools import tkwargs
@@ -185,7 +189,7 @@ def test_map_weighted_sum_feature():
     assert torch.allclose(result[:, -2:], expected)
 
 
-def test_map_weighted_sum_feature_normalized():
+def test_map_weighted_mean_feature():
     inputs = Inputs(
         features=[
             ContinuousDescriptorInput(
@@ -208,16 +212,15 @@ def test_map_weighted_sum_feature_normalized():
             ),
         ]
     )
-    aggregation = WeightedSumFeature(
+    aggregation = WeightedMeanFeature(
         key="agg1",
         features=["x1", "x2", "x3"],
         descriptors=["d1", "d2"],
-        normalize_by_weight_sum=True,
     )
 
     assert aggregation.n_transformed_inputs == 2
 
-    aggregator = map_weighted_sum_feature(
+    aggregator = map_weighted_mean_feature(
         inputs=inputs, transform_specs={}, feature=aggregation
     )
 
@@ -233,7 +236,7 @@ def test_map_weighted_sum_feature_normalized():
     assert torch.allclose(result[:, -2:], expected)
 
 
-def test_map_weighted_sum_feature_normalized_zero_weight_sum():
+def test_map_weighted_mean_feature_zero_weight_sum():
     inputs = Inputs(
         features=[
             ContinuousDescriptorInput(
@@ -250,13 +253,12 @@ def test_map_weighted_sum_feature_normalized_zero_weight_sum():
             ),
         ]
     )
-    aggregation = WeightedSumFeature(
+    aggregation = WeightedMeanFeature(
         key="agg1",
         features=["x1", "x2"],
         descriptors=["d1", "d2"],
-        normalize_by_weight_sum=True,
     )
-    aggregator = map_weighted_sum_feature(
+    aggregator = map_weighted_mean_feature(
         inputs=inputs, transform_specs={}, feature=aggregation
     )
 
@@ -333,7 +335,7 @@ def test_map_molecular_weighted_sum_feature():
     not (RDKIT_AVAILABLE and MORDRED_AVAILABLE),
     reason="requires rdkit and mordred",
 )
-def test_map_molecular_weighted_sum_feature_normalized():
+def test_map_molecular_weighted_mean_feature():
     inputs = Inputs(
         features=[
             ContinuousMolecularInput(key="m1", bounds=[0, 1], molecule="C"),
@@ -343,14 +345,13 @@ def test_map_molecular_weighted_sum_feature_normalized():
     molfeatures = MordredDescriptors(
         descriptors=["NssCH2", "ATSC2d"], ignore_3D=True, correlation_cutoff=1.0
     )
-    aggregation = MolecularWeightedSumFeature(
+    aggregation = MolecularWeightedMeanFeature(
         key="agg1",
         features=["m1", "m2"],
         molfeatures=molfeatures,
-        normalize_by_weight_sum=True,
     )
 
-    aggregator = map_molecular_weighted_sum_feature(
+    aggregator = map_molecular_weighted_mean_feature(
         inputs=inputs, transform_specs={}, feature=aggregation
     )
 


### PR DESCRIPTION
## Motivation

Implemented WeightedMeanFeature to support descriptor-based weighted averaging of selected input features, alongside existing engineered feature transforms.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/experimental-design/bofire/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

### Have you updated `CHANGELOG.md`?

No, not yet

## Test Plan

Written tests for:

- data model validation of WeightedMeanFeature
- surrogate mapping correctness for WeightedMeanFeature (including explicit expected weighted-mean values)
- weighted-sum surrogate test strengthened with explicit expected-value assertion