### PR TITLE
Aggregate duplicates before cross validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ and this project adheres to [Pragmatic Versioning](https://github.com/experiment
 - Configurable `noise_constraint` support for GP-based surrogates (`SingleTaskGP`, `MixedSingleTaskGP`, `TanimotoGP`, `MultiTaskGP`, and `RobustSingleTaskGP`) and corresponding linear/polynomial wrappers.
 - Optional `initial_value` field on the `GreaterThan`, `LessThan`, and `Positive` prior constraint data models (already present on `Interval`), letting users opt-in to a warm-start of the constrained gpytorch parameter at construction time.
 - Generalized NChooseK constraint support in DoE: `min_count > 0` is now supported, non-zero lower bounds (`lb > 0`) are allowed for NChooseK features, overlapping NChooseK constraints (shared features) are handled via incremental pairwise merge with consistency filtering, and `nchoosek_constraints_as_bounds` generates deactivation patterns for all activity levels `k ∈ [min_count, max_count]`.
-- Aggregation of duplicated experiments in the `cross_validate` method of trainable surrogates to avoid data leakage, controlled via the `aggregate` boolean flag, default `True`.
+- Aggregation of duplicated experiments in the `cross_validate` method of trainable surrogates to avoid data leakage, controlled via the `aggregate` boolean flag, default `False`.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Pragmatic Versioning](https://github.com/experiment
 - Configurable `noise_constraint` support for GP-based surrogates (`SingleTaskGP`, `MixedSingleTaskGP`, `TanimotoGP`, `MultiTaskGP`, and `RobustSingleTaskGP`) and corresponding linear/polynomial wrappers.
 - Optional `initial_value` field on the `GreaterThan`, `LessThan`, and `Positive` prior constraint data models (already present on `Interval`), letting users opt-in to a warm-start of the constrained gpytorch parameter at construction time.
 - Generalized NChooseK constraint support in DoE: `min_count > 0` is now supported, non-zero lower bounds (`lb > 0`) are allowed for NChooseK features, overlapping NChooseK constraints (shared features) are handled via incremental pairwise merge with consistency filtering, and `nchoosek_constraints_as_bounds` generates deactivation patterns for all activity levels `k ∈ [min_count, max_count]`.
+- Aggregation of duplicated experiments in the `cross_validate` method of trainable surrogates to avoid data leakage, controlled via the `aggregate` boolean flag, default `True`.
 
 ### Changed
 

--- a/bofire/surrogates/trainable.py
+++ b/bofire/surrogates/trainable.py
@@ -183,19 +183,19 @@ class TrainableSurrogate(ABC):
                 raise ValueError(
                     f"Number of unique groups {ngroups} is less than the number of folds {folds}."
                 )
-            
+
             if aggregate:
                 warnings.warn(
                     "Aggregation is not compatible with group split, fallback to no aggregation.",
                 )
                 aggregate = False
-            
+
         if aggregate:
-            # aggregate duplicates 
+            # aggregate duplicates
             domain = Domain(inputs=self.inputs, outputs=self.outputs)
             experiments, _ = domain.aggregate_by_duplicates(
-                experiments = experiments,
-                prec = aggregate_prec,
+                experiments=experiments,
+                prec=aggregate_prec,
             )
 
         # first filter the experiments based on the model setting

--- a/bofire/surrogates/trainable.py
+++ b/bofire/surrogates/trainable.py
@@ -6,6 +6,7 @@ import numpy as np
 import pandas as pd
 from sklearn.model_selection import GroupShuffleSplit, KFold, StratifiedKFold
 
+from bofire.data_models.domain.api import Domain
 from bofire.data_models.domain.features import Inputs, Outputs
 from bofire.data_models.enum import OutputFilteringEnum
 from bofire.data_models.features.api import (
@@ -92,6 +93,8 @@ class TrainableSurrogate(ABC):
         folds: int = -1,
         include_X: bool = False,
         include_labcodes: bool = False,
+        aggregate: bool = True,
+        aggregate_prec: int = 3,
         random_state: Optional[int] = None,
         stratified_feature: Optional[str] = None,
         group_split_column: Optional[str] = None,
@@ -119,6 +122,8 @@ class TrainableSurrogate(ABC):
             folds (int, optional): Number of folds. -1 is equal to LOO CV. Defaults to -1.
             include_X (bool, optional): If true the X values of the fold are written to respective CvResult objects for
                 later analysis. Defaults to False.
+            aggregate (bool, optional): If true, duplicate experiments are aggregated before the CV split. Defaults to True. When group_split_column is provided, aggregation falls back to False.
+            aggregate_prec (int, optional): The precision for rounding up when aggregating. Defaults to 3.
             random_state (int, optional): Controls the randomness of the indices in the train and test sets of each fold.
                 Defaults to None.
             stratified_feature (str, optional): The feature name to preserve the percentage of samples for each class in
@@ -178,6 +183,20 @@ class TrainableSurrogate(ABC):
                 raise ValueError(
                     f"Number of unique groups {ngroups} is less than the number of folds {folds}."
                 )
+            
+            if aggregate:
+                warnings.warn(
+                    "Aggregation is not compatible with group split, fallback to no aggregation.",
+                )
+                aggregate = False
+            
+        if aggregate:
+            # aggregate duplicates 
+            domain = Domain(inputs=self.inputs, outputs=self.outputs)
+            experiments, _ = domain.aggregate_by_duplicates(
+                experiments = experiments,
+                prec = aggregate_prec,
+            )
 
         # first filter the experiments based on the model setting
         experiments = self._preprocess_experiments(experiments)

--- a/bofire/surrogates/trainable.py
+++ b/bofire/surrogates/trainable.py
@@ -93,7 +93,7 @@ class TrainableSurrogate(ABC):
         folds: int = -1,
         include_X: bool = False,
         include_labcodes: bool = False,
-        aggregate: bool = True,
+        aggregate: bool = False,
         aggregate_prec: int = 3,
         random_state: Optional[int] = None,
         stratified_feature: Optional[str] = None,
@@ -122,7 +122,7 @@ class TrainableSurrogate(ABC):
             folds (int, optional): Number of folds. -1 is equal to LOO CV. Defaults to -1.
             include_X (bool, optional): If true the X values of the fold are written to respective CvResult objects for
                 later analysis. Defaults to False.
-            aggregate (bool, optional): If true, duplicate experiments are aggregated before the CV split. Defaults to True. When group_split_column is provided, aggregation falls back to False.
+            aggregate (bool, optional): If true, duplicate experiments are aggregated before the CV split. Defaults to False. When group_split_column is provided, aggregation is disabled.
             aggregate_prec (int, optional): The precision for rounding up when aggregating. Defaults to 3.
             random_state (int, optional): Controls the randomness of the indices in the train and test sets of each fold.
                 Defaults to None.

--- a/tests/bofire/surrogates/test_cross_validate.py
+++ b/tests/bofire/surrogates/test_cross_validate.py
@@ -654,11 +654,13 @@ def test_model_cross_validate_aggregate():
     outputs = Outputs(features=[ContinuousOutput(key="y")])
 
     # Create experiments with duplicates
-    experiments = pd.DataFrame({
-        "x_1": [1.0, 1.0, 2.0, 2.0, 3.0],
-        "x_2": [1.0, 1.0, 2.0, 2.0, 3.0],
-        "y": [1.0, 2.0, 3.0, 4.0, 5.0],
-    })
+    experiments = pd.DataFrame(
+        {
+            "x_1": [1.0, 1.0, 2.0, 2.0, 3.0],
+            "x_2": [1.0, 1.0, 2.0, 2.0, 3.0],
+            "y": [1.0, 2.0, 3.0, 4.0, 5.0],
+        }
+    )
     experiments["valid_y"] = 1
 
     model = SingleTaskGPSurrogate(
@@ -668,7 +670,9 @@ def test_model_cross_validate_aggregate():
     model = surrogates.map(model)
 
     # With aggregate, duplicates should be merged
-    train_cv_agg, test_cv_agg, _ = model.cross_validate(experiments, folds=2, aggregate=True)
+    train_cv_agg, test_cv_agg, _ = model.cross_validate(
+        experiments, folds=2, aggregate=True
+    )
 
     # Without aggregation for comparison, default is False
     train_cv_no_agg, test_cv_no_agg, _ = model.cross_validate(experiments, folds=2)

--- a/tests/bofire/surrogates/test_cross_validate.py
+++ b/tests/bofire/surrogates/test_cross_validate.py
@@ -585,7 +585,7 @@ def test_model_cross_validate_groupfold(random_state):
             train_set = set(train_index)
             assert test_set.issuperset(indices) or train_set.issuperset(indices)
 
-    # Test if aggregation is fallback to False with group split
+    # Test if aggregate fallback to False when group split is supplied
     with pytest.warns(
         UserWarning,
         match="Aggregation is not compatible with group split, fallback to no aggregation.",

--- a/tests/bofire/surrogates/test_cross_validate.py
+++ b/tests/bofire/surrogates/test_cross_validate.py
@@ -564,7 +564,6 @@ def test_model_cross_validate_groupfold(random_state):
     train_cv, test_cv, hook_results = model.cross_validate(
         experiments,
         folds=4,
-        aggregate=False,
         random_state=random_state,
         group_split_column="group",
     )
@@ -585,7 +584,7 @@ def test_model_cross_validate_groupfold(random_state):
             train_set = set(train_index)
             assert test_set.issuperset(indices) or train_set.issuperset(indices)
 
-    # Test if aggregate fallback to False when group split is supplied
+    # Test if aggregate is disabled when group split is supplied
     with pytest.warns(
         UserWarning,
         match="Aggregation is not compatible with group split, fallback to no aggregation.",
@@ -668,11 +667,11 @@ def test_model_cross_validate_aggregate():
     )
     model = surrogates.map(model)
 
-    # With default aggregate=True, duplicates should be merged
-    train_cv_agg, test_cv_agg, _ = model.cross_validate(experiments, folds=2)
+    # With aggregate, duplicates should be merged
+    train_cv_agg, test_cv_agg, _ = model.cross_validate(experiments, folds=2, aggregate=True)
 
-    # Without aggregation for comparison
-    train_cv_no_agg, test_cv_no_agg, _ = model.cross_validate(experiments, folds=2, aggregate=False)
+    # Without aggregation for comparison, default is False
+    train_cv_no_agg, test_cv_no_agg, _ = model.cross_validate(experiments, folds=2)
 
     # With aggregation, total unique observations across all test folds should be 3
     agg_test_obs = sum(len(r.observed) for r in test_cv_agg.results)

--- a/tests/bofire/surrogates/test_cross_validate.py
+++ b/tests/bofire/surrogates/test_cross_validate.py
@@ -564,6 +564,7 @@ def test_model_cross_validate_groupfold(random_state):
     train_cv, test_cv, hook_results = model.cross_validate(
         experiments,
         folds=4,
+        aggregate=False,
         random_state=random_state,
         group_split_column="group",
     )
@@ -583,6 +584,19 @@ def test_model_cross_validate_groupfold(random_state):
             test_set = set(test_index)
             train_set = set(train_index)
             assert test_set.issuperset(indices) or train_set.issuperset(indices)
+
+    # Test if aggregation is fallback to False with group split
+    with pytest.warns(
+        UserWarning,
+        match="Aggregation is not compatible with group split, fallback to no aggregation.",
+    ):
+        train_cv, test_cv, hook_results = model.cross_validate(
+            experiments,
+            folds=4,
+            aggregate=True,
+            random_state=random_state,
+            group_split_column="group",
+        )
 
 
 def test_model_cross_validate_invalid_group_split_column():
@@ -625,6 +639,55 @@ def test_model_cross_validate_invalid_group_split_column():
         match="Number of unique groups 3 is less than the number of folds 5.",
     ):
         model.cross_validate(experiments, folds=5, group_split_column="group")
+
+
+def test_model_cross_validate_aggregate():
+    """Test that aggregation is on by default and removes duplicates."""
+    inputs = Inputs(
+        features=[
+            ContinuousInput(
+                key=f"x_{i + 1}",
+                bounds=(-4, 4),
+            )
+            for i in range(2)
+        ],
+    )
+    outputs = Outputs(features=[ContinuousOutput(key="y")])
+
+    # Create experiments with duplicates
+    experiments = pd.DataFrame({
+        "x_1": [1.0, 1.0, 2.0, 2.0, 3.0],
+        "x_2": [1.0, 1.0, 2.0, 2.0, 3.0],
+        "y": [1.0, 2.0, 3.0, 4.0, 5.0],
+    })
+    experiments["valid_y"] = 1
+
+    model = SingleTaskGPSurrogate(
+        inputs=inputs,
+        outputs=outputs,
+    )
+    model = surrogates.map(model)
+
+    # With default aggregate=True, duplicates should be merged
+    train_cv_agg, test_cv_agg, _ = model.cross_validate(experiments, folds=2)
+
+    # Without aggregation for comparison
+    train_cv_no_agg, test_cv_no_agg, _ = model.cross_validate(experiments, folds=2, aggregate=False)
+
+    # With folds=2, there should be exactly 2 results (one per fold)
+    assert len(train_cv_agg.results) == 2
+    assert len(test_cv_agg.results) == 2
+    assert len(train_cv_no_agg.results) == 2
+    assert len(test_cv_no_agg.results) == 2
+
+    # With aggregation, total unique observations across all test folds should be 3
+    # (5 rows collapsed to 3 unique input combinations)
+    agg_test_obs = sum(len(r.observed) for r in test_cv_agg.results)
+    assert agg_test_obs == 3
+
+    # Without aggregation, total unique test observations should be 5
+    noagg_test_obs = sum(len(r.observed) for r in test_cv_no_agg.results)
+    assert noagg_test_obs == 5
 
 
 def test_make_cv_split():

--- a/tests/bofire/surrogates/test_cross_validate.py
+++ b/tests/bofire/surrogates/test_cross_validate.py
@@ -674,14 +674,7 @@ def test_model_cross_validate_aggregate():
     # Without aggregation for comparison
     train_cv_no_agg, test_cv_no_agg, _ = model.cross_validate(experiments, folds=2, aggregate=False)
 
-    # With folds=2, there should be exactly 2 results (one per fold)
-    assert len(train_cv_agg.results) == 2
-    assert len(test_cv_agg.results) == 2
-    assert len(train_cv_no_agg.results) == 2
-    assert len(test_cv_no_agg.results) == 2
-
     # With aggregation, total unique observations across all test folds should be 3
-    # (5 rows collapsed to 3 unique input combinations)
     agg_test_obs = sum(len(r.observed) for r in test_cv_agg.results)
     assert agg_test_obs == 3
 


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to make BoFire better.

Help us to understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to BoFire here: https://github.com/experimental-desgin/bofire/blob/main/CONTRIBUTING.md
-->

## Motivation

The Feature Request has been specified and discussed in #657 

Currently cross validation is applied on all experiments passed to the cross_validate method, if there are duplicates in the dataset, data leakage can lead to positively distorted model metrics. 

### Have you read the [Contributing Guidelines on pull requests](https://github.com/experimental-design/bofire/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

### Have you updated `CHANGELOG.md`?

Yes

## Test Plan

### Added a test case `test_model_cross_validate_aggregate` to verify if samples are correctly aggregated:

The input contains 5 samples with two duplicated inputs.
```python
   experiments = pd.DataFrame({
        "x_1": [1.0, 1.0, 2.0, 2.0, 3.0],
        "x_2": [1.0, 1.0, 2.0, 2.0, 3.0],
        "y": [1.0, 2.0, 3.0, 4.0, 5.0],
    })
```

This test verifies if the number of samples becomes 3 after aggregation. And also tested compatibility to see if number of samples is 5 when `aggregate` is set to `False`.

### Modified a test case `test_model_cross_validate_groupfold` to add validation of aggregate is correctly switched off when group fold is supplied:

```python
    # Test if aggregate fallback to False when group split is supplied
    with pytest.warns(
        UserWarning,
        match="Aggregation is not compatible with group split, fallback to no aggregation.",
    ):
        train_cv, test_cv, hook_results = model.cross_validate(
            experiments,
            folds=4,
            aggregate=True,
            random_state=random_state,
            group_split_column="group",
        )
```



