### PR TITLE
Data Model Migrator

### DIFF
--- a/bofire/data_models/migration/MIGRATION.md
+++ b/bofire/data_models/migration/MIGRATION.md
@@ -1,0 +1,153 @@
+# BoFire data-model migration
+
+A batch tool that converts legacy BoFire payloads (strategy / surrogate / domain
+JSON dicts) to the current schema.
+
+## Scope
+
+- **Offline / batch only.** No runtime adapter, no validation hooks. Callers
+  read from their store, pass dicts through `migrate(...)`, and write back.
+- **Pure dict -> dict.** Never calls `model_validate` internally. The output is
+  a dict that the current Pydantic models accept; default-valued fields are
+  left absent for Pydantic to fill in.
+- **Targets: strategies and surrogates** (and bare `Domain` payloads). Other
+  payload kinds are out of scope.
+
+## Public API
+
+```python
+from bofire.data_models.migration import migrate, UnrecoverablePayloadError
+
+migrated = migrate(
+    payload,
+    source="pre",          # version sentinel; see "Versioning model"
+    target="0.3.3",        # default = bofire.__version__ at the time of release
+    kind="strategy",       # "strategy" | "surrogate" | "domain"
+)
+```
+
+`migrate` is **idempotent**: `migrate(migrate(x)) == migrate(x)`.
+
+Errors:
+
+- `UnrecoverablePayloadError(payload_type, reason, hint)` — raised when a
+  payload references a type or value that has been removed and cannot be
+  auto-migrated (e.g. `XGBoostSurrogate`, `scaler="LOG"` on the input scaler).
+- `MigrationError` — base class.
+
+## CLI
+
+```
+python -m bofire.data_models.migration \
+    --kind {strategy|surrogate|domain} \
+    --source pre --target 0.3.3 \
+    [--input file.jsonl] [--output out.jsonl] \
+    [--validate] [--dry-run] [--report report.json] \
+    [--continue-on-error]
+```
+
+JSONL streaming, one record per line. Accepts both bare object lines
+(`{"type": ...}`) and double-encoded JSON-string lines (`"{\"type\": ...}"`).
+
+- `--validate` calls the current Pydantic adapter on each migrated record.
+- Failures route to `<output>.failed.jsonl` (or inline with `--continue-on-error`).
+- `--dry-run` writes no output, only a `--report`.
+
+The `--report` JSON contains `total`, `ok`, `unrecoverable[]`,
+`validation_failed[]`, and a `shape_histogram` of input types.
+
+## Versioning model
+
+The tool tracks named versions:
+
+```
+"pre"  ->  "0.3.3"  ->  (future steps)
+```
+
+`"pre"` is a sentinel meaning "any payload predating the baseline". The
+legacy step is a **shape-driven defensive normalizer** because the legacy data
+contains many shape variants per type (the production dump showed up to four
+shapes for `SingleTaskGPSurrogate`, five for `QnehviStrategy`). There is no
+per-record version tag and there will not be one — `source` is supplied by the
+caller.
+
+From `0.3.3` forward, each breaking schema PR adds a new step file
+(`steps/0_3_3_to_0_3_4/`) with **strict** version-to-version transforms.
+
+## Guiding principle for normalizers
+
+**Mutate only what would fail validation.** Specifically:
+
+- drop fields rejected by `extra="forbid"`,
+- fix wrong-typed values (e.g. legacy `scaler="NORMALIZE"` -> `Normalize()` object),
+- raise `UnrecoverablePayloadError` for removed types or unreachable states.
+
+Never insert fields just because they have a default value — Pydantic fills
+those in on validation. This keeps normalizers small, lets future schema
+additions stay backwards-compatible automatically, and avoids drift between
+the migration code and the data models.
+
+## Adding a new step
+
+1. Create `steps/<source>_to_<target>/` with one normalizer module per concern
+   (e.g. `surrogates.py`, `strategies.py`).
+2. Register normalizers with `@normalizer("<step_name>", "<TypeTag>", ...)`.
+3. Add the step to `steps/__init__.py`'s `STEPS` list.
+4. Add fixtures at `tests/bofire/data_models/migration/fixtures/<step>/...`.
+5. Tests in `tests/bofire/data_models/migration/test_<step>.py` parametrize
+   over the fixtures and assert `migrate(fixture) -> model_validate` succeeds.
+
+For non-trivial schema changes, also add a row to the relevant subclass's
+`RECURSE_MAP` entry in `walker.py` so the walker descends into the new field.
+
+## Walker contract
+
+The walker (`walker.py`) recurses **bottom-up** over typed dicts. It dispatches
+on the `type` discriminator and consults `RECURSE_MAP` to find children. For
+tagless containers (e.g. `BotorchSurrogates`), `STRUCTURAL_RECURSE_BY_KEY`
+provides a fallback recursion spec keyed on the parent's structural key.
+
+`INFERRED_TYPE_KEYS` lists structural keys whose child dicts have a Literal
+`type` field but may have been serialized without it (e.g. `Inputs`,
+`Outputs`, `Constraints`, `EngineeredFeatures`); the walker patches these in
+before descending.
+
+Recursion modes:
+
+- `"typed"` — single typed child dict, required.
+- `"typed_or_null"` — single typed child dict that may be `None`.
+- `"list_of_typed"` — list of typed child dicts.
+- `"container"` — single tagged container that itself has children
+  (e.g. `Inputs` containing a list of features).
+
+## Test fixtures
+
+Fixtures live at
+`tests/bofire/data_models/migration/fixtures/pre_to_0_3_3/<kind>/<type>/variant_N.json`.
+
+They are minimally-redacted real records pulled from the production dump.
+One file per `(type, field-shape)` combination observed in the wild.
+
+Tests parametrized over fixtures verify:
+
+1. `migrate(fixture)` produces a dict that passes `TypeAdapter.validate_python`.
+2. Migration is idempotent: `migrate(migrate(x)) == migrate(x)`.
+3. Known-unrecoverable types raise `UnrecoverablePayloadError`.
+
+Walker unit tests use synthetic typed dicts.
+
+## Deprecation policy
+
+The `pre -> 0.3.3` normalizer is a one-shot legacy bridge. It will be removed
+in BoFire **0.5.0**. By then, all downstream callers should have re-migrated
+their stores and be using forward steps for any subsequent schema changes.
+
+## Known unrecoverable payloads
+
+- `XGBoostSurrogate` — type was removed in 0.3.x. Re-fit as
+  `RandomForestSurrogate` or `LinearSurrogate`.
+- `CustomSoboStrategy` — was never supported in the public API; recreate as
+  a `SoboStrategy` with appropriate configuration.
+- `scaler: "LOG"` or `scaler: "CHAINED_LOG_STANDARDIZE"` on the input-side
+  `scaler` field — only valid on `output_scaler`. Re-fit the surrogate with
+  `scaler=Normalize()` (or `None`) and put the log transform on `output_scaler`.

