### PR TITLE
Update dependency from pandas to 3.0.0 to implement standardized WriteOnCopy-Behaviour on Pandas Dataframes. Refers to issue #777.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11.0, <3.15"
 dependencies = [
     "numpy<2.5.0", # we pin due to some incompatibility with shap under uv dependency resolution
-    "pandas",
+    "pandas>=3.0.0",
     "pydantic>=2.5",
     "scipy>=1.7",
     "typing-extensions",


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to make BoFire better.

Help us to understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to BoFire here: https://github.com/experimental-desgin/bofire/blob/main/CONTRIBUTING.md
-->

## Motivation

In Issue #777 pandas of version prior to 3.0.0 can cause SettingToCopyWarning. In even older pandas version evoking Strategy.tell with a spliced view could change the original dataframe in theory.

To mitigate this we can increase the dependency of pandas to atleast 3.0.0 to implement the standardized CopyOnWrite-Behaviour, where a pandas.Dataframe automaticly delivers a copy (instead of a view) when doing a filter-operation or something similar to it. The SettingWithCopyWarning would also not appear anymore.

I don't believe that would cause any new issues since it would restrict the version and not expand it. Please correct me if I'm wrong.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/experimental-design/bofire/blob/main/CONTRIBUTING.md#pull-requests)?

Y

### Have you updated `CHANGELOG.md`?

No

## Test Plan

Unit tests.
