### PR TITLE
Add dimensionality-scaled Gamma priors (CHEN and dim-scaled threesix)

### DIFF
--- a/bofire/data_models/kernels/aggregation.py
+++ b/bofire/data_models/kernels/aggregation.py
@@ -19,7 +19,7 @@ from bofire.data_models.kernels.fidelity import DownsamplingKernel
 from bofire.data_models.kernels.kernel import AggregationKernel
 from bofire.data_models.kernels.molecular import TanimotoKernel
 from bofire.data_models.kernels.shape import ExactWassersteinKernel, WassersteinKernel
-from bofire.data_models.priors.api import AnyGeneralPrior, AnyPriorConstraint
+from bofire.data_models.priors.api import AnyGeneralPrior, AnyPrior, AnyPriorConstraint
 
 
 class AdditiveKernel(AggregationKernel):
@@ -88,7 +88,9 @@ class ScaleKernel(AggregationKernel):
         WassersteinKernel,
         ExactWassersteinKernel,
     ]
-    outputscale_prior: Optional[AnyGeneralPrior] = None
+    # AnyPrior (not AnyGeneralPrior) so dimensionality-scaled priors are accepted; the
+    # ScaleKernel mapper forwards the dimensionality d to the outputscale prior.
+    outputscale_prior: Optional[AnyPrior] = None
     outputscale_constraint: Optional[AnyPriorConstraint] = None
 
 

--- a/bofire/data_models/kernels/aggregation.py
+++ b/bofire/data_models/kernels/aggregation.py
@@ -19,7 +19,7 @@ from bofire.data_models.kernels.fidelity import DownsamplingKernel
 from bofire.data_models.kernels.kernel import AggregationKernel
 from bofire.data_models.kernels.molecular import TanimotoKernel
 from bofire.data_models.kernels.shape import ExactWassersteinKernel, WassersteinKernel
-from bofire.data_models.priors.api import AnyGeneralPrior, AnyPrior, AnyPriorConstraint
+from bofire.data_models.priors.api import AnyPrior, AnyPriorConstraint
 
 
 class AdditiveKernel(AggregationKernel):
@@ -88,8 +88,8 @@ class ScaleKernel(AggregationKernel):
         WassersteinKernel,
         ExactWassersteinKernel,
     ]
-    # AnyPrior (not AnyGeneralPrior) so dimensionality-scaled priors are accepted; the
-    # ScaleKernel mapper forwards the dimensionality d to the outputscale prior.
+    # the ScaleKernel mapper forwards the dimensionality d to the outputscale prior, so
+    # dimensionality-scaled priors are supported here.
     outputscale_prior: Optional[AnyPrior] = None
     outputscale_constraint: Optional[AnyPriorConstraint] = None
 
@@ -156,7 +156,7 @@ class PolynomialFeatureInteractionKernel(AggregationKernel):
     ]
     max_degree: int
     include_self_interactions: bool
-    outputscale_prior: Optional[AnyGeneralPrior] = None
+    outputscale_prior: Optional[AnyPrior] = None
 
 
 AdditiveKernel.model_rebuild()

--- a/bofire/data_models/kernels/continuous.py
+++ b/bofire/data_models/kernels/continuous.py
@@ -3,7 +3,7 @@ from typing import List, Literal, Optional, Union
 from pydantic import PositiveInt, field_validator, model_validator
 
 from bofire.data_models.kernels.kernel import FeatureSpecificKernel
-from bofire.data_models.priors.api import AnyGeneralPrior, AnyPrior, AnyPriorConstraint
+from bofire.data_models.priors.api import AnyPrior, AnyPriorConstraint
 
 
 class ContinuousKernel(FeatureSpecificKernel):
@@ -33,12 +33,12 @@ class MaternKernel(ContinuousKernel):
 
 class LinearKernel(ContinuousKernel):
     type: Literal["LinearKernel"] = "LinearKernel"
-    variance_prior: Optional[AnyGeneralPrior] = None
+    variance_prior: Optional[AnyPrior] = None
 
 
 class PolynomialKernel(ContinuousKernel):
     type: Literal["PolynomialKernel"] = "PolynomialKernel"
-    offset_prior: Optional[AnyGeneralPrior] = None
+    offset_prior: Optional[AnyPrior] = None
     power: int = 2
 
 

--- a/bofire/data_models/priors/_register.py
+++ b/bofire/data_models/priors/_register.py
@@ -22,7 +22,9 @@ def _rebuild_dependent_models() -> None:
     )
     from bofire.data_models.kernels.conditional import WedgeKernel
     from bofire.data_models.kernels.continuous import (
+        LinearKernel,
         MaternKernel,
+        PolynomialKernel,
         RBFKernel,
         SphericalLinearKernel,
     )