--- a/bofire/data_models/migration/__init__.py
+++ b/bofire/data_models/migration/__init__.py
@@ -1,0 +1,14 @@
+from bofire.data_models.migration.api import migrate
+from bofire.data_models.migration.errors import (
+    MigrationError,
+    UnknownVersionError,
+    UnrecoverablePayloadError,
+)
+
+
+__all__ = [
+    "migrate",
+    "MigrationError",
+    "UnknownVersionError",
+    "UnrecoverablePayloadError",
+]

--- a/bofire/data_models/migration/__main__.py
+++ b/bofire/data_models/migration/__main__.py
@@ -1,0 +1,5 @@
+from bofire.data_models.migration.cli import main
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/bofire/data_models/migration/api.py
+++ b/bofire/data_models/migration/api.py
@@ -1,0 +1,55 @@
+from typing import Optional
+
+from bofire.data_models.migration.errors import UnknownVersionError
+from bofire.data_models.migration.steps import STEPS
+from bofire.data_models.migration.version import BASELINE, SOURCE_PRE, Kind
+
+
+def migrate(
+    payload: dict,
+    source: str = SOURCE_PRE,
+    target: Optional[str] = None,
+    kind: Kind = "strategy",
+) -> dict:
+    """Migrate a legacy BoFire payload to a newer schema version.
+
+    Pure dict -> dict; never calls model_validate internally. The result is the
+    minimum-essential dict that Pydantic will accept; default-valued fields are
+    left absent for Pydantic to fill in on validation.
+
+    Args:
+        payload: Serialized BoFire data model.
+        source: Source version. ``"pre"`` is the sentinel for any pre-baseline
+            dump. Future steps will accept explicit version strings.
+        target: Target version. Defaults to the migration tool's baseline
+            (currently ``0.3.3``).
+        kind: One of ``"strategy"``, ``"surrogate"``, ``"domain"``. Used to set
+            the top-level discriminator if absent.
+
+    Returns:
+        Migrated payload.
+    """
+    if target is None:
+        target = BASELINE
+    chain = _resolve_chain(source, target)
+    payload = dict(payload)
+    for step_fn in chain:
+        payload = step_fn(payload, kind)
+    return payload
+
+
+def _resolve_chain(source: str, target: str):
+    chain = []
+    cursor = source
+    while cursor != target:
+        for s, t, fn in STEPS:
+            if s == cursor:
+                chain.append(fn)
+                cursor = t
+                break
+        else:
+            raise UnknownVersionError(
+                f"No migration step from {cursor!r} towards {target!r}. "
+                f"Known steps: {[(s, t) for s, t, _ in STEPS]}"
+            )
+    return chain

--- a/bofire/data_models/migration/cli.py
+++ b/bofire/data_models/migration/cli.py
@@ -1,0 +1,173 @@
+import argparse
+import json
+import sys
+from typing import IO, Any, Dict, Iterator, Optional
+
+from pydantic import TypeAdapter, ValidationError
+
+from bofire.data_models.migration.api import migrate
+from bofire.data_models.migration.errors import (
+    MigrationError,
+    UnrecoverablePayloadError,
+)
+from bofire.data_models.migration.version import BASELINE, SOURCE_PRE
+
+
+def _validator_for(kind: str) -> Optional[TypeAdapter]:
+    if kind == "surrogate":
+        from bofire.data_models.surrogates.api import AnySurrogate
+
+        return TypeAdapter(AnySurrogate)
+    if kind == "strategy":
+        from bofire.data_models.strategies.api import AnyStrategy
+
+        return TypeAdapter(AnyStrategy)
+    if kind == "domain":
+        from bofire.data_models.domain.api import Domain
+
+        return TypeAdapter(Domain)
+    return None
+
+
+def _read_record(line: str) -> dict:
+    """Accept both bare JSON object lines and double-encoded JSON-string lines."""
+    stripped = line.lstrip()
+    if stripped.startswith('"'):
+        return json.loads(json.loads(line))
+    return json.loads(line)
+
+
+def _iter_records(stream: IO[str]) -> Iterator[dict]:
+    for line in stream:
+        line = line.rstrip("\n")
+        if not line.strip():
+            continue
+        yield _read_record(line)
+
+
+def main(argv: Optional[list] = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="python -m bofire.data_models.migration",
+        description="Migrate legacy BoFire payloads to the current schema.",
+    )
+    parser.add_argument(
+        "--kind",
+        choices=["strategy", "surrogate", "domain"],
+        required=True,
+    )
+    parser.add_argument("--source", default=SOURCE_PRE)
+    parser.add_argument("--target", default=BASELINE)
+    parser.add_argument(
+        "--input", "-i", default="-", help="JSONL input (default: stdin)"
+    )
+    parser.add_argument(
+        "--output", "-o", default="-", help="JSONL output (default: stdout)"
+    )
+    parser.add_argument(
+        "--validate",
+        action="store_true",
+        help="Validate each migrated record against the current schema.",
+    )
+    parser.add_argument(
+        "--dry-run", action="store_true", help="Migrate and report but write no output."
+    )
+    parser.add_argument("--report", help="Write a JSON summary report to this path.")
+    parser.add_argument(
+        "--continue-on-error",
+        action="store_true",
+        help="Write failed records inline with an error annotation "
+        "instead of routing them to a sidecar.",
+    )
+
+    args = parser.parse_args(argv)
+
+    in_stream = sys.stdin if args.input == "-" else open(args.input, "r")
+    out_stream = sys.stdout if args.output == "-" else open(args.output, "w")
+    fail_stream = None
+    fail_path = None
+    if args.output != "-" and not args.dry_run and not args.continue_on_error:
+        fail_path = args.output + ".failed.jsonl"
+
+    validator = _validator_for(args.kind) if args.validate else None
+
+    report: Dict[str, Any] = {
+        "total": 0,
+        "ok": 0,
+        "unrecoverable": [],
+        "validation_failed": [],
+        "shape_histogram": {},
+    }
+
+    try:
+        for lineno, payload in enumerate(_iter_records(in_stream), start=1):
+            report["total"] += 1
+            type_tag = payload.get("type", "<no-type>")
+            report["shape_histogram"].setdefault(type_tag, 0)
+            report["shape_histogram"][type_tag] += 1
+            try:
+                migrated = migrate(
+                    payload, source=args.source, target=args.target, kind=args.kind
+                )
+                if validator is not None:
+                    validator.validate_python(migrated)
+                report["ok"] += 1
+                if not args.dry_run:
+                    out_stream.write(json.dumps(migrated) + "\n")
+            except UnrecoverablePayloadError as e:
+                report["unrecoverable"].append(
+                    {"line": lineno, "type": e.payload_type, "reason": e.reason}
+                )
+                if args.continue_on_error and not args.dry_run:
+                    out_stream.write(
+                        json.dumps({"_migration_error": str(e), "_original": payload})
+                        + "\n"
+                    )
+                elif fail_path and not args.dry_run:
+                    if fail_stream is None:
+                        fail_stream = open(fail_path, "w")
+                    fail_stream.write(
+                        json.dumps({"_migration_error": str(e), "_original": payload})
+                        + "\n"
+                    )
+            except (ValidationError, MigrationError) as e:
+                report["validation_failed"].append(
+                    {"line": lineno, "type": type_tag, "error": str(e)[:500]}
+                )
+                if args.continue_on_error and not args.dry_run:
+                    out_stream.write(
+                        json.dumps(
+                            {"_validation_error": str(e)[:500], "_original": payload}
+                        )
+                        + "\n"
+                    )
+                elif fail_path and not args.dry_run:
+                    if fail_stream is None:
+                        fail_stream = open(fail_path, "w")
+                    fail_stream.write(
+                        json.dumps(
+                            {"_validation_error": str(e)[:500], "_original": payload}
+                        )
+                        + "\n"
+                    )
+    finally:
+        if in_stream is not sys.stdin:
+            in_stream.close()
+        if out_stream is not sys.stdout:
+            out_stream.close()
+        if fail_stream is not None:
+            fail_stream.close()
+
+    if args.report:
+        with open(args.report, "w") as f:
+            json.dump(report, f, indent=2)
+
+    sys.stderr.write(
+        f"migrated {report['ok']}/{report['total']} "
+        f"(unrecoverable={len(report['unrecoverable'])}, "
+        f"validation_failed={len(report['validation_failed'])})\n"
+    )
+    return 0 if len(report["validation_failed"]) == 0 else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/bofire/data_models/migration/errors.py
+++ b/bofire/data_models/migration/errors.py
@@ -1,0 +1,17 @@
+class MigrationError(Exception):
+    pass
+
+
+class UnrecoverablePayloadError(MigrationError):
+    def __init__(self, *, payload_type: str, reason: str, hint: str = ""):
+        self.payload_type = payload_type
+        self.reason = reason
+        self.hint = hint
+        msg = f"{payload_type}: {reason}"
+        if hint:
+            msg += f" Hint: {hint}"
+        super().__init__(msg)
+
+
+class UnknownVersionError(MigrationError):
+    pass

