### PR TITLE
Adding fixed_paramter to ContinuousInput

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Pragmatic Versioning](https://github.com/experiment
 - Entmoot >=2.1.1
 - Static type checking was migrated from `pyright` to `ty`.
 - Refactored weighted engineered-feature surrogate mapping to share implementation across weighted sum/mean and molecular weighted sum/mean.
+- `ContinuousInput` now accepts an explicit `fixed_value` parameter to pin a continuous input to a specific value during optimization while preserving its bounds for surrogate modelling, as a more intuitive alternative to setting `lower_bound == upper_bound`.
 
 ### Fixed
 

--- a/bofire/data_models/domain/features.py
+++ b/bofire/data_models/domain/features.py
@@ -456,7 +456,7 @@ class Inputs(_BaseFeatures[AnyInput]):
         samples = pd.concat(res, axis=1)
 
         for feat in self.get_fixed():
-            val = feat.fixed_value()
+            val = feat.get_fixed_value()
             assert val is not None
             samples[feat.key] = val[0]
 

--- a/bofire/data_models/features/categorical.py
+++ b/bofire/data_models/features/categorical.py
@@ -127,7 +127,7 @@ class CategoricalInput(Input):
             return False
         return sum(self.allowed) == 1
 
-    def fixed_value(
+    def get_fixed_value(
         self,
         transform_type: Optional[TTransform] = None,
     ) -> Union[List[str], List[float], None]:

--- a/bofire/data_models/features/continuous.py
+++ b/bofire/data_models/features/continuous.py
@@ -36,6 +36,7 @@ class ContinuousInput(NumericalInput):
     ] = None
     stepsize: Optional[PositiveFloat] = None
     allow_zero: bool = False
+    fixed_value: Optional[float] = None
 
     @property
     def lower_bound(self) -> float:
@@ -113,6 +114,31 @@ class ContinuousInput(NumericalInput):
             )
 
         return self
+
+    @model_validator(mode="after")
+    def validate_fixed_value(self):
+        if self.fixed_value is None:
+            return self
+        lower, upper = self.bounds
+        if not (lower <= self.fixed_value <= upper):
+            raise ValueError(
+                f"fixed_value {self.fixed_value} must be within bounds [{lower}, {upper}].",
+            )
+        return self
+
+    def is_fixed(self) -> bool:
+        return self.fixed_value is not None or self.lower_bound == self.upper_bound
+
+    def get_fixed_value(
+        self,
+        transform_type=None,
+    ):
+        assert transform_type is None
+        if self.fixed_value is not None:
+            return [self.fixed_value]
+        if self.lower_bound == self.upper_bound:
+            return [self.lower_bound]
+        return None
 
     def _get_allowed_steps(self) -> List[float]:
         """Method to get the allowed steps of the feature.

--- a/bofire/data_models/features/descriptor.py
+++ b/bofire/data_models/features/descriptor.py
@@ -144,7 +144,7 @@ class CategoricalDescriptorInput(CategoricalInput):
         data = dict(zip(self.categories, self.values))
         return pd.DataFrame.from_dict(data, orient="index", columns=self.descriptors)
 
-    def fixed_value(
+    def get_fixed_value(
         self,
         transform_type: Optional[TTransform] = None,
     ) -> Union[List[str], List[float], None]:
@@ -155,7 +155,7 @@ class CategoricalDescriptorInput(CategoricalInput):
 
         """
         if transform_type != CategoricalEncodingEnum.DESCRIPTOR:
-            return super().fixed_value(transform_type)
+            return super().get_fixed_value(transform_type)
         val = self.get_allowed_categories()[0]
         return self.to_descriptor_encoding(pd.Series([val])).values[0].tolist()
 

--- a/bofire/data_models/features/feature.py
+++ b/bofire/data_models/features/feature.py
@@ -78,7 +78,7 @@ class Input(Feature):
         pass
 
     @abstractmethod