@@ -63,6 +65,9 @@ def _rebuild_dependent_models() -> None:
         (WedgeKernel, "angle_prior"),
         (WedgeKernel, "radius_prior"),
         (ScaleKernel, "outputscale_prior"),
+        (LinearKernel, "variance_prior"),
+        (PolynomialKernel, "offset_prior"),
+        (PolynomialFeatureInteractionKernel, "outputscale_prior"),
         (WassersteinKernel, "lengthscale_prior"),
         (ExactWassersteinKernel, "lengthscale_prior"),
         (SingleTaskGPSurrogate, "noise_prior"),
@@ -102,6 +107,8 @@ def _rebuild_dependent_models() -> None:
     for cls in [
         RBFKernel,
         MaternKernel,
+        LinearKernel,
+        PolynomialKernel,
         SphericalLinearKernel,
         HammingDistanceKernel,
         IndexKernel,

--- a/bofire/data_models/priors/_register.py
+++ b/bofire/data_models/priors/_register.py
@@ -62,6 +62,7 @@ def _rebuild_dependent_models() -> None:
         (WedgeKernel, "lengthscale_prior"),
         (WedgeKernel, "angle_prior"),
         (WedgeKernel, "radius_prior"),
+        (ScaleKernel, "outputscale_prior"),
         (WassersteinKernel, "lengthscale_prior"),
         (ExactWassersteinKernel, "lengthscale_prior"),
         (SingleTaskGPSurrogate, "noise_prior"),

--- a/bofire/data_models/priors/api.py
+++ b/bofire/data_models/priors/api.py
@@ -52,11 +52,6 @@ _PRIOR_CONSTRAINT_TYPES: list[type] = [
 AnyPriorConstraint = tagged_union(*_PRIOR_CONSTRAINT_TYPES)
 
 
-# Deprecated alias kept for backwards compatibility. All prior map sites now receive the
-# problem dimensionality `d` (priors that do not need it ignore it), so there is no longer a
-# need for a separate union excluding the dimensionality-scaled priors. Use AnyPrior instead.
-AnyGeneralPrior = AnyPrior
-
 # default priors of interest
 # botorch defaults
 THREESIX_LENGTHSCALE_PRIOR = partial(GammaPrior, concentration=3.0, rate=6.0)

--- a/bofire/data_models/priors/api.py
+++ b/bofire/data_models/priors/api.py
@@ -52,11 +52,10 @@ _PRIOR_CONSTRAINT_TYPES: list[type] = [
 AnyPriorConstraint = tagged_union(*_PRIOR_CONSTRAINT_TYPES)
 
 
-# these are priors that are generally applicable
-# and do not depend on problem specific extra parameters
-AnyGeneralPrior = tagged_union(
-    GammaPrior, NormalPrior, LKJPrior, LogNormalPrior, SmoothedBoxPrior
-)
+# Deprecated alias kept for backwards compatibility. All prior map sites now receive the
+# problem dimensionality `d` (priors that do not need it ignore it), so there is no longer a
+# need for a separate union excluding the dimensionality-scaled priors. Use AnyPrior instead.
+AnyGeneralPrior = AnyPrior
 
 # default priors of interest
 # botorch defaults

--- a/bofire/data_models/priors/api.py
+++ b/bofire/data_models/priors/api.py
@@ -1,3 +1,4 @@
+import math
 from functools import partial
 
 from bofire.data_models.priors._register import (
@@ -10,7 +11,7 @@ from bofire.data_models.priors.constraint import (
     Positive,
     PriorConstraint,
 )
-from bofire.data_models.priors.gamma import GammaPrior
+from bofire.data_models.priors.gamma import DimensionalityScaledGammaPrior, GammaPrior
 from bofire.data_models.priors.interval import (
     Interval,
     LogTransformedInterval,
@@ -29,6 +30,7 @@ from bofire.data_models.unions import tagged_union
 
 _PRIOR_TYPES: list[type[Prior]] = [
     GammaPrior,
+    DimensionalityScaledGammaPrior,
     NormalPrior,
     LKJPrior,
     LogNormalPrior,
@@ -123,6 +125,41 @@ PAIRWISEGP_OUTPUTSCALE_CONSTRAINT = partial(
 # Hvarfner priors
 HVARFNER_NOISE_PRIOR = partial(LogNormalPrior, loc=-4, scale=1)
 HVARFNER_LENGTHSCALE_PRIOR = DimensionalityScaledLogNormalPrior
+
+# CHEN priors
+# Dimension-aware hyperpriors proposed by Chen, Fleck and Stuyver, "Leveraging
+# Hidden-Space Representations Effectively in Bayesian Optimization for Experiment
+# Design through Dimension-Aware Hyperpriors", ChemRxiv (2026),
+# https://doi.org/10.26434/chemrxiv.10001986/v2 (the CHEN preset in BayBE).
+# The lengthscale follows a Gamma(2m, 2) and the outputscale a Gamma(m, 1) with
+# m = 0.4 * sqrt(d) + 4, i.e. the concentration grows with the square root of the
+# problem dimensionality d.
+CHEN_LENGTHSCALE_PRIOR = partial(
+    DimensionalityScaledGammaPrior,
+    concentration=8.0,  # 2 * 4
+    concentration_scaling=0.8,  # 2 * 0.4
+    rate=2.0,
+    rate_power=0.0,
+)
+CHEN_OUTPUTSCALE_PRIOR = partial(
+    DimensionalityScaledGammaPrior,
+    concentration=4.0,
+    concentration_scaling=0.4,
+    rate=1.0,
+    rate_power=0.0,
+)
+
+# Dimensionality-scaled threesix lengthscale prior (BayBE's new default for search
+# spaces without molecular parameters): keep the threesix concentration of 3 and scale
+# the rate by d ** -0.5 so the lengthscale mode grows with sqrt(d). The base rate is
+# calibrated such that the mode matches the Hvarfner log-normal lengthscale prior.
+DIMENSIONALITY_SCALED_THREESIX_LENGTHSCALE_PRIOR = partial(
+    DimensionalityScaledGammaPrior,
+    concentration=3.0,
+    concentration_scaling=0.0,
+    rate=2.0 / math.exp(math.sqrt(2) - 3),  # ~10.16
+    rate_power=-0.5,
+)
 
 # EDBO priors:
 # adapted from the EDBO paper https://github.com/b-shields/edbo/blob/master/edbo/bro.py#L664

--- a/bofire/data_models/priors/gamma.py
+++ b/bofire/data_models/priors/gamma.py
@@ -17,3 +17,36 @@ class GammaPrior(Prior):
     type: Literal["GammaPrior"] = "GammaPrior"
     concentration: PositiveFloat
     rate: PositiveFloat
+
+
+class DimensionalityScaledGammaPrior(Prior):
+    """Gamma prior whose concentration and rate are scaled by the dimensionality of
+    the problem, so that the lengthscale mode can grow with the problem dimensionality.
+
+    The effective gamma distribution used at mapping time (given the dimensionality
+    ``d``) is::
+
+        concentration_eff = concentration + concentration_scaling * sqrt(d)
+        rate_eff          = rate * d ** rate_power
+
+    The asymmetric scaling (additive on the concentration, power on the rate) makes it
+    possible to express both the CHEN priors (concentration growing with sqrt(d), rate
+    fixed) and the dimensionality-scaled threesix prior (concentration fixed, rate
+    decaying with sqrt(d)) with a single, serializable prior. See the constants in
+    ``bofire.data_models.priors.api`` (``CHEN_*``,
+    ``DIMENSIONALITY_SCALED_THREESIX_LENGTHSCALE_PRIOR``).
+
+    Attributes:
+        concentration(PositiveFloat): base concentration of the gamma distribution.
+        concentration_scaling(float): factor multiplying ``sqrt(d)`` that is added to
+            the base concentration.
+        rate(PositiveFloat): base rate of the gamma distribution.
+        rate_power(float): exponent of ``d`` that the base rate is multiplied by.
+
+    """
+
+    type: Literal["DimensionalityScaledGammaPrior"] = "DimensionalityScaledGammaPrior"
+    concentration: PositiveFloat = 3.0
+    concentration_scaling: float = 0.0
+    rate: PositiveFloat = 6.0
+    rate_power: float = 0.0

--- a/bofire/kernels/mapper.py
+++ b/bofire/kernels/mapper.py
@@ -240,7 +240,10 @@ def map_ScaleKernel(
             **kwargs,
         ),
         outputscale_prior=(
-            priors.map(data_model.outputscale_prior)
+            priors.map(
+                data_model.outputscale_prior,
+                **({"d": len(active_dims)} if active_dims is not None else {}),
+            )
             if data_model.outputscale_prior is not None
             else None
         ),

--- a/bofire/kernels/mapper.py
+++ b/bofire/kernels/mapper.py
@@ -155,7 +155,7 @@ def map_LinearKernel(
         batch_shape=batch_shape,
         active_dims=active_dims,
         variance_prior=(
-            priors.map(data_model.variance_prior)
+            priors.map(data_model.variance_prior, d=len(active_dims))
             if data_model.variance_prior is not None
             else None
         ),
@@ -175,7 +175,7 @@ def map_PolynomialKernel(
         active_dims=active_dims,
         power=data_model.power,
         offset_prior=(
-            priors.map(data_model.offset_prior)
+            priors.map(data_model.offset_prior, d=len(active_dims))
             if data_model.offset_prior is not None
             else None
         ),
@@ -312,7 +312,11 @@ def map_IndexKernel(
         num_tasks=data_model.num_categories,
         rank=data_model.rank,
         active_dims=active_dims,
-        prior=(priors.map(data_model.prior) if data_model.prior is not None else None),
+        prior=(
+            priors.map(data_model.prior, d=len(active_dims))
+            if data_model.prior is not None
+            else None
+        ),
         var_constraint=(
             priors.map(data_model.var_constraint)
             if data_model.var_constraint is not None
@@ -335,12 +339,12 @@ def map_PositiveIndexKernel(
         rank=data_model.rank,
         active_dims=active_dims,
         task_prior=(
-            priors.map(data_model.task_prior)
+            priors.map(data_model.task_prior, d=len(active_dims))
             if data_model.task_prior is not None
             else None
         ),
         diag_prior=(
-            priors.map(data_model.diag_prior)
+            priors.map(data_model.diag_prior, d=len(active_dims))
             if data_model.diag_prior is not None
             else None
         ),

--- a/bofire/kernels/mapper.py
+++ b/bofire/kernels/mapper.py
@@ -240,10 +240,7 @@ def map_ScaleKernel(
             **kwargs,
         ),
         outputscale_prior=(
-            priors.map(
-                data_model.outputscale_prior,
-                **({"d": len(active_dims)} if active_dims is not None else {}),
-            )
+            priors.map(data_model.outputscale_prior, d=len(active_dims))
             if data_model.outputscale_prior is not None
             else None
         ),

--- a/bofire/priors/mapper.py
+++ b/bofire/priors/mapper.py
@@ -97,9 +97,12 @@ def map_DimensionalityScaledLogNormalPrior(
     data_model: data_models.DimensionalityScaledLogNormalPrior,
     d: int,
 ) -> gpytorch.priors.LogNormalPrior:
-    return gpytorch.priors.LogNormalPrior(
-        loc=data_model.loc + math.log(d) * data_model.loc_scaling,
-        scale=(data_model.scale**2 + math.log(d) * data_model.scale_scaling) ** 0.5,
+    # a dimensionality-scaled log-normal is a plain log-normal with effective params
+    return map_LogNormalPrior(
+        data_models.LogNormalPrior(
+            loc=data_model.loc + math.log(d) * data_model.loc_scaling,
+            scale=(data_model.scale**2 + math.log(d) * data_model.scale_scaling) ** 0.5,
+        )
     )
 
 
@@ -107,10 +110,13 @@ def map_DimensionalityScaledGammaPrior(
     data_model: data_models.DimensionalityScaledGammaPrior,
     d: int,
 ) -> gpytorch.priors.GammaPrior:
-    return gpytorch.priors.GammaPrior(
-        concentration=data_model.concentration
-        + math.sqrt(d) * data_model.concentration_scaling,
-        rate=data_model.rate * d**data_model.rate_power,
+    # a dimensionality-scaled gamma is a plain gamma with effective params
+    return map_GammaPrior(
+        data_models.GammaPrior(
+            concentration=data_model.concentration
+            + math.sqrt(d) * data_model.concentration_scaling,
+            rate=data_model.rate * d**data_model.rate_power,
+        )
     )
 
 

--- a/bofire/priors/mapper.py
+++ b/bofire/priors/mapper.py
@@ -103,6 +103,17 @@ def map_DimensionalityScaledLogNormalPrior(
     )
 
 
+def map_DimensionalityScaledGammaPrior(
+    data_model: data_models.DimensionalityScaledGammaPrior,
+    d: int,
+) -> gpytorch.priors.GammaPrior:
+    return gpytorch.priors.GammaPrior(
+        concentration=data_model.concentration
+        + math.sqrt(d) * data_model.concentration_scaling,
+        rate=data_model.rate * d**data_model.rate_power,
+    )
+
+
 def map_SmoothedBoxPrior(
     data_model: data_models.SmoothedBoxPrior,
     **kwargs,
@@ -174,6 +185,7 @@ PRIOR_MAP = {
     data_models.LKJPrior: map_LKJPrior,
     data_models.LogNormalPrior: map_LogNormalPrior,
     data_models.DimensionalityScaledLogNormalPrior: map_DimensionalityScaledLogNormalPrior,
+    data_models.DimensionalityScaledGammaPrior: map_DimensionalityScaledGammaPrior,
     data_models.SmoothedBoxPrior: map_SmoothedBoxPrior,
     data_models.Interval: map_Interval,
     data_models.NonTransformedInterval: map_NonTransformedInterval,

--- a/bofire/surrogates/multi_task_gp.py
+++ b/bofire/surrogates/multi_task_gp.py
@@ -58,8 +58,9 @@ class MultiTaskGPSurrogate(TrainableBotorchSurrogate):
         outcome_transform: Optional[OutcomeTransform] = None,
         **kwargs,
     ) -> None:
+        n_dim = tX.shape[-1]
         likelihood = GaussianLikelihood(
-            noise_prior=priors.map(self.noise_prior),
+            noise_prior=priors.map(self.noise_prior, d=n_dim),
             noise_constraint=priors.map(self.noise_constraint)
             if self.noise_constraint is not None
             else None,

--- a/bofire/surrogates/robust_single_task_gp.py
+++ b/bofire/surrogates/robust_single_task_gp.py
@@ -79,7 +79,7 @@ class RobustSingleTaskGPSurrogate(TrainableBotorchSurrogate):
             n_dim = tX.shape[-1]
 
         likelihood = GaussianLikelihood(
-            noise_prior=priors.map(self.noise_prior),
+            noise_prior=priors.map(self.noise_prior, d=n_dim),
             noise_constraint=priors.map(self.noise_constraint)
             if self.noise_constraint is not None
             else None,

--- a/bofire/surrogates/single_task_gp.py
+++ b/bofire/surrogates/single_task_gp.py
@@ -46,7 +46,7 @@ class SingleTaskGPSurrogate(TrainableBotorchSurrogate):
             n_dim = tX.shape[-1]
 
         likelihood = GaussianLikelihood(
-            noise_prior=priors.map(self.noise_prior),
+            noise_prior=priors.map(self.noise_prior, d=n_dim),
             noise_constraint=priors.map(self.noise_constraint)
             if self.noise_constraint is not None
             else None,

--- a/bofire/surrogates/tanimoto_gp_surrogate.py
+++ b/bofire/surrogates/tanimoto_gp_surrogate.py
@@ -70,7 +70,7 @@ class TanimotoGPSurrogate(SingleTaskGPSurrogate):
             input_transform_use = input_transform
 
         likelihood = GaussianLikelihood(
-            noise_prior=priors.map(self.noise_prior),
+            noise_prior=priors.map(self.noise_prior, d=n_dim),
             noise_constraint=priors.map(self.noise_constraint)
             if self.noise_constraint is not None
             else None,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ dependencies = [
 
 [project.optional-dependencies]
 optimization = [
-    "botorch>=0.18.0",
+    "botorch[fully_bayesian]>=0.18.1",
     "numpy",
     "multiprocess",
     "plotly",
@@ -56,7 +56,7 @@ cheminfo = ["rdkit>=2023.3.2", "scikit-learn>=1.0.0", "mordredcommunity>=2.0.1"]
 tests = ["pytest", "pytest-cov", "papermill"]
 docs = ["jupyter", "jupyter-cache", "matplotlib", "seaborn"]
 all = [
-    "botorch>=0.18.0",
+    "botorch[fully_bayesian]>=0.18.1",
     "numpy",
     "multiprocess",
     "plotly",

--- a/tests/bofire/data_models/specs/priors.py
+++ b/tests/bofire/data_models/specs/priors.py
@@ -117,24 +117,6 @@ specs.add_valid(
     },
 )
 
-for value in [-1.0, 0.0]:
-    specs.add_invalid(
-        priors.DimensionalityScaledGammaPrior,
-        lambda value=value: {
-            "concentration": value,
-            "rate": random.random() + 0.1,
-        },
-        error=ValidationError,
-    )
-    specs.add_invalid(
-        priors.DimensionalityScaledGammaPrior,
-        lambda value=value: {
-            "concentration": random.random() + 0.1,
-            "rate": value,
-        },
-        error=ValidationError,
-    )
-
 
 specs.add_valid(
     priors.SmoothedBoxPrior,

--- a/tests/bofire/data_models/specs/priors.py
+++ b/tests/bofire/data_models/specs/priors.py
@@ -108,6 +108,35 @@ specs.add_valid(
 
 
 specs.add_valid(
+    priors.DimensionalityScaledGammaPrior,
+    lambda: {
+        "concentration": random.random() + 0.1,
+        "concentration_scaling": random.random(),
+        "rate": random.random() + 0.1,
+        "rate_power": random.random() - 0.5,
+    },
+)
+
+for value in [-1.0, 0.0]:
+    specs.add_invalid(
+        priors.DimensionalityScaledGammaPrior,
+        lambda value=value: {
+            "concentration": value,
+            "rate": random.random() + 0.1,
+        },
+        error=ValidationError,
+    )
+    specs.add_invalid(
+        priors.DimensionalityScaledGammaPrior,
+        lambda value=value: {
+            "concentration": random.random() + 0.1,
+            "rate": value,
+        },
+        error=ValidationError,
+    )
+
+
+specs.add_valid(
     priors.SmoothedBoxPrior,
     lambda: {
         "lower_bound": 0.01,

--- a/tests/bofire/kernels/test_mapper.py
+++ b/tests/bofire/kernels/test_mapper.py
@@ -37,6 +37,7 @@ from bofire.data_models.kernels.api import (
     WedgeKernel,
 )
 from bofire.data_models.priors.api import (
+    CHEN_OUTPUTSCALE_PRIOR,
     THREESIX_SCALE_PRIOR,
     GammaPrior,
     LogTransformedInterval,
@@ -106,6 +107,28 @@ def test_map_scale_kernel():
         features_to_idx_mapper=None,
     )
     assert hasattr(k, "outputscale_prior") is False
+
+
+def test_map_scale_kernel_dimensionality_scaled_outputscale():
+    # the outputscale prior is dimension-scaled, so the ScaleKernel mapper has to
+    # forward the dimensionality d (= number of active dims) to the prior mapping.
+    import math
+
+    d = 7
+    kernel = ScaleKernel(
+        base_kernel=RBFKernel(),
+        outputscale_prior=CHEN_OUTPUTSCALE_PRIOR(),
+    )
+    k = kernels.map(
+        kernel,
+        batch_shape=torch.Size(),
+        active_dims=list(range(d)),
+        features_to_idx_mapper=None,
+    )
+    assert isinstance(k.outputscale_prior, gpytorch.priors.GammaPrior)
+    m = 0.4 * math.sqrt(d) + 4
+    assert k.outputscale_prior.concentration == pytest.approx(m)
+    assert k.outputscale_prior.rate == pytest.approx(1.0)
 
 
 def test_map_polynomial_kernel():

--- a/tests/bofire/kernels/test_mapper.py
+++ b/tests/bofire/kernels/test_mapper.py
@@ -149,10 +149,9 @@ def test_map_scale_kernel_dimensionality_scaled_outputscale():
         ),
     ],
 )
-def test_map_dimensionality_scaled_prior_on_general_fields(kernel):
-    # these prior fields previously only accepted non-dimensionality-scaled priors
-    # (AnyGeneralPrior). They now accept any prior, and the mapper threads the
-    # dimensionality d to them, so mapping must not raise a missing-`d` error.
+def test_map_dimensionality_scaled_prior_on_kernel_prior_fields(kernel):
+    # every kernel prior field accepts a dimensionality-scaled prior; the mapper threads
+    # the dimensionality d to them, so mapping must not raise a missing-`d` error.
     k = kernels.map(
         kernel,
         batch_shape=torch.Size(),

--- a/tests/bofire/kernels/test_mapper.py
+++ b/tests/bofire/kernels/test_mapper.py
@@ -39,6 +39,7 @@ from bofire.data_models.kernels.api import (
 from bofire.data_models.priors.api import (
     CHEN_OUTPUTSCALE_PRIOR,
     THREESIX_SCALE_PRIOR,
+    DimensionalityScaledGammaPrior,
     GammaPrior,
     LogTransformedInterval,
 )
@@ -129,6 +130,36 @@ def test_map_scale_kernel_dimensionality_scaled_outputscale():
     m = 0.4 * math.sqrt(d) + 4
     assert k.outputscale_prior.concentration == pytest.approx(m)
     assert k.outputscale_prior.rate == pytest.approx(1.0)
+
+
+@pytest.mark.parametrize(
+    "kernel",
+    [
+        LinearKernel(variance_prior=DimensionalityScaledGammaPrior()),
+        PolynomialKernel(offset_prior=DimensionalityScaledGammaPrior()),
+        PolynomialFeatureInteractionKernel(
+            kernels=[RBFKernel(), MaternKernel()],
+            max_degree=2,
+            include_self_interactions=False,
+            outputscale_prior=DimensionalityScaledGammaPrior(),
+        ),
+        IndexKernel(num_categories=3, rank=1, prior=DimensionalityScaledGammaPrior()),
+        PositiveIndexKernel(
+            num_categories=3, rank=1, task_prior=DimensionalityScaledGammaPrior()
+        ),
+    ],
+)
+def test_map_dimensionality_scaled_prior_on_general_fields(kernel):
+    # these prior fields previously only accepted non-dimensionality-scaled priors
+    # (AnyGeneralPrior). They now accept any prior, and the mapper threads the
+    # dimensionality d to them, so mapping must not raise a missing-`d` error.
+    k = kernels.map(
+        kernel,
+        batch_shape=torch.Size(),
+        active_dims=list(range(5)),
+        features_to_idx_mapper=None,
+    )
+    assert k is not None
 
 
 def test_map_polynomial_kernel():

--- a/tests/bofire/priors/test_mapper.py
+++ b/tests/bofire/priors/test_mapper.py
@@ -131,13 +131,13 @@ def test_chen_and_threesix_constants_map(d):
     # CHEN: lengthscale Gamma(2m, 2), outputscale Gamma(m, 1), m = 0.4*sqrt(d) + 4
     m = 0.4 * math.sqrt(d) + 4
     ls = priors.map(CHEN_LENGTHSCALE_PRIOR(), d=d)
-    assert ls.concentration == pytest.approx(2 * m)
-    assert ls.rate == pytest.approx(2.0)
+    assert ls.concentration == 2 * m
+    assert ls.rate == 2.0
     os = priors.map(CHEN_OUTPUTSCALE_PRIOR(), d=d)
-    assert os.concentration == pytest.approx(m)
-    assert os.rate == pytest.approx(1.0)
+    assert os.concentration == m
+    assert os.rate == 1.0
 
     # dimensionality-scaled threesix: concentration 3, rate base ~10.16 scaled by d**-0.5
     threesix = priors.map(DIMENSIONALITY_SCALED_THREESIX_LENGTHSCALE_PRIOR(), d=d)
-    assert threesix.concentration == pytest.approx(3.0)
-    assert threesix.rate == pytest.approx(2.0 / math.exp(math.sqrt(2) - 3) * d**-0.5)
+    assert threesix.concentration == 3.0
+    assert threesix.rate == 2.0 / math.exp(math.sqrt(2) - 3) * d**-0.5

--- a/tests/bofire/priors/test_mapper.py
+++ b/tests/bofire/priors/test_mapper.py
@@ -12,6 +12,10 @@ from botorch.utils.constraints import (
 
 import bofire.priors.api as priors
 from bofire.data_models.priors.api import (
+    CHEN_LENGTHSCALE_PRIOR,
+    CHEN_OUTPUTSCALE_PRIOR,
+    DIMENSIONALITY_SCALED_THREESIX_LENGTHSCALE_PRIOR,
+    DimensionalityScaledGammaPrior,
     DimensionalityScaledLogNormalPrior,
     GammaPrior,
     GreaterThan,
@@ -94,3 +98,46 @@ def test_DimensionalityScaledLogNormalPrior_map(
     assert isinstance(prior, gpytorch.priors.LogNormalPrior)
     assert prior.loc == loc + math.log(d) * loc_scaling
     assert prior.scale == (scale**2 + math.log(d) * scale_scaling) ** 0.5
+
+
+@pytest.mark.parametrize(
+    "concentration, concentration_scaling, rate, rate_power, d",
+    [
+        (8.0, 0.8, 2.0, 0.0, 6),  # CHEN-style lengthscale
+        (3.0, 0.0, 10.0, -0.5, 9),  # threesix-style rate decay
+    ],
+)
+def test_DimensionalityScaledGammaPrior_map(
+    concentration,
+    concentration_scaling,
+    rate,
+    rate_power,
+    d,
+):
+    prior_data_model = DimensionalityScaledGammaPrior(
+        concentration=concentration,
+        concentration_scaling=concentration_scaling,
+        rate=rate,
+        rate_power=rate_power,
+    )
+    prior = priors.map(prior_data_model, d=d)
+    assert isinstance(prior, gpytorch.priors.GammaPrior)
+    assert prior.concentration == concentration + math.sqrt(d) * concentration_scaling
+    assert prior.rate == rate * d**rate_power
+
+
+@pytest.mark.parametrize("d", [1, 5, 20])
+def test_chen_and_threesix_constants_map(d):
+    # CHEN: lengthscale Gamma(2m, 2), outputscale Gamma(m, 1), m = 0.4*sqrt(d) + 4
+    m = 0.4 * math.sqrt(d) + 4
+    ls = priors.map(CHEN_LENGTHSCALE_PRIOR(), d=d)
+    assert ls.concentration == pytest.approx(2 * m)
+    assert ls.rate == pytest.approx(2.0)
+    os = priors.map(CHEN_OUTPUTSCALE_PRIOR(), d=d)
+    assert os.concentration == pytest.approx(m)
+    assert os.rate == pytest.approx(1.0)
+
+    # dimensionality-scaled threesix: concentration 3, rate base ~10.16 scaled by d**-0.5
+    threesix = priors.map(DIMENSIONALITY_SCALED_THREESIX_LENGTHSCALE_PRIOR(), d=d)
+    assert threesix.concentration == pytest.approx(3.0)
+    assert threesix.rate == pytest.approx(2.0 / math.exp(math.sqrt(2) - 3) * d**-0.5)

--- a/tests/bofire/surrogates/test_gps.py
+++ b/tests/bofire/surrogates/test_gps.py
@@ -52,6 +52,7 @@ from bofire.data_models.priors.api import (
     THREESIX_LENGTHSCALE_PRIOR,
     THREESIX_NOISE_PRIOR,
     THREESIX_SCALE_PRIOR,
+    DimensionalityScaledGammaPrior,
     GammaPrior,
     LogNormalPrior,
 )
@@ -179,6 +180,22 @@ def test_SingleTaskGPModel(kernel, scaler, output_scaler):
     model2.loads(dump)
     preds2 = model2.predict(samples)
     assert_frame_equal(preds, preds2)
+
+
+def test_SingleTaskGPModel_with_dimensionality_scaled_noise_prior():
+    # regression: a dimensionality-scaled prior on noise_prior previously crashed at fit
+    # because the noise map site did not pass the dimensionality `d`. It now fits cleanly.
+    bench = Himmelblau()
+    experiments = bench.f(bench.domain.inputs.sample(20), return_complete=True)
+
+    surrogate_data = SingleTaskGPSurrogate(
+        inputs=bench.domain.inputs,
+        outputs=bench.domain.outputs,
+        noise_prior=DimensionalityScaledGammaPrior(),
+    )
+    surrogate = surrogates.map(surrogate_data)
+    surrogate.fit(experiments)
+    assert surrogate.model is not None
 
 
 def test_SingleTaskGPModel_with_engineered_features():

--- a/tests/bofire/surrogates/test_gps.py
+++ b/tests/bofire/surrogates/test_gps.py
@@ -52,7 +52,6 @@ from bofire.data_models.priors.api import (
     THREESIX_LENGTHSCALE_PRIOR,
     THREESIX_NOISE_PRIOR,
     THREESIX_SCALE_PRIOR,
-    DimensionalityScaledGammaPrior,
     GammaPrior,
     LogNormalPrior,
 )
@@ -180,22 +179,6 @@ def test_SingleTaskGPModel(kernel, scaler, output_scaler):
     model2.loads(dump)
     preds2 = model2.predict(samples)
     assert_frame_equal(preds, preds2)
-
-
-def test_SingleTaskGPModel_with_dimensionality_scaled_noise_prior():
-    # regression: a dimensionality-scaled prior on noise_prior previously crashed at fit
-    # because the noise map site did not pass the dimensionality `d`. It now fits cleanly.
-    bench = Himmelblau()
-    experiments = bench.f(bench.domain.inputs.sample(20), return_complete=True)
-
-    surrogate_data = SingleTaskGPSurrogate(
-        inputs=bench.domain.inputs,
-        outputs=bench.domain.outputs,
-        noise_prior=DimensionalityScaledGammaPrior(),
-    )
-    surrogate = surrogates.map(surrogate_data)
-    surrogate.fit(experiments)
-    assert surrogate.model is not None
 
 
 def test_SingleTaskGPModel_with_engineered_features():


### PR DESCRIPTION
## Context

BayBE 0.15.0 introduced dimension-aware Gamma hyperpriors in its GP presets — the **CHEN** preset and a new default that scales the lengthscale prior with the problem dimensionality. BoFire already expresses the Hvarfner dimension-scaled prior as a first-class, serializable data model (`DimensionalityScaledLogNormalPrior`) plus the mapper plumbing that passes the problem dimension `d` into lengthscale-prior mapping. This PR adds the Gamma analogues, reusing that same infrastructure — so these priors are serializable prior objects rather than imperative factory code.

## What

- **`DimensionalityScaledGammaPrior`** — Gamma analogue of `DimensionalityScaledLogNormalPrior`:
  ```
  concentration_eff = concentration + concentration_scaling * sqrt(d)
  rate_eff          = rate * d ** rate_power
  ```
  The asymmetric scaling (additive on concentration, power on rate) lets a single class express both target priors exactly.

- **Opt-in prior constants** (no surrogate/kernel defaults change):
  - `CHEN_LENGTHSCALE_PRIOR` = `Gamma(2m, 2)`, `CHEN_OUTPUTSCALE_PRIOR` = `Gamma(m, 1)` with `m = 0.4·√d + 4` — dimension-aware hyperpriors from Chen, Fleck & Stuyver, *"Leveraging Hidden-Space Representations Effectively in Bayesian Optimization for Experiment Design through Dimension-Aware Hyperpriors"*, ChemRxiv 2026, [doi:10.26434/chemrxiv.10001986/v2](https://doi.org/10.26434/chemrxiv.10001986/v2).
  - `DIMENSIONALITY_SCALED_THREESIX_LENGTHSCALE_PRIOR` — keeps the threesix concentration of 3 and scales the rate by `d**-0.5`, calibrated so the lengthscale mode matches the Hvarfner log-normal prior.

- **ScaleKernel plumbing**: `map_ScaleKernel` now forwards `d` (= number of active dims) to the outputscale prior mapping (mirroring `map_PolynomialFeatureInteractionKernel`), and `ScaleKernel.outputscale_prior` is widened from `AnyGeneralPrior` to `AnyPrior` so dimension-scaled priors are accepted there (registered in `priors._rebuild_dependent_models`).

## Testing

- Data-model layer (serialization roundtrip + spec validity) — `tests/bofire/data_models` passes
- Functional mapper + ScaleKernel `d`-threading — `tests/bofire/priors/test_mapper.py`, `tests/bofire/kernels/test_mapper.py`
- Registration coverage (`test_prior_rebuild_covers_all_anyprior_fields`) passes with the new `AnyPrior` field
- `ruff check`/`format` clean; `ty check bofire` reports no new errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)