--- a/bofire/data_models/migration/registry.py
+++ b/bofire/data_models/migration/registry.py
@@ -1,0 +1,29 @@
+from typing import Callable, Dict, Tuple
+
+
+Normalizer = Callable[[dict], dict]
+
+NORMALIZERS: Dict[Tuple[str, str], Normalizer] = {}
+
+
+def normalizer(step: str, *type_tags: str):
+    """Register a per-type normalizer for a given migration step.
+
+    A normalizer is a pure dict->dict function that mutates only what would
+    fail Pydantic validation. The walker dispatches on the dict's `type` tag.
+    """
+
+    def deco(fn: Normalizer) -> Normalizer:
+        for tag in type_tags:
+            NORMALIZERS[(step, tag)] = fn
+        return fn
+
+    return deco
+
+
+def get_normalizer(step: str, type_tag: str) -> Normalizer:
+    return NORMALIZERS.get((step, type_tag), _identity)
+
+
+def _identity(p: dict) -> dict:
+    return p

--- a/bofire/data_models/migration/steps/__init__.py
+++ b/bofire/data_models/migration/steps/__init__.py
@@ -1,0 +1,6 @@
+from bofire.data_models.migration.steps.pre_to_0_3_3 import run as run_pre_to_baseline
+
+
+STEPS = [
+    ("pre", "0.3.3", run_pre_to_baseline),
+]

--- a/bofire/data_models/migration/steps/pre_to_0_3_3/__init__.py
+++ b/bofire/data_models/migration/steps/pre_to_0_3_3/__init__.py
@@ -1,0 +1,25 @@
+from bofire.data_models.migration.steps.pre_to_0_3_3 import (  # noqa: F401
+    domain,
+    kernels,
+    strategies,
+    surrogates,
+)
+from bofire.data_models.migration.version import Kind
+from bofire.data_models.migration.walker import walk
+
+
+STEP = "pre_to_0_3_3"
+
+_KIND_TOP_TYPES = {
+    # If a payload lacks a top-level "type" tag, the kind argument tells us
+    # what to expect. We don't currently need to invent one because every
+    # observed strategy/surrogate carries `type`, but bare Domain payloads do
+    # not always carry it (it was added recently).
+    "domain": "Domain",
+}
+
+
+def run(payload: dict, kind: Kind) -> dict:
+    if "type" not in payload and kind in _KIND_TOP_TYPES:
+        payload["type"] = _KIND_TOP_TYPES[kind]
+    return walk(payload, STEP)

