### PR TITLE
LLMStrategy capabilities (serializable + registerable) + pydantic-ai v2

### DIFF
--- a/bofire/data_models/api.py
+++ b/bofire/data_models/api.py
@@ -22,7 +22,12 @@ from bofire.data_models.features.api import (
     Output,
 )
 from bofire.data_models.kernels.api import AnyKernel, Kernel
-from bofire.data_models.llm.api import AnyLLMProvider, LLMProvider
+from bofire.data_models.llm.api import (
+    AnyLLMCapability,
+    AnyLLMProvider,
+    LLMCapability,
+    LLMProvider,
+)
 from bofire.data_models.molfeatures.api import AnyMolFeatures, MolFeatures
 from bofire.data_models.objectives.api import AnyObjective, Objective
 from bofire.data_models.outlier_detection.api import (

--- a/bofire/data_models/llm/_register.py
+++ b/bofire/data_models/llm/_register.py
@@ -28,3 +28,32 @@ def register_llm_provider(data_model_cls: type) -> None:
 
     patch_field(LLMStrategy, "llm", llm_api.AnyLLMProvider)
     LLMStrategy.model_rebuild(force=True)
+
+
+def register_llm_capability(data_model_cls: type) -> None:
+    """Register a custom LLM capability so it is accepted in capability fields.
+
+    Rebuilds the ``AnyLLMCapability`` union with the new type appended, and
+    patches the ``LLMStrategy.capabilities`` list field so the new type is
+    accepted by Pydantic.
+
+    Users must separately register a mapper function via
+    ``bofire.llm.capabilities_mapper.register`` so that the data model can be
+    turned into a pydantic-ai capability at runtime.
+
+    Args:
+        data_model_cls: A concrete subclass of ``LLMCapability``.
+    """
+    import bofire.data_models.llm.api as llm_api
+    from bofire.data_models._register_utils import patch_field
+    from bofire.data_models.strategies.llm import LLMStrategy
+
+    existing_types, _ = extract_union_args(llm_api.AnyLLMCapability)
+    if data_model_cls in existing_types:
+        return
+    llm_api.AnyLLMCapability = tagged_union(*existing_types, data_model_cls)
+
+    # ``capabilities`` is a list field; patch_field detects the list origin and
+    # rewraps the union as ``Sequence[AnyLLMCapability]``.
+    patch_field(LLMStrategy, "capabilities", llm_api.AnyLLMCapability)
+    LLMStrategy.model_rebuild(force=True)

--- a/bofire/data_models/llm/api.py
+++ b/bofire/data_models/llm/api.py
@@ -1,4 +1,11 @@
-from bofire.data_models.llm._register import register_llm_provider  # noqa: F401
+from bofire.data_models.llm._register import (  # noqa: F401
+    register_llm_capability,
+    register_llm_provider,
+)
+from bofire.data_models.llm.capability import (
+    ExperimentAccessCapability,
+    LLMCapability,  # noqa: F401
+)
 from bofire.data_models.llm.provider import (
     AnthropicFoundryLLMProvider,
     AnthropicLLMProvider,
@@ -14,4 +21,8 @@ AnyLLMProvider = tagged_union(
     AnthropicFoundryLLMProvider,
     OpenAILLMProvider,
     OpenAICompatibleLLMProvider,
+)
+
+AnyLLMCapability = tagged_union(
+    ExperimentAccessCapability,
 )

--- a/bofire/data_models/llm/capability.py
+++ b/bofire/data_models/llm/capability.py
@@ -1,0 +1,55 @@
+from typing import Any, Literal
+
+from pydantic import Field
+
+from bofire.data_models.base import BaseModel
+
+
+class LLMCapability(BaseModel):
+    """Base class for all LLM capability configurations.
+
+    A capability is a serializable, composable unit that extends what an LLM
+    recommender (e.g. ``LLMStrategy``) can do. It bundles — depending on the
+    concrete type — instructions, tools, model settings, and lifecycle hooks
+    into a single object that is attached to the underlying agent.
+
+    Like LLM providers, capabilities are pure configuration: the data model
+    serializes the ``type`` discriminator plus typed config fields, while the
+    functional mapper (``bofire.llm.capabilities_mapper``) reconstructs the
+    live pydantic-ai capability — including any tool functions — at runtime.
+    A capability's tools are therefore never serialized; they are rebuilt by
+    the registered mapper keyed on ``type``.
+
+    Attributes:
+        type: Discriminator for the concrete capability type.
+    """
+
+    type: Any
+
+
+class ExperimentAccessCapability(LLMCapability):
+    """Exposes prior experiments and pending candidates to the LLM via tools.
+
+    Instead of rendering experiments into the prompt as a fixed view, this
+    capability gives the agent tool calls to inspect the experiment table on
+    demand (recent rows, top rows by objective, nearest neighbours, summary
+    statistics) and to list pending candidates. The capability's instructions
+    surface only the *counts* of experiments and pending candidates, which
+    motivates the model to call the tools rather than imposing a predefined
+    view.
+
+    Enabled by default on ``LLMStrategy``. Note that supplying an explicit
+    ``capabilities`` list to the strategy replaces this default, so re-add it
+    if you also pass other capabilities.
+
+    Attributes:
+        max_rows_per_tool_call: Upper bound on the number of experiment rows a
+            single tool call may return, to keep tool outputs bounded.
+    """
+
+    type: Literal["ExperimentAccessCapability"] = "ExperimentAccessCapability"
+    max_rows_per_tool_call: int = Field(
+        default=50,
+        gt=0,
+        description="Maximum number of experiment rows returned per tool call.",
+    )

--- a/bofire/data_models/strategies/llm.py
+++ b/bofire/data_models/strategies/llm.py
@@ -1,4 +1,4 @@
-from typing import Annotated, Any, Dict, Literal, Optional, Type
+from typing import Any, Dict, List, Literal, Optional, Type
 
 from pydantic import Field, PositiveInt, model_validator
 
@@ -9,7 +9,11 @@ from bofire.data_models.constraints.api import (
     NChooseKConstraint,
 )
 from bofire.data_models.features.api import Feature
-from bofire.data_models.llm.api import AnyLLMProvider
+from bofire.data_models.llm.api import (
+    AnyLLMCapability,
+    AnyLLMProvider,
+    ExperimentAccessCapability,
+)
 from bofire.data_models.objectives.api import MaximizeObjective, MinimizeObjective
 from bofire.data_models.strategies.strategy import Strategy
 
@@ -32,10 +36,11 @@ class LLMStrategy(Strategy):
 
     On each ``ask()``, a pydantic output schema is generated from the
     domain's input features and the LLM is prompted with a textual problem
-    description plus, optionally, a selection of prior experiments. Returned
-    candidates are validated against the domain; bound or constraint
-    violations are sent back to the LLM as retry messages via pydantic-ai's
-    ``output_retries``.
+    description. Prior experiments and pending candidates are exposed to the
+    LLM through capabilities (by default the ``ExperimentAccessCapability``,
+    which provides tools to inspect them on demand) rather than being rendered
+    into the prompt. Returned candidates are validated against the domain;
+    bound or constraint violations are sent back to the LLM as retry messages.
 
     Currently supports single-objective optimization with ``MaximizeObjective``
     or ``MinimizeObjective``, and ``LinearEquality``, ``LinearInequality``,
@@ -76,12 +81,12 @@ class LLMStrategy(Strategy):
         output_retries: Number of retries when output validation fails
             (constraint or bound violations). Each retry sends the LLM the
             invalid candidates and the error so it can correct.
-        n_recent_experiments: If set, only the most recent N experiments
-            are shown to the LLM. Keeps prompt size bounded on long
-            campaigns.
-        n_top_experiments: If set, the top N experiments by objective
-            value are shown to the LLM. Combine with
-            ``n_recent_experiments`` to mix recency and quality.
+        capabilities: Capabilities attached to the underlying agent. Defaults
+            to a single ``ExperimentAccessCapability`` that exposes prior
+            experiments and pending candidates via tools. Supplying an explicit
+            list replaces this default, so re-add ``ExperimentAccessCapability``
+            if you want experiment access alongside other capabilities. Pass an
+            empty list to disable all capabilities.
         system_prompt: Optional override for the default system prompt.
     """
 
@@ -90,8 +95,9 @@ class LLMStrategy(Strategy):
     llm: AnyLLMProvider
     model_settings: Optional[Dict[str, Any]] = None
     output_retries: PositiveInt = 3
-    n_recent_experiments: Optional[Annotated[int, Field(gt=0)]] = None
-    n_top_experiments: Optional[Annotated[int, Field(gt=0)]] = None
+    capabilities: List[AnyLLMCapability] = Field(
+        default_factory=lambda: [ExperimentAccessCapability()]
+    )
     system_prompt: Optional[str] = None
 
     @model_validator(mode="after")

--- a/bofire/llm/api.py
+++ b/bofire/llm/api.py
@@ -1,6 +1,9 @@
-"""Public API for mapping LLM provider data models to pydantic-ai Models."""
+"""Public API for mapping LLM data models to pydantic-ai objects."""
 
+from bofire.llm.capabilities_mapper import map as map_capability
+from bofire.llm.capabilities_mapper import register as register_capability
 from bofire.llm.mapper import map
+from bofire.llm.mapper import register as register_provider
 
 
-__all__ = ["map"]
+__all__ = ["map", "map_capability", "register_provider", "register_capability"]

--- a/bofire/llm/capabilities_mapper.py
+++ b/bofire/llm/capabilities_mapper.py
@@ -1,0 +1,86 @@
+"""Map LLM capability data models to pydantic-ai capability objects.
+
+Each capability data model (e.g. ``ExperimentAccessCapability``) is mapped to a
+pydantic-ai ``AbstractCapability`` via a registered factory function. The data
+model carries only serializable config; the factory reconstructs the live
+capability — including its tool functions — at mapping time.
+"""
+
+from typing import Callable, Optional, Type
+
+import bofire.data_models.llm.api as data_models
+from bofire.data_models.llm.capability import ExperimentAccessCapability, LLMCapability
+
+
+CAPABILITY_MAP: dict[Type[LLMCapability], Callable] = {}
+
+
+def register(
+    data_model_cls: Type[LLMCapability],
+    map_fn: Optional[Callable] = None,
+):
+    """Register a custom capability mapping from data model to factory function.
+
+    Can be used as a decorator or as a direct function call::
+
+        # Decorator form
+        @register(MyCapability)
+        def map_my_capability(data_model):
+            return MyPydanticAICapability(...)
+
+        # Direct call form
+        register(MyCapability, map_my_capability)
+
+    Args:
+        data_model_cls: The Pydantic data model class.
+        map_fn: A callable that takes the data model instance and returns a
+            pydantic-ai capability. If not provided, returns a decorator.
+
+    Returns:
+        The mapping function (unchanged) when used as a decorator, None otherwise.
+    """
+
+    def _register(fn: Callable) -> Callable:
+        CAPABILITY_MAP[data_model_cls] = fn
+
+        # Also register with the data model union so Pydantic accepts the type.
+        data_models.register_llm_capability(data_model_cls)
+
+        return fn
+
+    if map_fn is not None:
+        _register(map_fn)
+        return None
+
+    return _register
+
+
+@register(ExperimentAccessCapability)
+def map_experiment_access(data_model: ExperimentAccessCapability):
+    from pydantic_ai.capabilities import Toolset
+
+    from bofire.llm.experiment_tools import build_experiment_toolset
+
+    return Toolset(build_experiment_toolset(data_model.max_rows_per_tool_call))
+
+
+def map(data_model: LLMCapability):
+    """Map an LLM capability data model to a pydantic-ai capability instance.
+
+    Args:
+        data_model: An LLM capability data model instance.
+
+    Returns:
+        A pydantic-ai ``AbstractCapability`` ready to attach to an Agent.
+
+    Raises:
+        ValueError: If the capability type is not supported.
+    """
+    mapper_fn = CAPABILITY_MAP.get(type(data_model))
+    if mapper_fn is None:
+        supported = ", ".join(c.__name__ for c in CAPABILITY_MAP)
+        raise ValueError(
+            f"Unsupported LLM capability type: {type(data_model).__name__}. "
+            f"Supported: {supported}"
+        )
+    return mapper_fn(data_model)

--- a/bofire/llm/context.py
+++ b/bofire/llm/context.py
@@ -1,0 +1,23 @@
+"""Runtime context passed to the LLM agent and its capability tools.
+
+This is the dependency object (pydantic-ai ``deps``) injected into every
+agent run. It carries only the strategy's intrinsic state — the domain, the
+completed experiments, and the pending candidates — which capability tools
+read via ``RunContext[LLMContext]``. Anything a specific capability needs that
+is not intrinsic strategy state (e.g. a surrogate, a vector store) is carried
+by that capability's own configuration, not here.
+"""
+
+from dataclasses import dataclass
+from typing import Optional
+
+import pandas as pd
+
+from bofire.data_models.domain.api import Domain
+
+
+@dataclass
+class LLMContext:
+    domain: Domain
+    experiments: Optional[pd.DataFrame]
+    candidates: Optional[pd.DataFrame]

--- a/bofire/llm/experiment_tools.py
+++ b/bofire/llm/experiment_tools.py
@@ -1,0 +1,176 @@
+"""Experiment-inspection tools exposed to the LLM via a capability.
+
+These build a pydantic-ai ``FunctionToolset`` that lets the agent query the
+strategy's experiment table on demand (recent rows, top rows by objective,
+nearest neighbours, summary statistics) and list pending candidates, instead
+of receiving a pre-rendered dump in the prompt. The tools read live state from
+``RunContext[LLMContext]``; the toolset's instructions surface only the counts
+of experiments and pending candidates to motivate tool use.
+
+The per-query logic lives in module-level pure functions that take an
+``LLMContext`` directly (so they are unit-testable without a ``RunContext``);
+the toolset wraps them in thin ``RunContext`` adapters.
+"""
+
+import json
+from typing import Optional
+
+import numpy as np
+import pandas as pd
+from pydantic_ai import FunctionToolset, RunContext
+
+from bofire.data_models.domain.api import Domain
+from bofire.data_models.objectives.api import MinimizeObjective
+from bofire.llm.context import LLMContext
+
+
+def _objective(domain: Domain) -> tuple[Optional[str], bool]:
+    """Return the single objective output key and whether lower is better.
+
+    The single-objective invariant is enforced at the data-model level, so the
+    first output carrying an objective is the relevant one.
+    """
+    for feat in domain.outputs:
+        if feat.objective is not None:
+            return feat.key, isinstance(feat.objective, MinimizeObjective)
+    return None, False
+
+
+def _display_cols(domain: Domain, df: pd.DataFrame) -> list[str]:
+    """Input + output columns that are actually present in the frame."""
+    keys = domain.inputs.get_keys() + domain.outputs.get_keys()
+    return [k for k in keys if k in df.columns]
+
+
+def _records(df: pd.DataFrame, cols: list[str]) -> list[dict]:
+    """JSON-native records (avoids numpy types leaking into tool output)."""
+    return json.loads(df[cols].to_json(orient="records"))
+
+
+def _experiments(deps: LLMContext) -> Optional[pd.DataFrame]:
+    df = deps.experiments
+    if df is None or len(df) == 0:
+        return None
+    return df
+
+
+# --- pure query functions (unit-testable with a plain LLMContext) ---
+
+
+def recent_experiments(deps: LLMContext, n: int, max_rows: int) -> list[dict]:
+    """The n most recent experiments (most recently added last)."""
+    df = _experiments(deps)
+    if df is None:
+        return []
+    cols = _display_cols(deps.domain, df)
+    return _records(df.tail(min(n, max_rows)), cols)
+
+
+def top_experiments(deps: LLMContext, n: int, max_rows: int) -> list[dict]:
+    """The top n experiments ranked by the objective (best first)."""
+    df = _experiments(deps)
+    if df is None:
+        return []
+    cols = _display_cols(deps.domain, df)
+    key, ascending = _objective(deps.domain)
+    if key is None or key not in df.columns:
+        return _records(df.head(min(n, max_rows)), cols)
+    ranked = df.sort_values(by=key, ascending=ascending)
+    return _records(ranked.head(min(n, max_rows)), cols)
+
+
+def near_experiments(
+    deps: LLMContext, point: dict, k: int, max_rows: int
+) -> list[dict]:
+    """The k experiments closest to *point* (Euclidean over numeric inputs)."""
+    df = _experiments(deps)
+    if df is None:
+        return []
+    cols = _display_cols(deps.domain, df)
+    numeric = [
+        c
+        for c in deps.domain.inputs.get_keys()
+        if c in point and c in df.columns and pd.api.types.is_numeric_dtype(df[c])
+    ]
+    if not numeric:
+        return _records(df.head(min(k, max_rows)), cols)
+    target = np.array([float(point[c]) for c in numeric])
+    dist = np.sqrt(((df[numeric].astype(float).to_numpy() - target) ** 2).sum(axis=1))
+    idx = np.argsort(dist)[: min(k, max_rows)]
+    return _records(df.iloc[idx], cols)
+
+
+def experiment_summary(deps: LLMContext) -> dict:
+    """Per-feature numeric statistics and the best objective value."""
+    df = _experiments(deps)
+    if df is None:
+        return {"n_experiments": 0}
+    cols = _display_cols(deps.domain, df)
+    numeric_cols = [c for c in cols if pd.api.types.is_numeric_dtype(df[c])]
+    out: dict = {"n_experiments": int(len(df))}
+    if numeric_cols:
+        out["statistics"] = json.loads(df[numeric_cols].describe().to_json())
+    key, ascending = _objective(deps.domain)
+    if key is not None and key in df.columns:
+        best = df[key].min() if ascending else df[key].max()
+        out["best_objective"] = {
+            "key": key,
+            "value": float(best),
+            "direction": "minimize" if ascending else "maximize",
+        }
+    return out
+
+
+def pending_candidates(deps: LLMContext, max_rows: int) -> list[dict]:
+    """Candidates already proposed but not yet evaluated (avoid duplicates)."""
+    df = deps.candidates
+    if df is None or len(df) == 0:
+        return []
+    cols = [k for k in deps.domain.inputs.get_keys() if k in df.columns]
+    return _records(df.head(max_rows), cols)
+
+
+def build_experiment_toolset(max_rows: int) -> FunctionToolset:
+    """Build the experiment-access toolset, capping rows per call at *max_rows*."""
+
+    def _instructions(ctx: RunContext[LLMContext]) -> str:
+        n = 0 if ctx.deps.experiments is None else len(ctx.deps.experiments)
+        m = 0 if ctx.deps.candidates is None else len(ctx.deps.candidates)
+        return (
+            f"There are {n} completed experiment(s) and {m} pending candidate(s). "
+            f"Use the experiment tools to inspect them before proposing candidates. "
+            f"Each tool returns at most {max_rows} rows."
+        )
+
+    def inspect_recent(ctx: RunContext[LLMContext], n: int = 10) -> list[dict]:
+        """Return the n most recent experiments (most recently added last)."""
+        return recent_experiments(ctx.deps, n, max_rows)
+
+    def inspect_top(ctx: RunContext[LLMContext], n: int = 10) -> list[dict]:
+        """Return the top n experiments ranked by the objective (best first)."""
+        return top_experiments(ctx.deps, n, max_rows)
+
+    def inspect_near(
+        ctx: RunContext[LLMContext], point: dict, k: int = 5
+    ) -> list[dict]:
+        """Return the k experiments closest to *point* over numeric inputs."""
+        return near_experiments(ctx.deps, point, k, max_rows)
+
+    def summary_stats(ctx: RunContext[LLMContext]) -> dict:
+        """Return per-feature numeric statistics and the best objective value."""
+        return experiment_summary(ctx.deps)
+
+    def list_pending_candidates(ctx: RunContext[LLMContext]) -> list[dict]:
+        """Return candidates already proposed but not yet evaluated."""
+        return pending_candidates(ctx.deps, max_rows)
+
+    return FunctionToolset(
+        tools=[
+            inspect_recent,
+            inspect_top,
+            inspect_near,
+            summary_stats,
+            list_pending_candidates,
+        ],
+        instructions=_instructions,
+    )

--- a/bofire/llm/mapper.py
+++ b/bofire/llm/mapper.py
@@ -101,7 +101,7 @@ def map_anthropic_foundry(data_model: AnthropicFoundryLLMProvider):
 @register(OpenAILLMProvider)
 def map_openai(data_model: OpenAILLMProvider):
     from openai import AsyncOpenAI
-    from pydantic_ai.models.openai import OpenAIModel
+    from pydantic_ai.models.openai import OpenAIChatModel
     from pydantic_ai.providers.openai import OpenAIProvider
 
     kwargs = {"api_key": _resolve_env_var(data_model.api_key_env_var)}
@@ -112,13 +112,15 @@ def map_openai(data_model: OpenAILLMProvider):
 
     client = AsyncOpenAI(**kwargs)
     provider = OpenAIProvider(openai_client=client)
-    return OpenAIModel(data_model.model, provider=provider)
+    # pydantic-ai v2 renamed ``OpenAIModel`` -> ``OpenAIChatModel`` (the bare
+    # ``openai:`` prefix now defaults to the Responses API).
+    return OpenAIChatModel(data_model.model, provider=provider)
 
 
 @register(OpenAICompatibleLLMProvider)
 def map_openai_compatible(data_model: OpenAICompatibleLLMProvider):
     from openai import AsyncOpenAI
-    from pydantic_ai.models.openai import OpenAIModel
+    from pydantic_ai.models.openai import OpenAIChatModel
     from pydantic_ai.providers.openai import OpenAIProvider
 
     client = AsyncOpenAI(
@@ -126,7 +128,7 @@ def map_openai_compatible(data_model: OpenAICompatibleLLMProvider):
         base_url=data_model.base_url,
     )
     provider = OpenAIProvider(openai_client=client)
-    return OpenAIModel(data_model.model, provider=provider)
+    return OpenAIChatModel(data_model.model, provider=provider)
 
 
 def map(data_model: LLMProvider):

--- a/bofire/strategies/llm.py
+++ b/bofire/strategies/llm.py
@@ -2,8 +2,7 @@
 
 import asyncio
 import json
-from dataclasses import dataclass
-from typing import Any, Dict, Optional, cast
+from typing import Any, Dict, List, Optional, cast
 
 import pandas as pd
 from pydantic import BaseModel as PydanticBaseModel
@@ -13,17 +12,9 @@ from typing_extensions import Self
 
 import bofire.data_models.strategies.api as data_models
 from bofire.data_models.domain.api import Domain
-from bofire.data_models.features.api import ContinuousOutput
-from bofire.data_models.llm.api import AnyLLMProvider
-from bofire.data_models.objectives.api import MinimizeObjective
+from bofire.data_models.llm.api import AnyLLMCapability, AnyLLMProvider
+from bofire.llm.context import LLMContext
 from bofire.strategies.strategy import Strategy, make_strategy
-
-
-# --- Dependencies dataclass for pydantic-ai agent ---
-@dataclass
-class _LLMDeps:
-    domain: Domain
-    experiments_text: str
 
 
 # --- Default system prompt ---
@@ -45,51 +36,6 @@ Consider:
 - If previous experiments are provided, use them to inform proposals
 For each candidate, briefly explain your reasoning.
 """
-
-
-# --- Experiment selection ---
-def _select_experiments(
-    experiments: pd.DataFrame,
-    domain: Domain,
-    n_recent: Optional[int],
-    n_top: Optional[int],
-) -> tuple[pd.DataFrame, str]:
-    """Select a subset of experiments for LLM presentation.
-
-    Returns a tuple of (selected_df, description_text) where description_text
-    explains to the LLM what kind of experiments are being shown.
-    """
-    if n_recent is None and n_top is None:
-        return experiments, f"All {len(experiments)} experiments"
-
-    parts = []
-    desc_parts = []
-
-    if n_recent is not None:
-        recent = experiments.tail(n_recent)
-        parts.append(recent)
-        desc_parts.append(f"last {len(recent)} most recent")
-
-    if n_top is not None:
-        # Use the single objective output (validated at data model level)
-        for feat in domain.outputs:
-            if isinstance(feat, ContinuousOutput) and feat.objective is not None:
-                metric_key = feat.key
-                ascending = isinstance(feat.objective, MinimizeObjective)
-                break
-
-        sorted_exps = experiments.sort_values(by=metric_key, ascending=ascending)
-        top = sorted_exps.head(n_top)
-        parts.append(top)
-        direction = "lowest" if ascending else "highest"
-        desc_parts.append(f"top {len(top)} by {direction} {metric_key}")
-
-    selected = pd.concat(parts).drop_duplicates()
-    description = (
-        " + ".join(desc_parts)
-        + f" ({len(selected)} unique shown out of {len(experiments)} total)"
-    )
-    return selected, description
 
 
 def _reasoning_column_name(domain: Domain) -> str:
@@ -139,8 +85,7 @@ class LLMStrategy(Strategy):
         super().__init__(data_model=data_model, **kwargs)
         self._llm_provider = data_model.llm
         self._output_retries = data_model.output_retries
-        self._n_recent_experiments = data_model.n_recent_experiments
-        self._n_top_experiments = data_model.n_top_experiments
+        self._capabilities = data_model.capabilities
         self._system_prompt = data_model.system_prompt or _DEFAULT_SYSTEM_PROMPT
         self._pydantic_ai_model = None
         self._agent = None
@@ -163,35 +108,40 @@ class LLMStrategy(Strategy):
         """Lazily constructed pydantic-ai Agent. Built once on first access.
 
         Per BoFire's "build once, execute many" philosophy: the Agent
-        captures the domain, output schema, system prompt, and provider
-        model at first access. Per-call inputs (current experiments,
-        candidate count) are passed in via ``_LLMDeps`` on each
+        captures the domain, output schema, system prompt, capabilities, and
+        provider model at first access. Per-call inputs (current experiments,
+        pending candidates) are passed in via ``LLMContext`` on each
         ``agent.run()``.
         """
         if self._agent is None:
             from pydantic_ai import Agent, ModelRetry
 
+            import bofire.llm.capabilities_mapper as cap_mapper
+
             proposal_model = _build_proposal_model(self.domain)
+            capabilities = [cap_mapper.map(c) for c in self._capabilities]
 
             agent = Agent(
                 self.pydantic_ai_model,
+                deps_type=LLMContext,
                 system_prompt=self._system_prompt,
                 output_type=proposal_model,
-                output_retries=self._output_retries,
+                # pydantic-ai v2 unified ``output_retries`` into ``retries``
+                # (``AgentRetries = {tools, output}``). We only retry on output
+                # validation failures, so map onto the ``output`` budget.
+                retries={"output": self._output_retries},
+                capabilities=capabilities or None,
                 name="LLMStrategy",
             )
 
             @agent.system_prompt
             async def add_domain_description(ctx) -> str:
-                deps: _LLMDeps = ctx.deps
-                parts = [deps.domain.to_description()]
-                if deps.experiments_text:
-                    parts.append(deps.experiments_text)
-                return "\n".join(parts)
+                deps: LLMContext = ctx.deps
+                return deps.domain.to_description()
 
             @agent.output_validator
             async def validate_against_domain(ctx, proposal):
-                deps: _LLMDeps = ctx.deps
+                deps: LLMContext = ctx.deps
                 rows = [c.values.model_dump() for c in proposal.candidates]
                 candidates_df = pd.DataFrame(rows)
                 try:
@@ -226,32 +176,12 @@ class LLMStrategy(Strategy):
             candidate_count = 1
         return asyncio.run(self._ask_async(candidate_count))
 
-    def _build_experiments_text(self) -> str:
-        """Render the currently held experiments as a JSON block for the LLM."""
-        if self.experiments is None or len(self.experiments) == 0:
-            return ""
-        selected, description = _select_experiments(
-            self.domain.outputs.preprocess_experiments_all_valid_outputs(
-                self.experiments
-            ),
-            self.domain,
-            self._n_recent_experiments,
-            self._n_top_experiments,
-        )
-        display_cols = self.domain.inputs.get_keys() + self.domain.outputs.get_keys()
-        experiments_json = json.dumps(
-            selected[display_cols].to_dict(orient="records"), indent=2
-        )
-        return (
-            f"\n## Previous Experiments ({description})\n"
-            f"```json\n{experiments_json}\n```"
-        )
-
     async def _ask_async(self, candidate_count: int) -> pd.DataFrame:
         """Async implementation of candidate generation."""
-        deps = _LLMDeps(
+        deps = LLMContext(
             domain=self.domain,
-            experiments_text=self._build_experiments_text(),
+            experiments=self.experiments,
+            candidates=self.candidates,
         )
 
         result = await self.agent.run(
@@ -275,8 +205,7 @@ class LLMStrategy(Strategy):
         llm: AnyLLMProvider,
         model_settings: Optional[Dict[str, Any]] = None,
         output_retries: Optional[int] = None,
-        n_recent_experiments: Optional[int] = None,
-        n_top_experiments: Optional[int] = None,
+        capabilities: Optional[List[AnyLLMCapability]] = None,
         system_prompt: Optional[str] = None,
         seed: Optional[int] = None,
     ) -> Self:
@@ -289,8 +218,9 @@ class LLMStrategy(Strategy):
                 ``model_settings`` (e.g. ``{"temperature": 0.2,
                 "max_tokens": 4096, "thinking": "high"}``).
             output_retries: Number of retries for output validation.
-            n_recent_experiments: Number of recent experiments to show.
-            n_top_experiments: Number of top experiments to show.
+            capabilities: Capabilities to attach to the agent. If omitted, the
+                data model default (a single ``ExperimentAccessCapability``) is
+                used. Supplying a list replaces the default.
             system_prompt: Custom system prompt override.
             seed: Random seed.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,7 @@ entmoot = [
     "pyomo<=6.9.4",
     "entmoot>=2.1.1",
 ] # we pin the pyomo version here due to compatibility issues
-llm = ["pydantic-ai>=0.1"]
+llm = ["pydantic-ai>=2,<3"]
 cheminfo = ["rdkit>=2023.3.2", "scikit-learn>=1.0.0", "mordredcommunity>=2.0.1"]
 tests = ["pytest", "pytest-cov", "papermill"]
 docs = ["jupyter", "jupyter-cache", "matplotlib", "seaborn"]
@@ -84,7 +84,7 @@ all = [
     "seaborn",
     "pymoo>=0.6.0",
     "shap>=0.48.0",
-    "pydantic-ai>=0.1",
+    "pydantic-ai>=2,<3",
 ]
 
 [tool.setuptools.packages]

--- a/tests/bofire/data_models/serialization/test_deserialization.py
+++ b/tests/bofire/data_models/serialization/test_deserialization.py
@@ -7,6 +7,7 @@ from bofire.data_models.api import (
     AnyDataFrame,
     AnyFeature,
     AnyKernel,
+    AnyLLMCapability,
     AnyLLMProvider,
     AnyLocalSearchConfig,
     AnyMolFeatures,
@@ -147,6 +148,10 @@ def test_local_search_config_should_be_deserializable(local_search_config_spec: 
 
 
 def test_llm_should_be_deserializable(llm_spec: Spec):
+    from bofire.data_models.llm.provider import LLMProvider
+
     obj = llm_spec.obj()
-    deserialized = TypeAdapter(AnyLLMProvider).validate_python(obj.model_dump())
+    # The llm spec group holds both providers and capabilities; pick the union.
+    union = AnyLLMProvider if isinstance(obj, LLMProvider) else AnyLLMCapability
+    deserialized = TypeAdapter(union).validate_python(obj.model_dump())
     assert obj == deserialized

--- a/tests/bofire/data_models/specs/llm.py
+++ b/tests/bofire/data_models/specs/llm.py
@@ -1,3 +1,4 @@
+from bofire.data_models.llm.capability import ExperimentAccessCapability
 from bofire.data_models.llm.provider import (
     AnthropicFoundryLLMProvider,
     AnthropicLLMProvider,
@@ -8,6 +9,13 @@ from tests.bofire.data_models.specs.specs import Specs
 
 
 specs = Specs([])
+
+specs.add_valid(
+    ExperimentAccessCapability,
+    lambda: {
+        "max_rows_per_tool_call": 50,
+    },
+)
 
 specs.add_valid(
     AnthropicLLMProvider,

--- a/tests/bofire/data_models/specs/strategies.py
+++ b/tests/bofire/data_models/specs/strategies.py
@@ -26,6 +26,7 @@ from bofire.data_models.features.api import (
     ContinuousTaskInput,
     DiscreteInput,
 )
+from bofire.data_models.llm.capability import ExperimentAccessCapability
 from bofire.data_models.llm.provider import AnthropicLLMProvider
 from bofire.data_models.objectives.api import (
     MaximizeObjective,
@@ -1037,8 +1038,7 @@ specs.add_valid(
         "seed": 42,
         "model_settings": None,
         "output_retries": 3,
-        "n_recent_experiments": None,
-        "n_top_experiments": None,
+        "capabilities": [ExperimentAccessCapability().model_dump()],
         "system_prompt": None,
     },
 )
@@ -1058,8 +1058,9 @@ specs.add_valid(
             "thinking": "medium",
         },
         "output_retries": 5,
-        "n_recent_experiments": 10,
-        "n_top_experiments": 5,
+        "capabilities": [
+            ExperimentAccessCapability(max_rows_per_tool_call=20).model_dump()
+        ],
         "system_prompt": "You are a helpful assistant.",
     },
 )

--- a/tests/bofire/strategies/test_llm.py
+++ b/tests/bofire/strategies/test_llm.py
@@ -15,7 +15,7 @@ from bofire.data_models.llm.provider import AnthropicLLMProvider
 from bofire.data_models.objectives.api import MaximizeObjective, MinimizeObjective
 from bofire.data_models.strategies.api import LLMStrategy as LLMStrategyDataModel
 from bofire.strategies.api import LLMStrategy
-from bofire.strategies.llm import _build_proposal_model, _select_experiments
+from bofire.strategies.llm import _build_proposal_model
 
 
 PYDANTIC_AI_AVAILABLE = importlib.util.find_spec("pydantic_ai") is not None
@@ -54,31 +54,41 @@ def experiments():
     )
 
 
-# --- _select_experiments ---
+# --- experiment-access tools ---
 
 
-def test_select_experiments_all(simple_domain, experiments):
-    selected, desc = _select_experiments(experiments, simple_domain, None, None)
-    assert len(selected) == 10
-    assert "All" in desc
+def _ctx(domain, experiments=None, candidates=None):
+    from bofire.llm.context import LLMContext
+
+    return LLMContext(domain=domain, experiments=experiments, candidates=candidates)
 
 
-def test_select_experiments_recent(simple_domain, experiments):
-    selected, desc = _select_experiments(experiments, simple_domain, 3, None)
-    assert len(selected) == 3
-    assert selected["y"].tolist() == [80, 90, 100]
-    assert "recent" in desc
+def test_recent_experiments(simple_domain, experiments):
+    from bofire.llm.experiment_tools import recent_experiments
+
+    rows = recent_experiments(_ctx(simple_domain, experiments), n=3, max_rows=50)
+    assert [r["y"] for r in rows] == [80, 90, 100]
+    # output columns included, helper/valid columns excluded
+    assert set(rows[0]) == {"x1", "x2", "x3", "y"}
 
 
-def test_select_experiments_top(simple_domain, experiments):
-    selected, desc = _select_experiments(experiments, simple_domain, None, 3)
-    assert len(selected) == 3
-    assert set(selected["y"].tolist()) == {80, 90, 100}
-    assert "top" in desc
-    assert "highest" in desc
+def test_recent_experiments_capped(simple_domain, experiments):
+    from bofire.llm.experiment_tools import recent_experiments
+
+    rows = recent_experiments(_ctx(simple_domain, experiments), n=100, max_rows=4)
+    assert len(rows) == 4
 
 
-def test_select_experiments_top_minimize(experiments):
+def test_top_experiments_maximize(simple_domain, experiments):
+    from bofire.llm.experiment_tools import top_experiments
+
+    rows = top_experiments(_ctx(simple_domain, experiments), n=3, max_rows=50)
+    assert {r["y"] for r in rows} == {80, 90, 100}
+
+
+def test_top_experiments_minimize(experiments):
+    from bofire.llm.experiment_tools import top_experiments
+
     domain = Domain.from_lists(
         inputs=[
             ContinuousInput(key="x1", bounds=(0, 1)),
@@ -87,26 +97,51 @@ def test_select_experiments_top_minimize(experiments):
         ],
         outputs=[ContinuousOutput(key="y", objective=MinimizeObjective(w=1.0))],
     )
-    selected, desc = _select_experiments(experiments, domain, None, 3)
-    assert set(selected["y"].tolist()) == {10, 20, 30}
-    assert "lowest" in desc
+    rows = top_experiments(_ctx(domain, experiments), n=3, max_rows=50)
+    assert {r["y"] for r in rows} == {10, 20, 30}
 
 
-def test_select_experiments_both_deduplicates(simple_domain, experiments):
-    selected, desc = _select_experiments(experiments, simple_domain, 5, 5)
-    # Last 5: y=[60,70,80,90,100], Top 5: y=[60,70,80,90,100] — same set
-    assert len(selected) == 5
-    assert "unique" in desc
+def test_near_experiments(simple_domain, experiments):
+    from bofire.llm.experiment_tools import near_experiments
+
+    rows = near_experiments(
+        _ctx(simple_domain, experiments), point={"x1": 0.1, "x2": 0.9}, k=1, max_rows=50
+    )
+    assert len(rows) == 1
+    assert rows[0]["y"] == 10  # the (0.1, 0.9) row
 
 
-def test_select_experiments_both_union(simple_domain, experiments):
-    # Recent 2: y=[90,100], Top 2: y=[90,100] — overlap
-    selected, _ = _select_experiments(experiments, simple_domain, 2, 2)
-    assert len(selected) == 2
+def test_experiment_summary(simple_domain, experiments):
+    from bofire.llm.experiment_tools import experiment_summary
 
-    # Recent 3: y=[80,90,100], Top 3: y=[80,90,100]
-    selected, _ = _select_experiments(experiments, simple_domain, 3, 3)
-    assert len(selected) == 3
+    summary = experiment_summary(_ctx(simple_domain, experiments))
+    assert summary["n_experiments"] == 10
+    assert summary["best_objective"] == {
+        "key": "y",
+        "value": 100.0,
+        "direction": "maximize",
+    }
+
+
+def test_pending_candidates(simple_domain):
+    from bofire.llm.experiment_tools import pending_candidates
+
+    cands = pd.DataFrame({"x1": [0.5], "x2": [0.5], "x3": ["a"]})
+    rows = pending_candidates(_ctx(simple_domain, candidates=cands), max_rows=50)
+    assert rows == [{"x1": 0.5, "x2": 0.5, "x3": "a"}]
+
+
+def test_experiment_tools_empty(simple_domain):
+    from bofire.llm.experiment_tools import (
+        experiment_summary,
+        pending_candidates,
+        recent_experiments,
+    )
+
+    ctx = _ctx(simple_domain)
+    assert recent_experiments(ctx, n=5, max_rows=50) == []
+    assert pending_candidates(ctx, max_rows=50) == []
+    assert experiment_summary(ctx) == {"n_experiments": 0}
 
 
 # --- _build_proposal_model ---
@@ -182,6 +217,37 @@ def test_llm_strategy_ask_with_test_model():
     strategy._pydantic_ai_model = TestModel()
 
     # TestModel generates a single array item by default, so ask(1).
+    candidates = strategy.ask(1)
+    assert len(candidates) == 1
+    assert "reasoning" in candidates.columns
+
+
+def test_llm_strategy_ask_with_experiments_and_tools():
+    """ask() succeeds with experiments told and the default ExperimentAccessCapability.
+
+    TestModel exercises every available tool, so this also confirms the
+    experiment-access toolset is wired and callable end-to-end.
+    """
+    from pydantic_ai.models.test import TestModel
+
+    domain = Domain.from_lists(
+        inputs=[
+            ContinuousInput(key="x1", bounds=(0, 10)),
+            ContinuousInput(key="x2", bounds=(0, 10)),
+        ],
+        outputs=[ContinuousOutput(key="y", objective=MaximizeObjective(w=1.0))],
+    )
+    data_model = LLMStrategyDataModel(
+        domain=domain,
+        llm=AnthropicLLMProvider(api_key_env_var="UNUSED_KEY"),
+    )
+    assert len(data_model.capabilities) == 1  # default ExperimentAccessCapability
+    strategy = LLMStrategy(data_model=data_model)
+    strategy._pydantic_ai_model = TestModel()
+
+    experiments = pd.DataFrame({"x1": [1.0, 2.0], "x2": [3.0, 4.0], "y": [10.0, 20.0]})
+    strategy.tell(domain.validate_experiments(experiments))
+
     candidates = strategy.ask(1)
     assert len(candidates) == 1
     assert "reasoning" in candidates.columns

--- a/tests/bofire/test_register.py
+++ b/tests/bofire/test_register.py
@@ -16,6 +16,7 @@ from bofire.data_models.features.api import (
 )
 from bofire.data_models.kernels.continuous import ContinuousKernel as _ContinuousBase
 from bofire.data_models.kernels.kernel import Kernel as KernelDataModel
+from bofire.data_models.llm.capability import LLMCapability
 from bofire.data_models.llm.provider import LLMProvider
 from bofire.data_models.priors.prior import Prior as PriorDataModel
 from bofire.data_models.strategies.strategy import Strategy as StrategyDataModel
@@ -824,6 +825,85 @@ class TestLLMProviderPydanticIntegration:
         )
         data_model = LLMStrategyDataModel(domain=domain, llm=_MapperLLMProvider())
         assert isinstance(data_model.llm, _MapperLLMProvider)
+
+
+# ---------------------------------------------------------------------------
+# LLM capability registration tests
+# ---------------------------------------------------------------------------
+
+
+class _IntegrationLLMCapability(LLMCapability):
+    type: Literal["_IntegrationLLMCapability"] = "_IntegrationLLMCapability"
+
+
+class TestLLMCapabilityPydanticIntegration:
+    """After register_llm_capability, custom capability types should pass
+    Pydantic validation on LLMStrategy.capabilities and round-trip through
+    AnyLLMCapability."""
+
+    def test_custom_capability_in_llm_strategy(self):
+        from pydantic import TypeAdapter
+
+        import bofire.data_models.llm.api as llm_api
+        from bofire.data_models.llm.api import register_llm_capability
+        from bofire.data_models.llm.provider import AnthropicLLMProvider
+        from bofire.data_models.objectives.api import MaximizeObjective
+        from bofire.data_models.strategies.api import (
+            LLMStrategy as LLMStrategyDataModel,
+        )
+
+        register_llm_capability(_IntegrationLLMCapability)
+
+        obj = _IntegrationLLMCapability()
+        deserialized = TypeAdapter(llm_api.AnyLLMCapability).validate_python(
+            obj.model_dump()
+        )
+        assert deserialized == obj
+
+        domain = Domain(
+            inputs=Inputs(features=[ContinuousInput(key="x", bounds=(0, 1))]),
+            outputs=Outputs(
+                features=[ContinuousOutput(key="y", objective=MaximizeObjective(w=1.0))]
+            ),
+        )
+        data_model = LLMStrategyDataModel(
+            domain=domain,
+            llm=AnthropicLLMProvider(api_key_env_var="FAKE_KEY"),
+            capabilities=[obj],
+        )
+        assert isinstance(data_model.capabilities[0], _IntegrationLLMCapability)
+
+    def test_mapper_register_also_updates_pydantic(self):
+        """The capability mapper-level register() should trigger data model registration."""
+        import bofire.llm.capabilities_mapper as cap_mapper
+
+        class _MapperLLMCapability(LLMCapability):
+            type: Literal["_MapperLLMCapability"] = "_MapperLLMCapability"
+
+        sentinel = MagicMock(name="pydantic_ai_capability")
+        cap_mapper.register(_MapperLLMCapability, lambda dm: sentinel)
+
+        assert cap_mapper.CAPABILITY_MAP[_MapperLLMCapability] is not None
+        assert cap_mapper.map(_MapperLLMCapability()) is sentinel
+
+        from bofire.data_models.llm.provider import AnthropicLLMProvider
+        from bofire.data_models.objectives.api import MaximizeObjective
+        from bofire.data_models.strategies.api import (
+            LLMStrategy as LLMStrategyDataModel,
+        )
+
+        domain = Domain(
+            inputs=Inputs(features=[ContinuousInput(key="x", bounds=(0, 1))]),
+            outputs=Outputs(
+                features=[ContinuousOutput(key="y", objective=MaximizeObjective(w=1.0))]
+            ),
+        )
+        data_model = LLMStrategyDataModel(
+            domain=domain,
+            llm=AnthropicLLMProvider(api_key_env_var="FAKE_KEY"),
+            capabilities=[_MapperLLMCapability()],
+        )
+        assert isinstance(data_model.capabilities[0], _MapperLLMCapability)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Brings the LLM recommender to the next level: a **serializable + registerable capability system** for `LLMStrategy`, plus migration to **pydantic-ai v2**. Capabilities are typed, serializable config; a mapper reconstructs the live pydantic-ai capability (including its tool functions) at runtime — mirroring the existing LLM-provider triplet (data model + tagged union + mapper + `register`).

As the first capability, experiment presentation moves from a prompt-dump (with `n_recent`/`n_top` knobs) to a **tool-only** `ExperimentAccessCapability` the model queries on demand.

## What's included

**Capability triplet** (mirrors `AnyLLMProvider` + `LLM_MAP` + `register_llm_provider`)
- `bofire/data_models/llm/capability.py` — `LLMCapability` base + `ExperimentAccessCapability`
- `AnyLLMCapability` union + `register_llm_capability()`; `LLMStrategy.capabilities` field (default-on via `default_factory`, replace-semantics documented)
- `bofire/llm/capabilities_mapper.py` — `CAPABILITY_MAP` + `register`/`map`
- `bofire/llm/experiment_tools.py` — `FunctionToolset` of `inspect_recent`/`inspect_top`/`inspect_near`/`summary_stats`/`list_pending_candidates`; per-query logic in unit-testable pure functions

**Tool-only experiment access**
- Removed `n_recent_experiments` / `n_top_experiments` and the prompt-dump path
- The capability instructions surface only **counts** (metadata, not a predefined view) to motivate tool use
- Strategy deps refactored `_LLMDeps` → `LLMContext` (domain + experiments + **pending candidates**)
- The `output_validator` feasibility gate is **unchanged** — capabilities enrich, never bypass `domain.validate_candidates`

**pydantic-ai v2 migration**
- `output_retries` → `retries={"output": N}`, `OpenAIModel` → `OpenAIChatModel`, pin `pydantic-ai>=2,<3`

## Design notes
- **Serialization boundary:** config serializes; the mapper is the code that rebuilds tools. Custom capabilities round-trip only where their mapper is registered (same as custom providers).
- **Why capabilities, not a bare tool system:** v2's capability bundles instructions + tools + model settings + hooks; "skill" and "tool" collapse into one primitive, one registry, one mapper.
- Future capabilities (`MCPCapability`, RAG, BO-as-a-tool, sandboxed code analysis) drop into the same slot without redesign.

## Verification
- `1418 passed, 5 skipped` across `tests/bofire/data_models`, `test_llm`, `bofire/llm`, `test_register` (incl. exact serialization round-trip for the default capability)
- `ruff check` clean, formatted; `ty check bofire` exits 0 (new modules produce zero diagnostics)

## Follow-ups (out of scope)
- `asyncio.run()` in `_ask` throws inside a running event loop (Jupyter); matters more once a deep/agentic harness lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)