-    def fixed_value(
+    def get_fixed_value(
         self,
         transform_type: Optional[TTransform] = None,
     ) -> Union[None, List[str], List[float]]:

--- a/bofire/data_models/features/numerical.py
+++ b/bofire/data_models/features/numerical.py
@@ -93,7 +93,7 @@ class NumericalInput(Input):
         """
         return self.lower_bound == self.upper_bound
 
-    def fixed_value(
+    def get_fixed_value(
         self,
         transform_type: Optional[TTransform] = None,
     ) -> Union[None, List[float]]:

--- a/bofire/data_models/strategies/predictives/multi_fidelity_knowledge_gradient.py
+++ b/bofire/data_models/strategies/predictives/multi_fidelity_knowledge_gradient.py
@@ -92,7 +92,7 @@ class MultiFidelityHVKGStrategy(MoboStrategy):
         fidelity_outputs = Outputs(
             features=[ContinuousOutput(key="fidelity cost", objective=None)]
         )
-        coefficients = {key: 1.0 for key in fidelity_inputs.get_keys()}
+        coefficients = dict.fromkeys(fidelity_inputs.get_keys(), 1.0)
 
         return LinearDeterministicSurrogate(
             inputs=fidelity_inputs,

--- a/bofire/strategies/predictives/acqf_optimization.py
+++ b/bofire/strategies/predictives/acqf_optimization.py
@@ -209,8 +209,8 @@ class AcquisitionOptimizer(ABC):
 
         for _, feat in enumerate(domain.inputs.get(Input)):
             assert isinstance(feat, Input)
-            if feat.fixed_value() is not None:
-                fixed_values = feat.fixed_value(
+            if feat.get_fixed_value() is not None:
+                fixed_values = feat.get_fixed_value(
                     transform_type=input_preprocessing_specs.get(feat.key),
                 )
                 for j, idx in enumerate(features2idx[feat.key]):
@@ -245,7 +245,7 @@ class AcquisitionOptimizer(ABC):
         )
         # adding categorical features that are fixed
         for feat in domain.inputs.get_fixed():
-            fixed_val = feat.fixed_value()
+            fixed_val = feat.get_fixed_value()
             assert fixed_val is not None
             choices[feat.key] = fixed_val[0]
         # compare the choices with the training data and remove all that are also part

--- a/bofire/strategies/predictives/predictive.py
+++ b/bofire/strategies/predictives/predictive.py
@@ -121,14 +121,13 @@ class PredictiveStrategy(Strategy):
                 experiments=experiments,
             )
         )
-
         fixed_nontasks = (
             feat
             for feat in self.domain.inputs.get_fixed()
-            if not isinstance(feat, TaskInput)
+            if not isinstance(feat, TaskInput) and feat.lower_bound == feat.upper_bound
         )
         for feature in fixed_nontasks:
-            fixed_value = feature.fixed_value()
+            fixed_value = feature.get_fixed_value()
             assert fixed_value is not None
             if (cleaned_experiments[feature.key] == fixed_value[0]).all():
                 raise ValueError(

--- a/bofire/strategies/random.py
+++ b/bofire/strategies/random.py
@@ -335,7 +335,7 @@ class RandomStrategy(Strategy):
         )
         cleaned_eqs = []
         fixed_features: Dict[str, float] = {  # ty: ignore[invalid-assignment]
-            feat.key: feat.fixed_value()[0]  # ty: ignore[not-subscriptable]
+            feat.key: feat.get_fixed_value()[0]  # ty: ignore[not-subscriptable]
             for feat in domain.inputs.get(ContinuousInput)
             if feat.is_fixed()
         }
@@ -461,7 +461,7 @@ class RandomStrategy(Strategy):
             samples[key] = value
         # setup the fixed discrete/categorical ones
         for feat in domain.inputs.get([CategoricalInput, DiscreteInput]).get_fixed():
-            samples[feat.key] = feat.fixed_value()[0]
+            samples[feat.key] = feat.get_fixed_value()[0]
 
         return samples[domain.inputs.get_keys()]
 

--- a/bofire/strategies/shortest_path.py
+++ b/bofire/strategies/shortest_path.py
@@ -69,7 +69,7 @@ class ShortestPathStrategy(Strategy):
                 feat = inputs.get_by_key(key)
                 assert isinstance(feat, ContinuousInput)
                 if feat.is_fixed():
-                    fixed_val = feat.fixed_value()
+                    fixed_val = feat.get_fixed_value()
                     assert fixed_val is not None
                     b[i] -= fixed_val[0] * coef
                 else:

--- a/bofire/utils/torch_tools.py
+++ b/bofire/utils/torch_tools.py
@@ -82,7 +82,7 @@ def get_linear_constraints(
             idx = domain.inputs.get_keys(Input).index(featkey)
             feat = domain.inputs.get_by_key(featkey)
             if feat.is_fixed():
-                fixed = feat.fixed_value()
+                fixed = feat.get_fixed_value()
                 assert fixed is not None
                 rhs -= fixed[0] * c.coefficients[i]
             else:

--- a/tests/bofire/data_models/features/test_categorical.py
+++ b/tests/bofire/data_models/features/test_categorical.py
@@ -448,7 +448,7 @@ def test_categorical_input_feature_is_fixed(
     transform_type,
 ):
     assert input_feature.is_fixed() == expected
-    assert input_feature.fixed_value(transform_type) == expected_value
+    assert input_feature.get_fixed_value(transform_type) == expected_value
 
 
 @pytest.mark.parametrize(

--- a/tests/bofire/data_models/features/test_continuous.py
+++ b/tests/bofire/data_models/features/test_continuous.py
@@ -289,6 +289,7 @@ def test_continuous_input_feature_to_unit_range(feature, x, expected, real):
         (ContinuousInput(key="k", bounds=(1, 1)), True, [1]),
         (ContinuousInput(key="k", bounds=(1, 2)), False, None),
         (ContinuousInput(key="k", bounds=(2, 3)), False, None),
+        (ContinuousInput(key="k", bounds=(1, 5), fixed_value=3.0), True, [3.0]),
         (
             ContinuousDescriptorInput(
                 key="k",
@@ -323,7 +324,7 @@ def test_continuous_input_feature_to_unit_range(feature, x, expected, real):
 )
 def test_continuous_input_feature_is_fixed(input_feature, expected, expected_value):
     assert input_feature.is_fixed() == expected
-    assert input_feature.fixed_value() == expected_value
+    assert input_feature.get_fixed_value() == expected_value
 
 
 def test_continuous_input_to_pydantic_field():

--- a/tests/bofire/data_models/features/test_discrete.py
+++ b/tests/bofire/data_models/features/test_discrete.py
@@ -18,7 +18,7 @@ from bofire.data_models.features.api import DiscreteInput
 def test_discrete_input_feature_is_fixed(input_feature, expected, expected_value):
     print(input_feature)
     assert input_feature.is_fixed() == expected
-    assert input_feature.fixed_value() == expected_value
+    assert input_feature.get_fixed_value() == expected_value
 
 
 @pytest.mark.parametrize(

--- a/tests/bofire/data_models/specs/features.py
+++ b/tests/bofire/data_models/specs/features.py
@@ -258,8 +258,17 @@ specs.add_valid(
         "local_relative_bounds": None,
         "stepsize": None,
         "allow_zero": False,
+        "fixed_value": None,
         "context": None,
     },
+)
+
+
+specs.add_invalid(
+    features.ContinuousInput,
+    lambda: {"key": "a", "bounds": [1, 5], "fixed_value": 10.0},
+    error=ValueError,
+    message="fixed_value 10.0 must be within bounds",
 )
 
 specs.add_invalid(
@@ -287,6 +296,7 @@ specs.add_valid(
         "local_relative_bounds": None,
         "stepsize": None,
         "allow_zero": False,
+        "fixed_value": None,
         "context": None,
     },
 )
@@ -399,6 +409,7 @@ specs.add_valid(
         "unit": random.choice(["°C", "mg", "mmol/l", None]),
         "local_relative_bounds": None,
         "stepsize": None,
+        "fixed_value": None,
         "context": None,
     },
 )
@@ -428,6 +439,7 @@ specs.add_valid(
         "local_relative_bounds": None,
         "stepsize": None,
         "allow_zero": False,
+        "fixed_value": None,
         "context": None,
     },
 )

--- a/tests/bofire/strategies/test_fixed_value.py
+++ b/tests/bofire/strategies/test_fixed_value.py
@@ -1,0 +1,49 @@
+import numpy as np
+import pandas as pd
+import pytest
+
+import bofire.data_models.strategies.api as data_models
+from bofire.data_models.acquisition_functions.api import qLogEI
+from bofire.data_models.domain.api import Domain
+from bofire.data_models.features.api import ContinuousInput, ContinuousOutput
+from bofire.strategies.api import SoboStrategy
+
+
+def test_fixed_value_respected_in_candidate():
+    """Candidate from SoboStrategy must pin the parameter with fixed_value to that value."""
+    fixed_val = 3.0
+
+    domain = Domain.from_lists(
+        inputs=[
+            ContinuousInput(key="x1", bounds=(0.0, 5.0)),
+            ContinuousInput(key="x2", bounds=(0.0, 5.0)),
+            ContinuousInput(key="x3", bounds=(0.0, 5.0)),
+            ContinuousInput(key="x4", bounds=(1.0, 5.0), fixed_value=fixed_val),
+        ],
+        outputs=[ContinuousOutput(key="y")],
+    )
+
+    rng = np.random.default_rng(42)
+    n = 10
+    experiments = pd.DataFrame(
+        {
+            "x1": rng.uniform(0.0, 5.0, n),
+            "x2": rng.uniform(0.0, 5.0, n),
+            "x3": rng.uniform(0.0, 5.0, n),
+            "x4": rng.uniform(1.0, 5.0, n),
+            "y": rng.uniform(0.0, 10.0, n),
+            "valid_y": [1] * n,
+        }
+    )
+
+    strategy = SoboStrategy(
+        data_model=data_models.SoboStrategy(
+            domain=domain,
+            acquisition_function=qLogEI(),
+        )
+    )
+    strategy.tell(experiments)
+
+    candidates = strategy.ask(candidate_count=1)
+
+    assert candidates["x4"].iloc[0] == pytest.approx(fixed_val)


### PR DESCRIPTION
## Motivation

In this pull request, I am targeting optimization problems where we want to hold one or more continuous parameters constant during optimization while still including them as inputs to the surrogate model. Previously, the only way to achieve this in BoFire was to set `lower_bound == upper_bound`, which collapses the parameter's range to a single point. This is non-intuitive for two reasons:
(1) it destroys the meaningful range of the parameter, making it impossible to express the true experimental bounds; and 
(2) it conflates two distinct concepts — a parameter that is physically constrained to one value versus one that is deliberately fixed for a particular optimization run. 
                                                                                   
This PR introduces an explicit `fixed_value: Optional[float] = None` field on `ContinuousInput`. When set, the parameter is pinned to that value during acquisition function optimization (via BoTorch's fixed_features mechanism), while its bounds remain intact for surrogate training. Training data may contain any value within `[lower, upper]` for the parameter, allowing historical experiments — collected before the parameter was frozen — to inform the surrogate model. The existing `lower == uppe`r convention is fully preserved for backward compatibility.                                                                                                                                                                                                                 The method previously named `fixed_value()` across the input feature hierarchy has been renamed to `get_fixed_value()` to avoid a name collision with the new Pydantic field.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/experimental-design/bofire/blob/main/CONTRIBUTING.md#pull-requests)?

yes

### Have you updated `CHANGELOG.md`?

yes

## Test Plan

- added a new test to test fixed parameter,
- Modified exiting tests to accommodate for the new term.  