--- a/bofire/data_models/migration/steps/pre_to_0_3_3/_atoms.py
+++ b/bofire/data_models/migration/steps/pre_to_0_3_3/_atoms.py
@@ -1,0 +1,94 @@
+from typing import Iterable
+
+from bofire.data_models.migration.errors import UnrecoverablePayloadError
+
+
+def drop_keys(d: dict, keys: Iterable[str]) -> dict:
+    for k in keys:
+        d.pop(k, None)
+    return d
+
+
+_LEGACY_SCALER_TO_OBJECT = {
+    "NORMALIZE": {"type": "Normalize", "features": []},
+    "STANDARDIZE": {"type": "Standardize", "features": []},
+    "IDENTITY": None,
+}
+
+_SCALER_UNRECOVERABLE_ON_INPUT_SIDE = {"LOG", "CHAINED_LOG_STANDARDIZE"}
+
+
+def normalize_scaler_field(d: dict, key: str = "scaler") -> dict:
+    """Convert a legacy string scaler value to the current object form.
+
+    Only the input-side ``scaler`` field changed (string enum -> tagged-union
+    object). ``output_scaler`` remains a ``ScalerEnum`` string, so this atom
+    must not be called on ``output_scaler``.
+    """
+    if key not in d:
+        return d
+    value = d[key]
+    if isinstance(value, str):
+        if value in _SCALER_UNRECOVERABLE_ON_INPUT_SIDE:
+            raise UnrecoverablePayloadError(
+                payload_type=d.get("type", "<unknown>"),
+                reason=(
+                    f"scaler={value!r} is no longer valid for the input scaler; "
+                    f"only Normalize/Standardize/None are accepted."
+                ),
+                hint=(
+                    "Re-fit the surrogate with scaler=Normalize() (or None) and "
+                    "use output_scaler for log transforms."
+                ),
+            )
+        if value not in _LEGACY_SCALER_TO_OBJECT:
+            raise UnrecoverablePayloadError(
+                payload_type=d.get("type", "<unknown>"),
+                reason=f"Unknown legacy scaler value {value!r}.",
+            )
+        d[key] = _LEGACY_SCALER_TO_OBJECT[value]
+    return d
+
+
+_HYPERSTRATEGY_RENAMES = {
+    "FactorialStrategy": "FractionalFactorialStrategy",
+}
+
+
+def normalize_hyperstrategy(hc: dict) -> dict:
+    """Apply known renames to ``hyperstrategy`` in a hyperconfig dict."""
+    if not isinstance(hc, dict):
+        return hc
+    name = hc.get("hyperstrategy")
+    if name in _HYPERSTRATEGY_RENAMES:
+        hc["hyperstrategy"] = _HYPERSTRATEGY_RENAMES[name]
+    return hc
+
+
+_CATEGORICAL_ENCODING_STRINGS = {"ONE_HOT", "ORDINAL", "DUMMY", "DESCRIPTOR"}
+
+
+def split_input_preprocessing_specs(p: dict) -> dict:
+    """Move legacy categorical encodings into ``categorical_encodings``.
+
+    Legacy BotorchSurrogate payloads stored categorical encodings (``ONE_HOT``,
+    ``DESCRIPTOR``, etc.) in ``input_preprocessing_specs``. The current schema
+    forces ``ORDINAL`` for categoricals in ``input_preprocessing_specs`` and
+    carries the "within-the-model" encoding on ``categorical_encodings``.
+
+    String values are categorical encoding enums and get moved. Dict values
+    (``Fingerprints`` etc. for molecular features) stay put; the
+    ``categorical_encodings`` validator routes them based on feature type.
+    """
+    ips = p.get("input_preprocessing_specs")
+    if not isinstance(ips, dict) or not ips:
+        return p
+    ce = p.setdefault("categorical_encodings", {})
+    remaining = {}
+    for key, value in ips.items():
+        if isinstance(value, str) and value in _CATEGORICAL_ENCODING_STRINGS:
+            ce.setdefault(key, value)
+        else:
+            remaining[key] = value
+    p["input_preprocessing_specs"] = remaining
+    return p

--- a/bofire/data_models/migration/steps/pre_to_0_3_3/domain.py
+++ b/bofire/data_models/migration/steps/pre_to_0_3_3/domain.py
@@ -1,0 +1,83 @@
+from bofire.data_models.migration.registry import normalizer
+
+
+STEP = "pre_to_0_3_3"
+
+
+@normalizer(STEP, "ContinuousOutput")
+def normalize_continuous_output(p: dict) -> dict:
+    # Some legacy RandomStrategy records carry `"objective": {}`, which is not
+    # a valid AnyObjective discriminated-union member. ContinuousOutput.objective
+    # is Optional, so collapse the empty dict to None.
+    if p.get("objective") == {}:
+        p["objective"] = None
+    return p
+
+
+@normalizer(STEP, "MaximizeObjective", "MinimizeObjective", "IdentityObjective")
+def normalize_identity_objective(p: dict) -> dict:
+    """Collapse legacy ``lower_bound`` / ``upper_bound`` fields into ``bounds``.
+
+    The current ``IdentityObjective`` keeps ``bounds: [low, high]`` as a single
+    field; ``lower_bound`` and ``upper_bound`` are now read-only properties.
+    """
+    has_lb = "lower_bound" in p
+    has_ub = "upper_bound" in p
+    if has_lb or has_ub:
+        lb = p.pop("lower_bound", 0.0)
+        ub = p.pop("upper_bound", 1.0)
+        p.setdefault("bounds", [lb, ub])
+    return p
+
+
+@normalizer(STEP, "CategoricalInput", "CategoricalDescriptorInput")
+def normalize_categorical_input(p: dict) -> dict:
+    cats = p.get("categories")
+    if isinstance(cats, list):
+        p["categories"] = [str(c) for c in cats]
+    return p
+
+
+@normalizer(STEP, "Domain")
+def normalize_domain(p: dict) -> dict:
+    """Cross-cutting Domain fixups that need access to both inputs and constraints.
+
+    Specifically: for every ``ContinuousInput`` that appears in a
+    ``NChooseKConstraint`` with ``bounds[0] > 0`` and ``allow_zero`` not set,
+    we set ``allow_zero=True``. The legacy schema didn't require this; the
+    current NChooseK validator does.
+    """
+    constraints = p.get("constraints")
+    if isinstance(constraints, dict):
+        cs = constraints.get("constraints", []) or []
+    elif isinstance(constraints, list):
+        cs = constraints
+    else:
+        cs = []
+    nchoosek_feature_keys: set = set()
+    for c in cs:
+        if isinstance(c, dict) and c.get("type") == "NChooseKConstraint":
+            for k in c.get("features", []) or []:
+                nchoosek_feature_keys.add(k)
+    if not nchoosek_feature_keys:
+        return p
+    inputs = p.get("inputs")
+    if isinstance(inputs, dict):
+        feats = inputs.get("features", []) or []
+    elif isinstance(inputs, list):
+        feats = inputs
+    else:
+        feats = []
+    for f in feats:
+        if not isinstance(f, dict):
+            continue
+        if f.get("type") != "ContinuousInput":
+            continue
+        if f.get("key") not in nchoosek_feature_keys:
+            continue
+        bounds = f.get("bounds")
+        if not (isinstance(bounds, list) and len(bounds) == 2):
+            continue
+        if bounds[0] > 0 and not f.get("allow_zero"):
+            f["allow_zero"] = True
+    return p

