### PR TITLE
callback function for GA, file-based progress tracking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -114,6 +114,7 @@ venv/
 ENV/
 env.bak/
 venv.bak/
+uv.lock
 
 # Spyder project settings
 .spyderproject

--- a/bofire/data_models/strategies/api.py
+++ b/bofire/data_models/strategies/api.py
@@ -21,6 +21,7 @@ from bofire.data_models.strategies.fractional_factorial import (
 from bofire.data_models.strategies.llm import LLMStrategy
 from bofire.data_models.strategies.meta_strategy_type import MetaStrategy
 from bofire.data_models.strategies.predictives.acqf_optimization import (
+    ImportPathCallback,
     LSRBO,
     AcquisitionOptimizer,
     AnyAcqfOptimizer,

--- a/bofire/data_models/strategies/api.py
+++ b/bofire/data_models/strategies/api.py
@@ -21,8 +21,6 @@ from bofire.data_models.strategies.fractional_factorial import (
 from bofire.data_models.strategies.llm import LLMStrategy
 from bofire.data_models.strategies.meta_strategy_type import MetaStrategy
 from bofire.data_models.strategies.predictives.acqf_optimization import (
-    CsvProgressCallback,
-    ImportPathCallback,
     LSRBO,
     AcquisitionOptimizer,
     AnyAcqfOptimizer,

--- a/bofire/data_models/strategies/api.py
+++ b/bofire/data_models/strategies/api.py
@@ -21,6 +21,7 @@ from bofire.data_models.strategies.fractional_factorial import (
 from bofire.data_models.strategies.llm import LLMStrategy
 from bofire.data_models.strategies.meta_strategy_type import MetaStrategy
 from bofire.data_models.strategies.predictives.acqf_optimization import (
+    CsvProgressCallback,
     ImportPathCallback,
     LSRBO,
     AcquisitionOptimizer,

--- a/bofire/data_models/strategies/predictives/acqf_optimization.py
+++ b/bofire/data_models/strategies/predictives/acqf_optimization.py
@@ -1,6 +1,6 @@
 import warnings
 from abc import abstractmethod
-from typing import Literal, Optional, Type
+from typing import Any, Dict, Literal, Optional, Type
 
 from pydantic import Field, PositiveFloat, PositiveInt, field_validator
 
@@ -98,6 +98,21 @@ class LSRBO(LocalSearchConfig):
 
 
 AnyLocalSearchConfig = LSRBO
+
+
+class ImportPathCallback(BaseModel):
+    """Serializable callback definition resolved from a Python import path.
+
+    The callback target must be specified as "module.submodule:function_name".
+    Optional keyword arguments are bound when constructing the runtime callback.
+    """
+
+    type: Literal["ImportPathCallback"] = "ImportPathCallback"
+    target: str
+    kwargs: Dict[str, Any] = Field(default_factory=dict)
+
+
+AnyGACallback = ImportPathCallback
 
 
 class BotorchOptimizer(AcquisitionOptimizer):
@@ -259,6 +274,9 @@ class GeneticAlgorithmOptimizer(AcquisitionOptimizer):
 
     # verbosity
     verbose: bool = False
+
+    # Optional serializable callback definition resolved at runtime.
+    callback: Optional[AnyGACallback] = None
 
     def is_constraint_implemented(self, my_type: Type[constraints.Constraint]) -> bool:
         return my_type in [

--- a/bofire/data_models/strategies/predictives/acqf_optimization.py
+++ b/bofire/data_models/strategies/predictives/acqf_optimization.py
@@ -112,7 +112,14 @@ class ImportPathCallback(BaseModel):
     kwargs: Dict[str, Any] = Field(default_factory=dict)
 
 
-AnyGACallback = ImportPathCallback
+class CsvProgressCallback(BaseModel):
+    """Built-in GA callback writing per-generation progress to a CSV file."""
+
+    type: Literal["CsvProgressCallback"] = "CsvProgressCallback"
+    file_path: str
+
+
+AnyGACallback = tagged_union(ImportPathCallback, CsvProgressCallback)
 
 
 class BotorchOptimizer(AcquisitionOptimizer):

--- a/bofire/data_models/strategies/predictives/acqf_optimization.py
+++ b/bofire/data_models/strategies/predictives/acqf_optimization.py
@@ -1,6 +1,6 @@
 import warnings
 from abc import abstractmethod
-from typing import Any, Dict, Literal, Optional, Type
+from typing import Literal, Optional, Type
 
 from pydantic import Field, PositiveFloat, PositiveInt, field_validator
 
@@ -98,28 +98,6 @@ class LSRBO(LocalSearchConfig):
 
 
 AnyLocalSearchConfig = LSRBO
-
-
-class ImportPathCallback(BaseModel):
-    """Serializable callback definition resolved from a Python import path.
-
-    The callback target must be specified as "module.submodule:function_name".
-    Optional keyword arguments are bound when constructing the runtime callback.
-    """
-
-    type: Literal["ImportPathCallback"] = "ImportPathCallback"
-    target: str
-    kwargs: Dict[str, Any] = Field(default_factory=dict)
-
-
-class CsvProgressCallback(BaseModel):
-    """Built-in GA callback writing per-generation progress to a CSV file."""
-
-    type: Literal["CsvProgressCallback"] = "CsvProgressCallback"
-    file_path: str
-
-
-AnyGACallback = tagged_union(ImportPathCallback, CsvProgressCallback)
 
 
 class BotorchOptimizer(AcquisitionOptimizer):
@@ -282,8 +260,9 @@ class GeneticAlgorithmOptimizer(AcquisitionOptimizer):
     # verbosity
     verbose: bool = False
 
-    # Optional serializable callback definition resolved at runtime.
-    callback: Optional[AnyGACallback] = None
+    # progress tracking
+    ga_progress_csv_path: Optional[str] = Field(
+        default=None, description="Path to a CSV file where the progress of the genetic algorithm will be saved.")
 
     def is_constraint_implemented(self, my_type: Type[constraints.Constraint]) -> bool:
         return my_type in [

--- a/bofire/data_models/strategies/predictives/acqf_optimization.py
+++ b/bofire/data_models/strategies/predictives/acqf_optimization.py
@@ -262,7 +262,9 @@ class GeneticAlgorithmOptimizer(AcquisitionOptimizer):
 
     # progress tracking
     ga_progress_csv_path: Optional[str] = Field(
-        default=None, description="Path to a CSV file where the progress of the genetic algorithm will be saved.")
+        default=None,
+        description="Path to a CSV file where the progress of the genetic algorithm will be saved.",
+    )
 
     def is_constraint_implemented(self, my_type: Type[constraints.Constraint]) -> bool:
         return my_type in [

--- a/bofire/strategies/utils.py
+++ b/bofire/strategies/utils.py
@@ -1,5 +1,6 @@
 import importlib
 import inspect
+import os
 from functools import partial
 from typing import Any, Callable, Dict, List, Literal, Optional, Tuple, Type, Union
 
@@ -37,6 +38,10 @@ from bofire.data_models.features.api import (
 from bofire.data_models.strategies.api import (
     GeneticAlgorithmOptimizer as GeneticAlgorithmDataModel,
 )
+from bofire.data_models.strategies.predictives.acqf_optimization import (
+    CsvProgressCallback,
+    ImportPathCallback,
+)
 from bofire.data_models.types import InputTransformSpecs
 from bofire.utils.domain_repair import (
     LinearProjection,
@@ -52,6 +57,14 @@ def _resolve_ga_callback(
     callback_spec = data_model.callback
     if callback_spec is None:
         return None
+
+    if isinstance(callback_spec, CsvProgressCallback):
+        return _make_csv_progress_callback(callback_spec.file_path)
+
+    if not isinstance(callback_spec, ImportPathCallback):
+        raise ValueError(
+            f"Unsupported callback specification type: {type(callback_spec)}"
+        )
 
     module_name, sep, attr_name = callback_spec.target.rpartition(":")
     if not sep or not module_name or not attr_name:
@@ -83,6 +96,37 @@ def _resolve_ga_callback(
         return partial(callback_obj, **callback_spec.kwargs)
 
     return callback_obj
+
+
+def _make_csv_progress_callback(file_path: str) -> Callable[..., Any]:
+    """Create a callback that appends GA progress information to CSV."""
+
+    header = "generation,n_eval,best_f\n"
+    os.makedirs(os.path.dirname(file_path) or ".", exist_ok=True)
+    with open(file_path, "w", encoding="utf-8") as file:
+        file.write(header)
+
+    def _csv_callback(algorithm):
+        generation = getattr(algorithm, "n_gen", "")
+        evaluator = getattr(algorithm, "evaluator", None)
+        n_eval = getattr(evaluator, "n_eval", "") if evaluator is not None else ""
+
+        best_f = ""
+        opt = getattr(algorithm, "opt", None)
+        if opt is not None:
+            try:
+                f_val = opt.get("F")
+                if f_val is not None:
+                    arr = np.asarray(f_val).reshape(-1)
+                    if arr.size > 0:
+                        best_f = float(np.min(arr))
+            except Exception:
+                best_f = ""
+
+        with open(file_path, "a", encoding="utf-8") as file:
+            file.write(f"{generation},{n_eval},{best_f}\n")
+
+    return _csv_callback
 
 
 class GaMixedDomainHandler:

--- a/bofire/strategies/utils.py
+++ b/bofire/strategies/utils.py
@@ -1,4 +1,4 @@
-from typing import Callable, Dict, List, Literal, Optional, Tuple, Type, Union
+from typing import Any, Callable, Dict, List, Literal, Optional, Tuple, Type, Union
 
 import numpy as np
 import pandas as pd
@@ -666,6 +666,7 @@ def run_ga(
     n_obj: Optional[int] = None,
     verbose: bool = False,
     optimization_direction: Literal["min", "max"] = "max",
+    callback: Optional[Callable[..., Any]] = None,
 ) -> Tuple[Union[Tensor, List[pd.DataFrame]], Union[Tensor, np.ndarray]]:
     """Convenience function to minimize one or multiple objective functions using a genetic algorithm.
 
@@ -699,6 +700,8 @@ def run_ga(
             Assuming that each callable returns a single output. If the callables return multiple outputs, n_obj
             must be set to the sum of the number of outputs of each callable.
         verbose (bool, optional): Whether to print the QP iterations. Defaults to False.
+        callback (Optional[Callable[..., Any]], optional): Callback passed to `pymoo.optimize.minimize`.
+            The callback is invoked by pymoo during optimization. Defaults to None.
 
     Returns
         x_opt (Union[Tensor, pd.DataFrame]): optimized experiments
@@ -717,7 +720,13 @@ def run_ga(
         optimization_direction=optimization_direction,
     )
 
-    res = pymoo_minimize(problem, algorithm, termination, verbose=verbose)
+    res = pymoo_minimize(
+        problem,
+        algorithm,
+        termination,
+        verbose=verbose,
+        callback=callback,
+    )
 
     if callable_format == "torch":
         # transform the result to the numeric domain

--- a/bofire/strategies/utils.py
+++ b/bofire/strategies/utils.py
@@ -1,7 +1,4 @@
-import importlib
-import inspect
 import os
-from functools import partial
 from typing import Any, Callable, Dict, List, Literal, Optional, Tuple, Type, Union
 
 import numpy as np
@@ -38,10 +35,6 @@ from bofire.data_models.features.api import (
 from bofire.data_models.strategies.api import (
     GeneticAlgorithmOptimizer as GeneticAlgorithmDataModel,
 )
-from bofire.data_models.strategies.predictives.acqf_optimization import (
-    CsvProgressCallback,
-    ImportPathCallback,
-)
 from bofire.data_models.types import InputTransformSpecs
 from bofire.utils.domain_repair import (
     LinearProjection,
@@ -53,49 +46,11 @@ from bofire.utils.torch_tools import get_nonlinear_constraints, tkwargs
 def _resolve_ga_callback(
     data_model: GeneticAlgorithmDataModel,
 ) -> Optional[Callable[..., Any]]:
-    """Resolve a runtime callback from the serializable GA data model definition."""
-    callback_spec = data_model.callback
-    if callback_spec is None:
+    """Resolve a runtime callback from GA data model settings."""
+    file_path = data_model.ga_progress_csv_path
+    if file_path is None:
         return None
-
-    if isinstance(callback_spec, CsvProgressCallback):
-        return _make_csv_progress_callback(callback_spec.file_path)
-
-    if not isinstance(callback_spec, ImportPathCallback):
-        raise ValueError(
-            f"Unsupported callback specification type: {type(callback_spec)}"
-        )
-
-    module_name, sep, attr_name = callback_spec.target.rpartition(":")
-    if not sep or not module_name or not attr_name:
-        raise ValueError(
-            "Invalid callback target. Expected format "
-            "'module.submodule:function_name'."
-        )
-
-    module = importlib.import_module(module_name)
-    callback_obj = getattr(module, attr_name, None)
-    if callback_obj is None:
-        raise ValueError(
-            f"Could not resolve callback target {callback_spec.target!r}."
-        )
-    if not callable(callback_obj):
-        raise ValueError(
-            f"Callback target {callback_spec.target!r} is not callable."
-        )
-
-    if callback_spec.kwargs:
-        if inspect.isclass(callback_obj):
-            callback_obj = callback_obj(**callback_spec.kwargs)
-            if not callable(callback_obj):
-                raise ValueError(
-                    f"Callback class target {callback_spec.target!r} did not "
-                    "produce a callable instance."
-                )
-            return callback_obj
-        return partial(callback_obj, **callback_spec.kwargs)
-
-    return callback_obj
+    return _make_csv_progress_callback(file_path)
 
 
 def _make_csv_progress_callback(file_path: str) -> Callable[..., Any]:
@@ -809,12 +764,15 @@ def run_ga(
 
     resolved_callback = callback or _resolve_ga_callback(data_model)
 
+    pymoo_kwargs = {"verbose": verbose}
+    if resolved_callback is not None:
+        pymoo_kwargs["callback"] = resolved_callback
+
     res = pymoo_minimize(
         problem,
         algorithm,
         termination,
-        verbose=verbose,
-        callback=resolved_callback,
+        **pymoo_kwargs,
     )
 
     if callable_format == "torch":

--- a/bofire/strategies/utils.py
+++ b/bofire/strategies/utils.py
@@ -1,3 +1,6 @@
+import importlib
+import inspect
+from functools import partial
 from typing import Any, Callable, Dict, List, Literal, Optional, Tuple, Type, Union
 
 import numpy as np
@@ -40,6 +43,46 @@ from bofire.utils.domain_repair import (
     default_input_preprocessing_specs,
 )
 from bofire.utils.torch_tools import get_nonlinear_constraints, tkwargs
+
+
+def _resolve_ga_callback(
+    data_model: GeneticAlgorithmDataModel,
+) -> Optional[Callable[..., Any]]:
+    """Resolve a runtime callback from the serializable GA data model definition."""
+    callback_spec = data_model.callback
+    if callback_spec is None:
+        return None
+
+    module_name, sep, attr_name = callback_spec.target.rpartition(":")
+    if not sep or not module_name or not attr_name:
+        raise ValueError(
+            "Invalid callback target. Expected format "
+            "'module.submodule:function_name'."
+        )
+
+    module = importlib.import_module(module_name)
+    callback_obj = getattr(module, attr_name, None)
+    if callback_obj is None:
+        raise ValueError(
+            f"Could not resolve callback target {callback_spec.target!r}."
+        )
+    if not callable(callback_obj):
+        raise ValueError(
+            f"Callback target {callback_spec.target!r} is not callable."
+        )
+
+    if callback_spec.kwargs:
+        if inspect.isclass(callback_obj):
+            callback_obj = callback_obj(**callback_spec.kwargs)
+            if not callable(callback_obj):
+                raise ValueError(
+                    f"Callback class target {callback_spec.target!r} did not "
+                    "produce a callable instance."
+                )
+            return callback_obj
+        return partial(callback_obj, **callback_spec.kwargs)
+
+    return callback_obj
 
 
 class GaMixedDomainHandler:
@@ -720,12 +763,14 @@ def run_ga(
         optimization_direction=optimization_direction,
     )
 
+    resolved_callback = callback or _resolve_ga_callback(data_model)
+
     res = pymoo_minimize(
         problem,
         algorithm,
         termination,
         verbose=verbose,
-        callback=callback,
+        callback=resolved_callback,
     )
 
     if callable_format == "torch":

--- a/docs/tutorials/advanced_examples/genetic_algorithm.qmd
+++ b/docs/tutorials/advanced_examples/genetic_algorithm.qmd
@@ -361,3 +361,146 @@ x_opt[0]
 ```{python}
 x_opt[1]
 ```
+
+## Example 4: Callback Interface and CSV Progress Tracking
+
+The GA callback receives the pymoo algorithm object after each generation step.
+In abstract form, a callback has the following signature:
+
+```{python}
+def callback(algorithm):
+    # algorithm.n_gen: current generation
+    # algorithm.evaluator.n_eval: number of evaluated candidates
+    # algorithm.opt: current best population entry
+    ...
+```
+
+For serializable usage via the data model, two callback types are available:
+
+1. `ImportPathCallback`: resolve a callback from `"module:function"`
+2. `CsvProgressCallback`: built-in fixed CSV tracker
+
+`CsvProgressCallback` writes columns
+`generation,n_eval,best_f`.
+The output path must be specified explicitly with `file_path`.
+
+### 4a) Built-in CSV callback with custom location
+
+```{python}
+import tempfile
+from pathlib import Path
+```
+
+```{python}
+progress_dir = Path(tempfile.mkdtemp(prefix="bofire-ga-progress-"))
+progress_file = progress_dir / "custom_ga_progress.csv"
+
+optimizer = strategies_data_models.GeneticAlgorithmOptimizer(
+    population_size=30,
+    n_max_gen=10,
+    n_max_evals=200,
+    callback=strategies_data_models.CsvProgressCallback(
+        file_path=str(progress_file),
+    ),
+)
+
+x_opt, f_opt = run_ga(
+    data_model=optimizer,
+    domain=domain,
+    objective_callables=[objective_function],
+    q=3,
+    callable_format="pandas",
+    optimization_direction="max",
+)
+
+progress_file
+```
+
+```{python}
+pd.read_csv(progress_file).head()
+```
+
+### 4b) Run GA in a subprocess and track CSV from main process
+
+```{python}
+import subprocess
+import sys
+import textwrap
+import time
+```
+
+```{python}
+subprocess_progress_file = progress_dir / "subprocess_ga_progress.csv"
+
+worker_script = textwrap.dedent(
+    f"""
+    import numpy as np
+    import pandas as pd
+
+    from bofire.data_models.constraints import api as constraints_data_models
+    from bofire.data_models.domain import api as domains_data_models
+    from bofire.data_models.features import api as features_data_models
+    from bofire.data_models.strategies import api as strategies_data_models
+    from bofire.strategies.utils import run_ga
+
+    domain = domains_data_models.Domain(
+        inputs=domains_data_models.Inputs(
+            features=[
+                features_data_models.ContinuousInput(key="x_1", bounds=(-6, 6)),
+                features_data_models.ContinuousInput(key="x_2", bounds=(-6, 6)),
+            ]
+        ),
+        constraints=[
+            constraints_data_models.NonlinearInequalityConstraint(
+                expression="x_1**2 + x_2**2 - 16",
+                features=["x_1", "x_2"],
+            ),
+        ],
+    )
+
+    optimizer = strategies_data_models.GeneticAlgorithmOptimizer(
+        population_size=40,
+        n_max_gen=20,
+        n_max_evals=1000,
+        callback=strategies_data_models.CsvProgressCallback(
+            file_path={str(subprocess_progress_file)!r},
+        ),
+    )
+
+    def objective_function(x):
+        vars_ = [xi.var(numeric_only=True).mean() for xi in x]
+        return np.array(vars_)
+
+    run_ga(
+        data_model=optimizer,
+        domain=domain,
+        objective_callables=[objective_function],
+        q=3,
+        callable_format="pandas",
+        optimization_direction="max",
+    )
+    """
+)
+
+proc = subprocess.Popen(
+    [sys.executable, "-c", worker_script],
+    stdout=subprocess.PIPE,
+    stderr=subprocess.PIPE,
+    text=True,
+)
+
+last_n_rows = 0
+while proc.poll() is None:
+    if subprocess_progress_file.exists():
+        df_progress = pd.read_csv(subprocess_progress_file)
+        if len(df_progress) > last_n_rows:
+            display(df_progress.tail(1))
+            last_n_rows = len(df_progress)
+    time.sleep(0.2)
+
+stdout, stderr = proc.communicate()
+if proc.returncode != 0:
+    raise RuntimeError(stderr)
+
+pd.read_csv(subprocess_progress_file).tail()
+```

--- a/docs/tutorials/advanced_examples/genetic_algorithm.qmd
+++ b/docs/tutorials/advanced_examples/genetic_algorithm.qmd
@@ -59,6 +59,8 @@ optimizer = strategies_data_models.GeneticAlgorithmOptimizer(
     population_size=100,
     n_max_gen=100,
     verbose=False,
+    # Write per-generation GA progress so it can be inspected while optimization runs.
+    ga_progress_csv_path="_custom_ga_progress.csv",
 )
 ```
 
@@ -208,6 +210,13 @@ plt.legend()
 plt.show()
 ```
 
+Inspect the current progress rows written by the optimizer. Note, that these results can also be obtained during execution.
+
+```{python}
+pd.read_csv("_custom_ga_progress.csv").head()
+```
+
+
 ## Example 2) Usage for Custom Function Optimization
 
 We can define a domain with input features, and constraints. Output features are not required
@@ -242,6 +251,9 @@ optimizer = strategies_data_models.GeneticAlgorithmOptimizer(
     verbose=False,
 )
 ```
+
+The GA progress file is updated generation-by-generation and can already be read
+while the GA run is still executing.
 
 ### Define the optimization problem: a) Using evaluations on `pd.DataFrame`
 We want to maximize the mean variance of the experiments dataframe. The objective function will be called with a list of dataframes, each representing a set of experiments. Each list entry is one individual in the population of the GA.
@@ -360,147 +372,4 @@ x_opt[0]
 
 ```{python}
 x_opt[1]
-```
-
-## Example 4: Callback Interface and CSV Progress Tracking
-
-The GA callback receives the pymoo algorithm object after each generation step.
-In abstract form, a callback has the following signature:
-
-```{python}
-def callback(algorithm):
-    # algorithm.n_gen: current generation
-    # algorithm.evaluator.n_eval: number of evaluated candidates
-    # algorithm.opt: current best population entry
-    ...
-```
-
-For serializable usage via the data model, two callback types are available:
-
-1. `ImportPathCallback`: resolve a callback from `"module:function"`
-2. `CsvProgressCallback`: built-in fixed CSV tracker
-
-`CsvProgressCallback` writes columns
-`generation,n_eval,best_f`.
-The output path must be specified explicitly with `file_path`.
-
-### 4a) Built-in CSV callback with custom location
-
-```{python}
-import tempfile
-from pathlib import Path
-```
-
-```{python}
-progress_dir = Path(tempfile.mkdtemp(prefix="bofire-ga-progress-"))
-progress_file = progress_dir / "custom_ga_progress.csv"
-
-optimizer = strategies_data_models.GeneticAlgorithmOptimizer(
-    population_size=30,
-    n_max_gen=10,
-    n_max_evals=200,
-    callback=strategies_data_models.CsvProgressCallback(
-        file_path=str(progress_file),
-    ),
-)
-
-x_opt, f_opt = run_ga(
-    data_model=optimizer,
-    domain=domain,
-    objective_callables=[objective_function],
-    q=3,
-    callable_format="pandas",
-    optimization_direction="max",
-)
-
-progress_file
-```
-
-```{python}
-pd.read_csv(progress_file).head()
-```
-
-### 4b) Run GA in a subprocess and track CSV from main process
-
-```{python}
-import subprocess
-import sys
-import textwrap
-import time
-```
-
-```{python}
-subprocess_progress_file = progress_dir / "subprocess_ga_progress.csv"
-
-worker_script = textwrap.dedent(
-    f"""
-    import numpy as np
-    import pandas as pd
-
-    from bofire.data_models.constraints import api as constraints_data_models
-    from bofire.data_models.domain import api as domains_data_models
-    from bofire.data_models.features import api as features_data_models
-    from bofire.data_models.strategies import api as strategies_data_models
-    from bofire.strategies.utils import run_ga
-
-    domain = domains_data_models.Domain(
-        inputs=domains_data_models.Inputs(
-            features=[
-                features_data_models.ContinuousInput(key="x_1", bounds=(-6, 6)),
-                features_data_models.ContinuousInput(key="x_2", bounds=(-6, 6)),
-            ]
-        ),
-        constraints=[
-            constraints_data_models.NonlinearInequalityConstraint(
-                expression="x_1**2 + x_2**2 - 16",
-                features=["x_1", "x_2"],
-            ),
-        ],
-    )
-
-    optimizer = strategies_data_models.GeneticAlgorithmOptimizer(
-        population_size=40,
-        n_max_gen=20,
-        n_max_evals=1000,
-        callback=strategies_data_models.CsvProgressCallback(
-            file_path={str(subprocess_progress_file)!r},
-        ),
-    )
-
-    def objective_function(x):
-        vars_ = [xi.var(numeric_only=True).mean() for xi in x]
-        return np.array(vars_)
-
-    run_ga(
-        data_model=optimizer,
-        domain=domain,
-        objective_callables=[objective_function],
-        q=3,
-        callable_format="pandas",
-        optimization_direction="max",
-    )
-    """
-)
-
-proc = subprocess.Popen(
-    [sys.executable, "-c", worker_script],
-    stdout=subprocess.PIPE,
-    stderr=subprocess.PIPE,
-    text=True,
-)
-
-last_n_rows = 0
-while proc.poll() is None:
-    if subprocess_progress_file.exists():
-        df_progress = pd.read_csv(subprocess_progress_file)
-        if len(df_progress) > last_n_rows:
-            display(df_progress.tail(1))
-            last_n_rows = len(df_progress)
-    time.sleep(0.2)
-
-stdout, stderr = proc.communicate()
-if proc.returncode != 0:
-    raise RuntimeError(stderr)
-
-pd.read_csv(subprocess_progress_file).tail()
 ```

--- a/tests/bofire/data_models/specs/strategies.py
+++ b/tests/bofire/data_models/specs/strategies.py
@@ -173,9 +173,7 @@ specs.add_valid(
             population_size=4,
             n_max_gen=1,
             n_max_evals=20,
-            callback=strategies.ImportPathCallback(
-                target="tests.bofire.strategies.test_utils:_callback_write_generation"
-            ),
+            ga_progress_csv_path="ga_progress_specs.csv",
         ).model_dump(),
         "surrogate_specs": BotorchSurrogates(surrogates=[]).model_dump(),
         "outlier_detection_specs": None,
@@ -199,7 +197,7 @@ specs.add_valid(
             population_size=4,
             n_max_gen=1,
             n_max_evals=20,
-            callback=strategies.CsvProgressCallback(file_path="ga_progress_specs.csv"),
+            ga_progress_csv_path="ga_progress_specs_2.csv",
         ).model_dump(),
         "surrogate_specs": BotorchSurrogates(surrogates=[]).model_dump(),
         "outlier_detection_specs": None,

--- a/tests/bofire/data_models/specs/strategies.py
+++ b/tests/bofire/data_models/specs/strategies.py
@@ -189,6 +189,30 @@ specs.add_valid(
     },
 )
 specs.add_valid(
+    strategies.SoboStrategy,
+    lambda: {
+        "domain": Domain(
+            inputs=Inputs(features=[ContinuousInput(key="a", bounds=(0, 1))]),
+            outputs=Outputs(features=[ContinuousOutput(key="alpha")]),
+        ).model_dump(),
+        "acquisition_optimizer": strategies.GeneticAlgorithmOptimizer(
+            population_size=4,
+            n_max_gen=1,
+            n_max_evals=20,
+            callback=strategies.CsvProgressCallback(file_path="ga_progress_specs.csv"),
+        ).model_dump(),
+        "surrogate_specs": BotorchSurrogates(surrogates=[]).model_dump(),
+        "outlier_detection_specs": None,
+        "seed": 42,
+        "min_experiments_before_outlier_check": 1,
+        "frequency_check": 1,
+        "frequency_hyperopt": 0,
+        "folds": 5,
+        "include_infeasible_exps_in_acqf_calc": False,
+        "acquisition_function": qPI(tau=0.1).model_dump(),
+    },
+)
+specs.add_valid(
     strategies.AdditiveSoboStrategy,
     lambda: {
         "domain": domain.valid().obj().model_dump(),

--- a/tests/bofire/data_models/specs/strategies.py
+++ b/tests/bofire/data_models/specs/strategies.py
@@ -163,6 +163,32 @@ specs.add_valid(
     },
 )
 specs.add_valid(
+    strategies.SoboStrategy,
+    lambda: {
+        "domain": Domain(
+            inputs=Inputs(features=[ContinuousInput(key="a", bounds=(0, 1))]),
+            outputs=Outputs(features=[ContinuousOutput(key="alpha")]),
+        ).model_dump(),
+        "acquisition_optimizer": strategies.GeneticAlgorithmOptimizer(
+            population_size=4,
+            n_max_gen=1,
+            n_max_evals=20,
+            callback=strategies.ImportPathCallback(
+                target="tests.bofire.strategies.test_utils:_callback_write_generation"
+            ),
+        ).model_dump(),
+        "surrogate_specs": BotorchSurrogates(surrogates=[]).model_dump(),
+        "outlier_detection_specs": None,
+        "seed": 42,
+        "min_experiments_before_outlier_check": 1,
+        "frequency_check": 1,
+        "frequency_hyperopt": 0,
+        "folds": 5,
+        "include_infeasible_exps_in_acqf_calc": False,
+        "acquisition_function": qPI(tau=0.1).model_dump(),
+    },
+)
+specs.add_valid(
     strategies.AdditiveSoboStrategy,
     lambda: {
         "domain": domain.valid().obj().model_dump(),

--- a/tests/bofire/strategies/test_utils.py
+++ b/tests/bofire/strategies/test_utils.py
@@ -18,6 +18,11 @@ from bofire.strategies.utils import run_ga
 from bofire.utils.torch_tools import get_linear_constraints
 
 
+def _callback_write_generation(algorithm, path: str):
+    with open(path, "w", encoding="utf-8") as file:
+        file.write(f"generation={algorithm.n_gen}\n")
+
+
 @pytest.fixture
 def domain_handler(optimizer_benchmark) -> GaMixedDomainHandler:
     """Fixture to provide a problem and algorithm for testing."""
@@ -319,3 +324,42 @@ def test_run_ga_callback_writes_file(tmp_path):
     content = callback_path.read_text(encoding="utf-8").strip()
     assert content.startswith("generation=")
     callback_path.unlink()
+    assert not callback_path.exists()
+    assert x_opt.shape == (1, 1)
+    assert f_opt.shape == (1,)
+
+
+def test_run_ga_callback_from_data_model_definition(tmp_path):
+    domain = data_models_domain.Domain(
+        inputs=[data_models_features.ContinuousInput(key="x", bounds=(0.0, 1.0))],
+        constraints=[],
+    )
+    callback_path = tmp_path / "ga_callback_from_model.txt"
+    optimizer = data_models_strategies.GeneticAlgorithmOptimizer(
+        population_size=4,
+        n_max_gen=1,
+        n_max_evals=20,
+        callback=data_models_strategies.ImportPathCallback(
+            target="tests.bofire.strategies.test_utils:_callback_write_generation",
+            kwargs={"path": str(callback_path)},
+        ),
+    )
+
+    def _objective(x):
+        return -x[:, 0, 0].reshape(-1)
+
+    x_opt, f_opt = run_ga(
+        data_model=optimizer,
+        domain=domain,
+        objective_callables=[_objective],
+        q=1,
+        callable_format="torch",
+    )
+
+    assert callback_path.exists()
+    content = callback_path.read_text(encoding="utf-8").strip()
+    assert content.startswith("generation=")
+    callback_path.unlink()
+    assert not callback_path.exists()
+    assert x_opt.shape == (1, 1)
+    assert f_opt.shape == (1,)

--- a/tests/bofire/strategies/test_utils.py
+++ b/tests/bofire/strategies/test_utils.py
@@ -24,6 +24,35 @@ def _callback_write_generation(algorithm, path: str):
 
 
 @pytest.fixture
+def ga_domain() -> data_models_domain.Domain:
+    return data_models_domain.Domain(
+        inputs=[data_models_features.ContinuousInput(key="x", bounds=(0.0, 1.0))],
+        constraints=[],
+    )
+
+
+@pytest.fixture
+def ga_objective():
+    def _objective(x):
+        return -x[:, 0, 0].reshape(-1)
+
+    return _objective
+
+
+@pytest.fixture
+def ga_optimizer_factory():
+    def _make_optimizer(callback=None):
+        return data_models_strategies.GeneticAlgorithmOptimizer(
+            population_size=4,
+            n_max_gen=1,
+            n_max_evals=20,
+            callback=callback,
+        )
+
+    return _make_optimizer
+
+
+@pytest.fixture
 def domain_handler(optimizer_benchmark) -> GaMixedDomainHandler:
     """Fixture to provide a problem and algorithm for testing."""
     domain = optimizer_benchmark.get_adapted_domain()
@@ -293,28 +322,22 @@ class TestLinearProjection:
             assert n_non_zero >= min_count
 
 
-def test_run_ga_callback_writes_file(tmp_path):
-    domain = data_models_domain.Domain(
-        inputs=[data_models_features.ContinuousInput(key="x", bounds=(0.0, 1.0))],
-        constraints=[],
-    )
-    optimizer = data_models_strategies.GeneticAlgorithmOptimizer(
-        population_size=4,
-        n_max_gen=1,
-        n_max_evals=20,
-    )
+def test_run_ga_callback_writes_file(
+    tmp_path,
+    ga_domain,
+    ga_objective,
+    ga_optimizer_factory,
+):
+    optimizer = ga_optimizer_factory()
     callback_path = tmp_path / "ga_callback.txt"
-
-    def _objective(x):
-        return -x[:, 0, 0].reshape(-1)
 
     def _callback(algorithm):
         callback_path.write_text(f"generation={algorithm.n_gen}\n", encoding="utf-8")
 
     x_opt, f_opt = run_ga(
         data_model=optimizer,
-        domain=domain,
-        objective_callables=[_objective],
+        domain=ga_domain,
+        objective_callables=[ga_objective],
         q=1,
         callable_format="torch",
         callback=_callback,
@@ -329,29 +352,24 @@ def test_run_ga_callback_writes_file(tmp_path):
     assert f_opt.shape == (1,)
 
 
-def test_run_ga_callback_from_data_model_definition(tmp_path):
-    domain = data_models_domain.Domain(
-        inputs=[data_models_features.ContinuousInput(key="x", bounds=(0.0, 1.0))],
-        constraints=[],
-    )
+def test_run_ga_callback_from_data_model_definition(
+    tmp_path,
+    ga_domain,
+    ga_objective,
+    ga_optimizer_factory,
+):
     callback_path = tmp_path / "ga_callback_from_model.txt"
-    optimizer = data_models_strategies.GeneticAlgorithmOptimizer(
-        population_size=4,
-        n_max_gen=1,
-        n_max_evals=20,
+    optimizer = ga_optimizer_factory(
         callback=data_models_strategies.ImportPathCallback(
             target="tests.bofire.strategies.test_utils:_callback_write_generation",
             kwargs={"path": str(callback_path)},
         ),
     )
 
-    def _objective(x):
-        return -x[:, 0, 0].reshape(-1)
-
     x_opt, f_opt = run_ga(
         data_model=optimizer,
-        domain=domain,
-        objective_callables=[_objective],
+        domain=ga_domain,
+        objective_callables=[ga_objective],
         q=1,
         callable_format="torch",
     )
@@ -363,3 +381,35 @@ def test_run_ga_callback_from_data_model_definition(tmp_path):
     assert not callback_path.exists()
     assert x_opt.shape == (1, 1)
     assert f_opt.shape == (1,)
+
+
+@pytest.fixture
+def csv_callback_case(tmp_path):
+    callback_path = tmp_path / "ga_progress_custom.csv"
+    callback = data_models_strategies.CsvProgressCallback(file_path=str(callback_path))
+    return callback, callback_path
+
+
+def test_run_ga_csv_callback_from_data_model_definition(
+    ga_domain,
+    ga_objective,
+    ga_optimizer_factory,
+    csv_callback_case,
+):
+    callback, callback_path = csv_callback_case
+    optimizer = ga_optimizer_factory(callback=callback)
+
+    _x_opt, _f_opt = run_ga(
+        data_model=optimizer,
+        domain=ga_domain,
+        objective_callables=[ga_objective],
+        q=1,
+        callable_format="torch",
+    )
+
+    assert callback_path.exists()
+    lines = callback_path.read_text(encoding="utf-8").strip().splitlines()
+    assert lines[0] == "generation,n_eval,best_f"
+    assert len(lines) >= 2
+    callback_path.unlink()
+    assert not callback_path.exists()

--- a/tests/bofire/strategies/test_utils.py
+++ b/tests/bofire/strategies/test_utils.py
@@ -18,11 +18,6 @@ from bofire.strategies.utils import run_ga
 from bofire.utils.torch_tools import get_linear_constraints
 
 
-def _callback_write_generation(algorithm, path: str):
-    with open(path, "w", encoding="utf-8") as file:
-        file.write(f"generation={algorithm.n_gen}\n")
-
-
 @pytest.fixture
 def ga_domain() -> data_models_domain.Domain:
     return data_models_domain.Domain(
@@ -41,12 +36,12 @@ def ga_objective():
 
 @pytest.fixture
 def ga_optimizer_factory():
-    def _make_optimizer(callback=None):
+    def _make_optimizer(ga_progress_csv_path=None):
         return data_models_strategies.GeneticAlgorithmOptimizer(
             population_size=4,
             n_max_gen=1,
             n_max_evals=20,
-            callback=callback,
+            ga_progress_csv_path=ga_progress_csv_path,
         )
 
     return _make_optimizer
@@ -352,54 +347,16 @@ def test_run_ga_callback_writes_file(
     assert f_opt.shape == (1,)
 
 
-def test_run_ga_callback_from_data_model_definition(
+def test_run_ga_progress_csv_path_from_data_model(
     tmp_path,
     ga_domain,
     ga_objective,
     ga_optimizer_factory,
 ):
-    callback_path = tmp_path / "ga_callback_from_model.txt"
-    optimizer = ga_optimizer_factory(
-        callback=data_models_strategies.ImportPathCallback(
-            target="tests.bofire.strategies.test_utils:_callback_write_generation",
-            kwargs={"path": str(callback_path)},
-        ),
-    )
+    callback_path = tmp_path / "ga_progress_from_model.csv"
+    optimizer = ga_optimizer_factory(ga_progress_csv_path=str(callback_path))
 
     x_opt, f_opt = run_ga(
-        data_model=optimizer,
-        domain=ga_domain,
-        objective_callables=[ga_objective],
-        q=1,
-        callable_format="torch",
-    )
-
-    assert callback_path.exists()
-    content = callback_path.read_text(encoding="utf-8").strip()
-    assert content.startswith("generation=")
-    callback_path.unlink()
-    assert not callback_path.exists()
-    assert x_opt.shape == (1, 1)
-    assert f_opt.shape == (1,)
-
-
-@pytest.fixture
-def csv_callback_case(tmp_path):
-    callback_path = tmp_path / "ga_progress_custom.csv"
-    callback = data_models_strategies.CsvProgressCallback(file_path=str(callback_path))
-    return callback, callback_path
-
-
-def test_run_ga_csv_callback_from_data_model_definition(
-    ga_domain,
-    ga_objective,
-    ga_optimizer_factory,
-    csv_callback_case,
-):
-    callback, callback_path = csv_callback_case
-    optimizer = ga_optimizer_factory(callback=callback)
-
-    _x_opt, _f_opt = run_ga(
         data_model=optimizer,
         domain=ga_domain,
         objective_callables=[ga_objective],
@@ -413,3 +370,5 @@ def test_run_ga_csv_callback_from_data_model_definition(
     assert len(lines) >= 2
     callback_path.unlink()
     assert not callback_path.exists()
+    assert x_opt.shape == (1, 1)
+    assert f_opt.shape == (1,)

--- a/tests/bofire/strategies/test_utils.py
+++ b/tests/bofire/strategies/test_utils.py
@@ -13,8 +13,11 @@ from bofire.data_models.constraints.api import (
 from bofire.data_models.domain import api as data_models_domain
 from bofire.data_models.features import api as data_models_features
 from bofire.data_models.strategies import api as data_models_strategies
-from bofire.strategies.utils import GaMixedDomainHandler, LinearProjectionPymooRepair
-from bofire.strategies.utils import run_ga
+from bofire.strategies.utils import (
+    GaMixedDomainHandler,
+    LinearProjectionPymooRepair,
+    run_ga,
+)
 from bofire.utils.torch_tools import get_linear_constraints
 
 

--- a/tests/bofire/strategies/test_utils.py
+++ b/tests/bofire/strategies/test_utils.py
@@ -14,6 +14,7 @@ from bofire.data_models.domain import api as data_models_domain
 from bofire.data_models.features import api as data_models_features
 from bofire.data_models.strategies import api as data_models_strategies
 from bofire.strategies.utils import GaMixedDomainHandler, LinearProjectionPymooRepair
+from bofire.strategies.utils import run_ga
 from bofire.utils.torch_tools import get_linear_constraints
 
 
@@ -285,3 +286,36 @@ class TestLinearProjection:
             # check that the min_count is met
             n_non_zero = (xr[i, :] > 1e-5).sum()
             assert n_non_zero >= min_count
+
+
+def test_run_ga_callback_writes_file(tmp_path):
+    domain = data_models_domain.Domain(
+        inputs=[data_models_features.ContinuousInput(key="x", bounds=(0.0, 1.0))],
+        constraints=[],
+    )
+    optimizer = data_models_strategies.GeneticAlgorithmOptimizer(
+        population_size=4,
+        n_max_gen=1,
+        n_max_evals=20,
+    )
+    callback_path = tmp_path / "ga_callback.txt"
+
+    def _objective(x):
+        return -x[:, 0, 0].reshape(-1)
+
+    def _callback(algorithm):
+        callback_path.write_text(f"generation={algorithm.n_gen}\n", encoding="utf-8")
+
+    x_opt, f_opt = run_ga(
+        data_model=optimizer,
+        domain=domain,
+        objective_callables=[_objective],
+        q=1,
+        callable_format="torch",
+        callback=_callback,
+    )
+
+    assert callback_path.exists()
+    content = callback_path.read_text(encoding="utf-8").strip()
+    assert content.startswith("generation=")
+    callback_path.unlink()


### PR DESCRIPTION
The GA function now accepts a user-defined callback-function, in the systax given by pymoo:

```python
    def _callback(algorithm):
        callback_path.write_text(f"generation={algorithm.n_gen}\n", encoding="utf-8")

    x_opt, f_opt = run_ga(
        data_model=optimizer,
        domain=ga_domain,
        objective_callables=[ga_objective],
        q=1,
        callable_format="torch",
        callback=_callback,
    )
 ```
 
 For the high-level acquisition optimization, a default function is defined which exports basic stats to a user-specified csv file:
 
 ```python
optimizer = strategies_data_models.GeneticAlgorithmOptimizer(
    population_size=100,
    n_max_gen=100,
    verbose=False,
    # Write per-generation GA progress so it can be inspected while optimization runs.
    ga_progress_csv_path="_custom_ga_progress.csv",
)
```

This can then be tracked by other processes during execution and may be used for status updates in web-apps etc.