### PR TITLE
allow only one descriptor

### DIFF
--- a/bofire/data_models/types.py
+++ b/bofire/data_models/types.py
@@ -100,7 +100,7 @@ CategoryVals = Annotated[
 
 Descriptors = Annotated[
     List[str],
-    Field(min_length=2),
+    Field(min_length=1),
     AfterValidator(make_unique_validator("Descriptors")),
 ]
 


### PR DESCRIPTION
## Motivation

Was using the `WeightedMeanFeature` on `ContinuousDescriptorInput`s with only one descriptor, and was running into Pydantic Validation errors because we set `Descriptors` to have `min_length=2` is there a specific reason for this @jduerholt or can we simply alter this as I suggested?

### Have you read the [Contributing Guidelines on pull requests](https://github.com/experimental-design/bofire/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

### Have you updated `CHANGELOG.md`?

No

## Test Plan

Run current tests. Ran locally without issues.