--- a/bofire/data_models/migration/steps/pre_to_0_3_3/kernels.py
+++ b/bofire/data_models/migration/steps/pre_to_0_3_3/kernels.py
@@ -1,0 +1,21 @@
+from bofire.data_models.migration.registry import normalizer
+from bofire.data_models.migration.steps.pre_to_0_3_3._atoms import (
+    normalize_hyperstrategy,
+)
+
+
+STEP = "pre_to_0_3_3"
+
+
+# Hyperconfigs need the legacy "FactorialStrategy" -> "FractionalFactorialStrategy"
+# rename on the hyperstrategy field.
+@normalizer(STEP, "SingleTaskGPHyperconfig", "MixedSingleTaskGPHyperconfig")
+def normalize_hyperconfig(p: dict) -> dict:
+    return normalize_hyperstrategy(p)
+
+
+# A typo in legacy payloads — should always have been HammingDistanceKernel.
+@normalizer(STEP, "HammondDistanceKernel")
+def fix_hammond_typo(p: dict) -> dict:
+    p["type"] = "HammingDistanceKernel"
+    return p

--- a/bofire/data_models/migration/steps/pre_to_0_3_3/strategies.py
+++ b/bofire/data_models/migration/steps/pre_to_0_3_3/strategies.py
@@ -1,0 +1,67 @@
+from bofire.data_models.migration.errors import UnrecoverablePayloadError
+from bofire.data_models.migration.registry import normalizer
+from bofire.data_models.migration.steps.pre_to_0_3_3._atoms import drop_keys
+
+
+STEP = "pre_to_0_3_3"
+
+_SOBO_OBSOLETE = (
+    "categorical_method",
+    "descriptor_method",
+    "discrete_method",
+    "num_raw_samples",
+    "num_restarts",
+)
+
+
+@normalizer(STEP, "BotorchOptimizer")
+def normalize_botorch_optimizer(p: dict) -> dict:
+    """Drop legacy categorical_/descriptor_/discrete_method fields.
+
+    Some MoboStrategy records stored these fields on the ``acquisition_optimizer``
+    (BotorchOptimizer) rather than at the strategy top level. Current
+    BotorchOptimizer has no such fields.
+    """
+    return drop_keys(p, _SOBO_OBSOLETE)
+
+
+@normalizer(STEP, "SoboStrategy", "MoboStrategy", "MultiplicativeSoboStrategy")
+def normalize_sobo_family(p: dict) -> dict:
+    return drop_keys(p, _SOBO_OBSOLETE)
+
+
+@normalizer(STEP, "QnehviStrategy")
+def migrate_qnehvi_to_mobo(p: dict) -> dict:
+    """QnehviStrategy was deprecated; rewrite as MoboStrategy.
+
+    MoboStrategy with its default acquisition_function=qLogNEHVI() subsumes the
+    qNEHVI use case. All shared fields (ref_point, surrogate_specs,
+    outlier_detection_specs, frequency_check, frequency_hyperopt, folds,
+    min_experiments_before_outlier_check, seed) carry over unchanged.
+    """
+    drop_keys(p, ["alpha", *_SOBO_OBSOLETE])
+    p["type"] = "MoboStrategy"
+    return p
+
+
+@normalizer(STEP, "CustomSoboStrategy")
+def reject_custom_sobo(p: dict) -> dict:
+    raise UnrecoverablePayloadError(
+        payload_type="CustomSoboStrategy",
+        reason="CustomSoboStrategy is not supported by the migration tool.",
+        hint="Recreate the experiment as a SoboStrategy with appropriate config.",
+    )
+
+
+# Strategies that need no field migration; the walker still recurses into
+# their children. Registering identity ensures discriminator coverage.
+@normalizer(
+    STEP,
+    "RandomStrategy",
+    "QparegoStrategy",
+    "FractionalFactorialStrategy",
+    "DoEStrategy",
+    "StepwiseStrategy",
+)
+def passthrough(p: dict) -> dict:
+    return p

--- a/bofire/data_models/migration/steps/pre_to_0_3_3/surrogates.py
+++ b/bofire/data_models/migration/steps/pre_to_0_3_3/surrogates.py
@@ -1,0 +1,82 @@
+from bofire.data_models.migration.errors import UnrecoverablePayloadError
+from bofire.data_models.migration.registry import normalizer
+from bofire.data_models.migration.steps.pre_to_0_3_3._atoms import (
+    drop_keys,
+    normalize_scaler_field,
+    split_input_preprocessing_specs,
+)
+
+
+STEP = "pre_to_0_3_3"
+
+
+def _normalize_trainable_botorch(p: dict) -> dict:
+    drop_keys(p, ["aggregations"])
+    normalize_scaler_field(p, "scaler")
+    split_input_preprocessing_specs(p)
+    return p
+
+
+@normalizer(
+    STEP,
+    "SingleTaskGPSurrogate",
+    "LinearSurrogate",
+    "FullyBayesianSingleTaskGPSurrogate",
+    "AdditiveMapSaasSingleTaskGPSurrogate",
+    "RandomForestSurrogate",
+)
+def normalize_trainable_botorch(p: dict) -> dict:
+    return _normalize_trainable_botorch(p)
+
+
+@normalizer(STEP, "MixedSingleTaskGPSurrogate")
+def normalize_mixed_single_task_gp(p: dict) -> dict:
+    """MixedSingleTaskGPSurrogate requires ORDINAL encoding for categoricals.
+
+    Some legacy payloads put ``ONE_HOT`` in ``input_preprocessing_specs`` for
+    Mixed models. We drop the entry entirely so the BotorchSurrogate validator
+    fills in ORDINAL automatically; ``categorical_encodings`` likewise defaults
+    to ORDINAL for plain ``CategoricalInput`` on Mixed.
+    """
+    drop_keys(p, ["aggregations"])
+    normalize_scaler_field(p, "scaler")
+    ips = p.get("input_preprocessing_specs")
+    if isinstance(ips, dict):
+        # Strip string-valued (categorical-encoding) entries entirely; keep
+        # molecular dict entries (Fingerprints etc.).
+        p["input_preprocessing_specs"] = {
+            k: v for k, v in ips.items() if not isinstance(v, str)
+        }
+    return p
+
+
+@normalizer(STEP, "MLPEnsemble")
+def migrate_mlp_ensemble(p: dict) -> dict:
+    # Legacy "MLPEnsemble" type was renamed to "RegressionMLPEnsemble" when
+    # the classification variant was introduced. The legacy class is the
+    # regression model.
+    p["type"] = "RegressionMLPEnsemble"
+    return _normalize_trainable_botorch(p)
+
+
+@normalizer(STEP, "RegressionMLPEnsemble")
+def normalize_regression_mlp(p: dict) -> dict:
+    return _normalize_trainable_botorch(p)
+
+
+@normalizer(STEP, "EmpiricalSurrogate", "LinearDeterministicSurrogate")
+def normalize_simple_surrogate(p: dict) -> dict:
+    drop_keys(p, ["aggregations"])
+    # EmpiricalSurrogate is a BotorchSurrogate too, so it has the same
+    # input_preprocessing_specs / categorical_encodings split.
+    split_input_preprocessing_specs(p)
+    return p
+
+
+@normalizer(STEP, "XGBoostSurrogate")
+def reject_xgboost(p: dict) -> dict:
+    raise UnrecoverablePayloadError(
+        payload_type="XGBoostSurrogate",
+        reason="XGBoostSurrogate was removed in BoFire 0.3.x.",
+        hint="Re-fit the model as RandomForestSurrogate or LinearSurrogate.",
+    )

--- a/bofire/data_models/migration/version.py
+++ b/bofire/data_models/migration/version.py
@@ -1,0 +1,7 @@
+from typing import Literal
+
+
+SOURCE_PRE = "pre"
+BASELINE = "0.3.3"
+
+Kind = Literal["strategy", "surrogate", "domain"]

--- a/bofire/data_models/migration/walker.py
+++ b/bofire/data_models/migration/walker.py
@@ -1,0 +1,245 @@
+from typing import Dict, Literal
+
+from bofire.data_models.migration.registry import get_normalizer
+
+
+RecurseMode = Literal["typed", "typed_or_null", "list_of_typed", "container"]
+
+RECURSE_MAP: Dict[str, Dict[str, RecurseMode]] = {
+    "Domain": {
+        "inputs": "container",
+        "outputs": "container",
+        "constraints": "container",
+    },
+    "Inputs": {"features": "list_of_typed"},
+    "Outputs": {"features": "list_of_typed"},
+    "Constraints": {"constraints": "list_of_typed"},
+    "EngineeredFeatures": {"features": "list_of_typed"},
+    "BotorchSurrogates": {"surrogates": "list_of_typed"},
+    # Surrogate base recursion: most surrogates carry inputs/outputs and an
+    # engineered_features container; the trainable botorch ones additionally
+    # carry kernel(s), priors, scaler, hyperconfig. We register the union of
+    # plausibly-present keys for each type; absent keys are skipped.
+    "SingleTaskGPSurrogate": {
+        "inputs": "container",
+        "outputs": "container",
+        "kernel": "typed",
+        "noise_prior": "typed",
+        "noise_constraint": "typed_or_null",
+        "hyperconfig": "typed_or_null",
+        "scaler": "typed_or_null",
+        "engineered_features": "typed",
+    },
+    "MixedSingleTaskGPSurrogate": {
+        "inputs": "container",
+        "outputs": "container",
+        "continuous_kernel": "typed",
+        "categorical_kernel": "typed",
+        "noise_prior": "typed",
+        "noise_constraint": "typed_or_null",
+        "hyperconfig": "typed_or_null",
+        "scaler": "typed_or_null",
+        "engineered_features": "typed",
+    },
+    "LinearSurrogate": {
+        "inputs": "container",
+        "outputs": "container",
+        "kernel": "typed",
+        "noise_prior": "typed",
+        "noise_constraint": "typed_or_null",
+        "hyperconfig": "typed_or_null",
+        "scaler": "typed_or_null",
+        "engineered_features": "typed",
+    },
+    "FullyBayesianSingleTaskGPSurrogate": {
+        "inputs": "container",
+        "outputs": "container",
+        "hyperconfig": "typed_or_null",
+        "scaler": "typed_or_null",
+        "engineered_features": "typed",
+    },
+    "AdditiveMapSaasSingleTaskGPSurrogate": {
+        "inputs": "container",
+        "outputs": "container",
+        "hyperconfig": "typed_or_null",
+        "scaler": "typed_or_null",
+        "engineered_features": "typed",
+    },
+    "RandomForestSurrogate": {
+        "inputs": "container",
+        "outputs": "container",
+        "hyperconfig": "typed_or_null",
+        "scaler": "typed_or_null",
+        "engineered_features": "typed",
+    },
+    "MLPEnsemble": {
+        "inputs": "container",
+        "outputs": "container",
+        "hyperconfig": "typed_or_null",
+        "scaler": "typed_or_null",
+        "engineered_features": "typed",
+    },
+    "RegressionMLPEnsemble": {
+        "inputs": "container",
+        "outputs": "container",
+        "hyperconfig": "typed_or_null",
+        "scaler": "typed_or_null",
+        "engineered_features": "typed",
+    },
+    "EmpiricalSurrogate": {
+        "inputs": "container",
+        "outputs": "container",
+    },
+    "LinearDeterministicSurrogate": {
+        "inputs": "container",
+        "outputs": "container",
+        "engineered_features": "typed",
+    },
+    # Strategies
+    "RandomStrategy": {"domain": "container"},
+    "SoboStrategy": {
+        "domain": "container",
+        "surrogate_specs": "typed_or_null",
+        "acquisition_function": "typed_or_null",
+        "acquisition_optimizer": "typed_or_null",
+    },
+    "MoboStrategy": {
+        "domain": "container",
+        "surrogate_specs": "typed_or_null",
+        "acquisition_function": "typed_or_null",
+        "acquisition_optimizer": "typed_or_null",
+        "ref_point": "typed_or_null",
+    },
+    "QnehviStrategy": {
+        "domain": "container",
+        "surrogate_specs": "typed_or_null",
+        "acquisition_function": "typed_or_null",
+        "acquisition_optimizer": "typed_or_null",
+    },
+    "QparegoStrategy": {
+        "domain": "container",
+        "surrogate_specs": "typed_or_null",
+        "acquisition_function": "typed_or_null",
+        "acquisition_optimizer": "typed_or_null",
+    },
+    "MultiplicativeSoboStrategy": {
+        "domain": "container",
+        "surrogate_specs": "typed_or_null",
+        "acquisition_function": "typed_or_null",
+        "acquisition_optimizer": "typed_or_null",
+    },
+    "CustomSoboStrategy": {
+        "domain": "container",
+        "surrogate_specs": "typed_or_null",
+        "acquisition_function": "typed_or_null",
+        "acquisition_optimizer": "typed_or_null",
+    },
+    "FractionalFactorialStrategy": {"domain": "container"},
+    "DoEStrategy": {"domain": "container", "criterion": "typed_or_null"},
+    "StepwiseStrategy": {"domain": "container"},
+    # Hyperconfig carries its own inputs container (hyperparameter search space).
+    "SingleTaskGPHyperconfig": {"inputs": "container"},
+    "MixedSingleTaskGPHyperconfig": {"inputs": "container"},
+    # ContinuousOutput's objective field carries a typed AnyObjective dict.
+    "ContinuousOutput": {"objective": "typed_or_null"},
+    # Kernel structure: ScaleKernel wraps a base_kernel.
+    "ScaleKernel": {"base_kernel": "typed", "outputscale_prior": "typed_or_null"},
+    "MaternKernel": {"lengthscale_prior": "typed_or_null"},
+    "RBFKernel": {"lengthscale_prior": "typed_or_null"},
+    "LinearKernel": {"variance_prior": "typed_or_null"},
+}
+
+
+# Top-level type tags that may be missing in legacy payloads (the dump shows
+# Inputs/Outputs/Constraints embedded without a "type" key). We patch those in
+# before recursing so the walker can find a normalizer.
+INFERRED_TYPE_KEYS: Dict[str, str] = {
+    # Child structural key -> type tag to insert when the child dict is missing
+    # its `type` field. Only used for classes that *have* a `type` Literal so
+    # inserting it won't trigger extra="forbid".
+    "inputs": "Inputs",
+    "outputs": "Outputs",
+    "constraints": "Constraints",
+    "engineered_features": "EngineeredFeatures",
+}
+
+
+# Fallback recursion spec for tagless dicts encountered at a known parent
+# structural key. The walker uses this when a child dict has no `type` field
+# AND the child's class is not in INFERRED_TYPE_KEYS (e.g. `BotorchSurrogates`
+# is a tagless container).
+STRUCTURAL_RECURSE_BY_KEY: Dict[str, Dict[str, RecurseMode]] = {
+    "surrogate_specs": {"surrogates": "list_of_typed"},
+}
+
+
+def walk(node, step: str, structural_key: str = ""):
+    """Recursively normalize a payload bottom-up.
+
+    Returns the normalized node. Mutates dicts in place but the return value
+    is what callers should use (some normalizers replace the dict entirely).
+    """
+    if node is None:
+        return None
+    if isinstance(node, list):
+        return [walk(child, step, structural_key) for child in node]
+    if not isinstance(node, dict):
+        return node
+
+    type_tag = node.get("type")
+
+    if type_tag and type_tag in RECURSE_MAP:
+        spec = RECURSE_MAP[type_tag]
+    elif type_tag is None and structural_key in STRUCTURAL_RECURSE_BY_KEY:
+        spec = STRUCTURAL_RECURSE_BY_KEY[structural_key]
+    else:
+        spec = {}
+
+    # Descend into known typed children first (bottom-up).
+    for child_key, mode in spec.items():
+        if child_key not in node:
+            continue
+        child = node[child_key]
+        if mode == "typed":
+            node[child_key] = walk(
+                _with_inferred_type(child, child_key), step, child_key
+            )
+        elif mode == "typed_or_null":
+            if child is None:
+                continue
+            node[child_key] = walk(
+                _with_inferred_type(child, child_key), step, child_key
+            )
+        elif mode == "list_of_typed":
+            if not isinstance(child, list):
+                continue
+            node[child_key] = [
+                walk(_with_inferred_type(c, child_key), step, child_key) for c in child
+            ]
+        elif mode == "container":
+            node[child_key] = walk(
+                _with_inferred_type(child, child_key), step, child_key
+            )
+
+    # Now apply this node's normalizer.
+    if type_tag is not None:
+        normalizer_fn = get_normalizer(step, type_tag)
+        node = normalizer_fn(node)
+
+    return node
+
+
+def _with_inferred_type(node, child_key: str):
+    """If a child dict at a known structural key lacks a `type` tag, fill it in.
+
+    Only applied to classes that have a Literal `type` field — never to tagless
+    containers like ``BotorchSurrogates``.
+    """
+    if not isinstance(node, dict):
+        return node
+    if "type" in node:
+        return node
+    inferred = INFERRED_TYPE_KEYS.get(child_key)
+    if inferred is not None:
+        node["type"] = inferred
+    return node

--- a/tests/bofire/data_models/migration/test_pre_to_0_3_3.py
+++ b/tests/bofire/data_models/migration/test_pre_to_0_3_3.py
@@ -1,0 +1,101 @@
+import json
+from pathlib import Path
+
+import pytest
+from pydantic import TypeAdapter
+
+from bofire.data_models.domain.api import Domain
+from bofire.data_models.migration import UnrecoverablePayloadError, migrate
+from bofire.data_models.strategies.api import AnyStrategy
+from bofire.data_models.surrogates.api import AnySurrogate
+
+
+FIXTURE_ROOT = Path(__file__).parent / "fixtures" / "pre_to_0_3_3"
+
+# Payload types known to be unrecoverable. These fixtures are exercised by a
+# separate test that asserts UnrecoverablePayloadError is raised.
+UNRECOVERABLE = {
+    ("surrogate", "XGBoostSurrogate"),
+    ("strategy", "CustomSoboStrategy"),
+}
+
+_ADAPTERS = {
+    "surrogate": TypeAdapter(AnySurrogate),
+    "strategy": TypeAdapter(AnyStrategy),
+    "domain": TypeAdapter(Domain),
+}
+
+
+def _collect_fixtures():
+    items = []
+    for kind_dir in sorted(FIXTURE_ROOT.iterdir()):
+        if not kind_dir.is_dir():
+            continue
+        kind = kind_dir.name
+        for type_dir in sorted(kind_dir.iterdir()):
+            if not type_dir.is_dir():
+                continue
+            type_name = type_dir.name
+            for variant_file in sorted(type_dir.glob("variant_*.json")):
+                items.append((kind, type_name, variant_file))
+    return items
+
+
+_ALL = _collect_fixtures()
+_VALID = [(k, t, p) for (k, t, p) in _ALL if (k, t) not in UNRECOVERABLE]
+_UNRECOVERABLE = [(k, t, p) for (k, t, p) in _ALL if (k, t) in UNRECOVERABLE]
+
+
+@pytest.mark.parametrize(
+    "kind,type_name,variant_path",
+    _VALID,
+    ids=[f"{k}-{t}-{p.stem}" for k, t, p in _VALID],
+)
+def test_fixture_migrates_and_validates(kind, type_name, variant_path):
+    payload = json.loads(variant_path.read_text())
+    migrated = migrate(payload, source="pre", target="0.3.3", kind=kind)
+    _ADAPTERS[kind].validate_python(migrated)
+
+
+@pytest.mark.parametrize(
+    "kind,type_name,variant_path",
+    _VALID,
+    ids=[f"{k}-{t}-{p.stem}" for k, t, p in _VALID],
+)
+def test_migration_is_idempotent(kind, type_name, variant_path):
+    payload = json.loads(variant_path.read_text())
+    once = migrate(payload, source="pre", target="0.3.3", kind=kind)
+    twice = migrate(
+        json.loads(json.dumps(once)), source="pre", target="0.3.3", kind=kind
+    )
+    assert once == twice
+
+
+@pytest.mark.parametrize(
+    "kind,type_name,variant_path",
+    _UNRECOVERABLE,
+    ids=[f"{k}-{t}-{p.stem}" for k, t, p in _UNRECOVERABLE],
+)
+def test_unrecoverable_fixtures_raise(kind, type_name, variant_path):
+    payload = json.loads(variant_path.read_text())
+    with pytest.raises(UnrecoverablePayloadError):
+        migrate(payload, source="pre", target="0.3.3", kind=kind)
+
+
+def test_scaler_log_on_input_scaler_unrecoverable():
+    payload = {
+        "type": "SingleTaskGPSurrogate",
+        "inputs": {
+            "type": "Inputs",
+            "features": [{"type": "ContinuousInput", "key": "x", "bounds": [0.0, 1.0]}],
+        },
+        "outputs": {
+            "type": "Outputs",
+            "features": [{"type": "ContinuousOutput", "key": "y", "objective": None}],
+        },
+        "scaler": "LOG",  # only valid on output_scaler, not scaler
+        "kernel": {"type": "MaternKernel", "ard": True, "nu": 2.5},
+        "noise_prior": {"type": "GammaPrior", "concentration": 1.1, "rate": 0.05},
+    }
+    with pytest.raises(UnrecoverablePayloadError):
+        migrate(payload, kind="surrogate")

--- a/tests/bofire/data_models/migration/test_walker.py
+++ b/tests/bofire/data_models/migration/test_walker.py
@@ -1,0 +1,72 @@
+from bofire.data_models.migration.registry import normalizer
+from bofire.data_models.migration.walker import RECURSE_MAP, walk
+
+
+STEP = "_test_walker_step"
+ORDER: list = []
+
+
+def _register(tag: str, recurse_into=None):
+    if recurse_into is not None:
+        RECURSE_MAP[tag] = recurse_into
+
+    def fn(p: dict) -> dict:
+        ORDER.append(p["type"])
+        return p
+
+    normalizer(STEP, tag)(fn)
+
+
+def setup_function():
+    ORDER.clear()
+
+
+def test_bottom_up_order():
+    _register("__TestParent", {"child": "typed"})
+    _register("__TestChild", {})
+
+    walk({"type": "__TestParent", "child": {"type": "__TestChild"}}, STEP)
+    assert ORDER == ["__TestChild", "__TestParent"]
+
+
+def test_typed_or_null_skips_none():
+    _register("__TestRoot", {"opt": "typed_or_null"})
+    walk({"type": "__TestRoot", "opt": None}, STEP)
+    assert ORDER == ["__TestRoot"]
+
+
+def test_list_of_typed_walks_each_child():
+    _register("__TestList", {"items": "list_of_typed"})
+    _register("__TestItem", {})
+    walk(
+        {
+            "type": "__TestList",
+            "items": [{"type": "__TestItem"}, {"type": "__TestItem"}],
+        },
+        STEP,
+    )
+    assert ORDER.count("__TestItem") == 2
+    assert ORDER[-1] == "__TestList"
+
+
+def test_inferred_type_for_known_structural_key():
+    _register("__TestDomainLike", {"inputs": "container"})
+    payload = {"type": "__TestDomainLike", "inputs": {"features": []}}
+    walk(payload, STEP)
+    # Inputs container was untagged; walker infers "Inputs" before recursing.
+    assert payload["inputs"]["type"] == "Inputs"
+
+
+def test_tagless_container_recurses_via_structural_map():
+    # BotorchSurrogates is a tagless container; walker uses
+    # STRUCTURAL_RECURSE_BY_KEY to descend into its `surrogates` list.
+    _register("__TestStratWithSpecs", {"surrogate_specs": "typed_or_null"})
+    _register("__TestInnerSurrogate", {})
+    payload = {
+        "type": "__TestStratWithSpecs",
+        "surrogate_specs": {"surrogates": [{"type": "__TestInnerSurrogate"}]},
+    }
+    walk(payload, STEP)
+    assert "__TestInnerSurrogate" in ORDER
+    # The tagless container should NOT have been written with a `type` key.
+    assert "type" not in payload["surrogate_specs"]


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to make BoFire better.

Help us to understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to BoFire here: https://github.com/experimental-desgin/bofire/blob/main/CONTRIBUTING.md
-->

## Motivation

We introduce quite often breaking changes on data models, which is problematic for updating BoFire versions in production systems (we have such an issue right now). Out of urgent need, I created a migrator setup for data models (purly coded by claude on the basis of the examples from our production system). 

My question is: do we want to maintain something like this in BoFire or not? If yes, we could register here also future breaking changes, but we need to properly review this ;) ... If we decide to not have it here, we keep it out and I just use it for our current need as a script. 

What is your opinion? @bertiqwerty @LukasHebing @TobyBoyne 


### Have you read the [Contributing Guidelines on pull requests](https://github.com/experimental-design/bofire/blob/main/CONTRIBUTING.md#pull-requests)?

Yes.

### Have you updated `CHANGELOG.md`?

Not yet.

## Test Plan

Unit tests.
